### PR TITLE
EIP1-1270: EIP1-2177: Make middle names optional in the sqs message

### DIFF
--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.1.0'
+  version: '1.2.0'
   description: |-
     Print API SQS Message Types
     
@@ -89,7 +89,6 @@ components:
         - applicationReference
         - requestDateTime
         - firstName
-        - middleNames
         - surname
         - certificateLanguage
         - photoLocation

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/SendApplicationToPrintMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/SendApplicationToPrintMessageBuilder.kt
@@ -19,7 +19,7 @@ fun buildSendApplicationToPrintMessage(
     sourceType: SourceType = SourceType.VOTER_MINUS_CARD,
     requestDateTime: OffsetDateTime = Instant.now().atOffset(UTC),
     firstName: String = faker.name().firstName(),
-    middleNames: String = faker.name().firstName(),
+    middleNames: String? = faker.name().firstName(),
     surname: String = faker.name().lastName(),
     certificateLanguage: CertificateLanguage = CertificateLanguage.EN,
     delivery: CertificateDelivery = buildCertificateDelivery(),


### PR DESCRIPTION
This PR is to make the middleNames field optional in the SendApplicationToPrintMessage.