### PR TITLE
EIP1-1270 - Refining of SQS message SendApplicationToPrintMessage

### DIFF
--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -42,19 +42,19 @@ components:
       description: The SQS message for sending an application to print.
       type: object
       properties:
-        voterApplicationId:
+        sourceReference:
           type: string
-          format: uuid
-          description: The Voter Authority Certificate identifier
-          example: 14ab70e8-bd3b-400f-bd95-246caf9e4810
+          description: Reference in the source application that this print request relates to
         applicationReference:
           type: string
           description: The application reference as known by the citizen. Not guaranteed to be unique.
+        sourceType:
+          $ref: '#/components/schemas/SourceType'
         gssCode:
           type: string
           minLength: 9
           maxLength: 9
-          description: GSS Code to ensure permissions can be maintained in Print Service API
+          description: GSS code of the ERO responsible for sending the message
         issuingAuthority:
           type: string
           maxLength: 255
@@ -63,61 +63,61 @@ components:
         issueDate:
           type: string
           format: date
-          description: The issue date of the Voter Authority Card
+          description: The issue date of the Voter Authority Certificate
           example: '2022-06-01'
         requestDateTime:
           type: string
           format: date-time
-          description: The date time the Voter Authority Certificate was requested
+          description: The date time the Voter Authority Certificate print request was requested
           example: '2022-06-01T12:23:03.000Z'
-        cardFirstname:
+        firstName:
           type: string
           maxLength: 255
           description: First name of the Elector
           example: John
-        cardMiddlenames:
+        middleNames:
           type: string
           maxLength: 255
           description: Middle names of the Elector
           example: Malcolm
-        cardSurname:
+        surname:
           type: string
           maxLength: 255
           description: Surname of the Elector
           example: Smith
         certificateLanguage:
           $ref: '#/components/schemas/CertificateLanguage'
-        deliveryOption:
-          $ref: '#/components/schemas/DeliveryOption'
-        photoS3Arn:
+        photoLocation:
           type: string
-          description: S3 ARN to image to send to printers.
+          description: The location of the Elector's photo. Typically an S3 ARN
           maxLength: 1024
-        deliveryName:
-          type: string
-          maxLength: 255
-          description: Name to be printed with delivery address
-        deliveryAddress:
-          $ref: '#/components/schemas/Address'
+        delivery:
+          $ref: '#/components/schemas/CertificateDelivery'
         eroEnglish:
           $ref: '#/components/schemas/ElectoralRegistrationOffice'
         eroWelsh:
           $ref: '#/components/schemas/ElectoralRegistrationOffice'
       required:
-        - voterApplicationId
+        - sourceReference
+        - sourceType
         - applicationReference
         - issuingAuthority
         - issueDate
         - requestDateTime
-        - cardFirstname
-        - cardMiddlenames
-        - cardSurname
+        - firstName
+        - middleNames
+        - surname
         - certificateLanguage
-        - deliveryOption
-        - photoS3Arn
-        - deliveryName
-        - deliveryAddress
+        - photoLocation
+        - delivery
         - eroEnglish
+
+    SourceType:
+      title: SourceType
+      description: An enumeration of sources for this print request
+      type: string
+      enum:
+        - voter-card
 
     CertificateLanguage:
       title: CertificateLanguage
@@ -127,6 +127,24 @@ components:
         - cy
         - en
       default: en
+
+    CertificateDelivery:
+      title: CertificateDelivery
+      description: Object describing how and where the Voter Authority Certificate should be delivered
+      type: object
+      properties:
+        deliveryOption:
+          $ref: '#/components/schemas/DeliveryOption'
+        addressee:
+          type: string
+          maxLength: 255
+          description: The addressee to be printed in addition to the delivery address
+        address:
+          $ref: '#/components/schemas/Address'
+      required:
+        - deliveryOption
+        - addressee
+        - address
 
     DeliveryOption:
       title: DeliveryOption
@@ -170,6 +188,10 @@ components:
         postcode:
           type: string
           maxLength: 10
+        uprn:
+          type: string
+          description: Unique Property Reference Number consisting of up to 12 digits in length
+          pattern: '^\d{1,12}$'
       required:
         - street
         - postcode

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -60,11 +60,6 @@ components:
           maxLength: 255
           description: Issuing authority (LA/ERO/VJB)
           example: Camden Borough Council
-        issueDate:
-          type: string
-          format: date
-          description: The issue date of the Voter Authority Certificate
-          example: '2022-06-01'
         requestDateTime:
           type: string
           format: date-time
@@ -102,7 +97,6 @@ components:
         - sourceType
         - applicationReference
         - issuingAuthority
-        - issueDate
         - requestDateTime
         - firstName
         - middleNames
@@ -133,8 +127,8 @@ components:
       description: Object describing how and where the Voter Authority Certificate should be delivered
       type: object
       properties:
-        deliveryOption:
-          $ref: '#/components/schemas/DeliveryOption'
+        deliveryClass:
+          $ref: '#/components/schemas/DeliveryClass'
         addressee:
           type: string
           maxLength: 255
@@ -146,9 +140,9 @@ components:
         - addressee
         - address
 
-    DeliveryOption:
-      title: DeliveryOption
-      description: The delivery option for the Voter Authority Certificate
+    DeliveryClass:
+      title: DeliveryClass
+      description: The delivery class for the Voter Authority Certificate
       type: string
       enum:
         - standard


### PR DESCRIPTION
This PR makes a few refinement & corrections to the `SendApplicationToPrintMessage` introduced in my last PR.

Just for context, the `SendApplicationToPrintMessage` is an SQS message that will be consumed by `print-api` (service that owns the queue and therefore the API and this spec); and apps such as VCA (and proxy/postal/overseas as and when we get there) will publish this message. These apps will publish this message to instruct the `print-api` to send the application details to the print provider in order for them to print and post the physical Voter Authority Certificate. Therefore this `SendApplicationToPrintMessage` message needs to contain all the data necessary in order to print the certificate.

The "necessary data" is the data held by VCA (and the other future apps), and is essentially the applicant's name, photo, the date at which the certificate is issued (though there is a question about that - see the comment on the file), the delivery address (which may be the applicant's address, but may also be the ERO's address in the case of pick up from ERO), the ERO details (name, address, phone number, website etc - we don't currently hold this data in `ero-management` but it's coming ....). and the certificate language.

WRT certificate language - 2 languages are supported, English and Welsh. In the case of Welsh, it's actually a dual language certificate, where stuff is printed in English, then also in Welsh on the next line. This doesn't impact us particularly in respect of the data printed on the certificate because we don't provide this "non-placeholder" text. That's the responsibility of the print provider and their template. We simply need to tell them the language.
However, there is one notable exception to this. If the certificate is to be printed in Welsh (dual language) then we need to provide the ERO details (name, address, phone number, website etc) in Welsh so that both the English language and Welsh language name and address etc of the ERO can be printed. This is why there are 2 properties for ERO (snappily named `eroEnglish` and `eroWelsh`)

Data that is specifically not included is:
* DOB - this is not printed on the certificate
* NINo
* Applicant address (except in the case of it being the delivery address - I guess what I'm saying here is that we don't have a specific property/fields for "applicant address". Delivery Address is not the same as Applicant Address, though the data itself could be the same)
* Identity status / documents etc - these are used by the vc-admin to assert the identity of the applicant, but are not needed for the certificate itself
* 