### PR TITLE
EIP1-1364 - Introduction of ID class similar to mongo ObjectId (12 byte ID)

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/TwelveByteId.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/TwelveByteId.kt
@@ -1,0 +1,157 @@
+package uk.gov.dluhc.printapi.database
+
+import java.nio.ByteBuffer
+import java.security.SecureRandom
+import java.util.Date
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A globally unique identifier, heavily based on [mongodb's ObjectId class](https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/types/ObjectId.java)
+ *
+ * Consists of 12 bytes, divided as follows:
+ *
+ * ```
+ *   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
+ *   |---------------|-----------|-------|-------------|
+ *   | time          |rnd 1      | rnd 2 | increment   |
+ * ```
+ *
+ * Where:
+ *   * `time` is the timestamp since epoch rounded to second precision. The first 4 bytes of the integer are used.
+ *   * `rnd 1` is a random integer. This is a static member. The first 3 bytes of the integer are used.
+ *   * `rnd 2` is a random short. This is a static member. The first 2 bytes of the short are used.
+ *   * `increment` is a sequential increment, starting from a random integer. The first 3 bytes of the integer are used.
+ *
+ *  `rnd 1` and `rnd 2` are static members, meaning that all instances of [TwelveByteId] generated in the same JVM will have
+ *  the same `rnd 1` and `rnd 2` values. The net result is that bytes [4, 5, 6, 7, 8] of 2 instances generated in the same JVM
+ *  will be the same.
+ *
+ *  `increment` is an [AtomicInteger] and is a static member seeded from a random number. The use of `getAndIncrement()` means
+ *  this is a thread safe way of generating an incremental counter.
+ *
+ * An instance of [TwelveByteId] is a 12 byte identifier which serializes via it's `toString()` method into a 24 character hex string.
+ */
+class TwelveByteId {
+
+    private val timestamp: Int
+    private val counter: Int
+    private val randomValue1: Int
+    private val randomValue2: Short
+
+    companion object {
+        private const val OBJECT_ID_LENGTH = 12
+        private const val LOW_ORDER_THREE_BYTES = 0x00ffffff
+
+        // Use primitives to represent the 5-byte random value.
+        private val RANDOM_VALUE1: Int = SecureRandom().nextInt(0x01000000)
+        private val RANDOM_VALUE2: Short = SecureRandom().nextInt(0x00008000).toShort()
+
+        private val NEXT_COUNTER = AtomicInteger(SecureRandom().nextInt())
+
+        private val HEX_CHARS = charArrayOf(
+            '0', '1', '2', '3', '4', '5', '6', '7',
+            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
+        )
+
+        private fun dateToTimestampSeconds(date: Date): Int =
+            (date.time / 1000).toInt()
+
+        fun get(): TwelveByteId = TwelveByteId()
+    }
+
+    constructor() : this(Date())
+
+    private constructor(date: Date) : this(
+        dateToTimestampSeconds(date),
+        NEXT_COUNTER.getAndIncrement() and LOW_ORDER_THREE_BYTES,
+        false
+    )
+
+    private constructor(timestamp: Int, counter: Int, checkCounter: Boolean) : this(
+        timestamp,
+        RANDOM_VALUE1,
+        RANDOM_VALUE2,
+        counter,
+        checkCounter
+    )
+
+    private constructor(timestamp: Int, randomValue1: Int, randomValue2: Short, counter: Int, checkCounter: Boolean) {
+        require(randomValue1 and -0x1000000 == 0) { "The random value must be between 0 and 16777215 (it must fit in three bytes)." }
+        require(!(checkCounter && counter and -0x1000000 != 0)) { "The counter must be between 0 and 16777215 (it must fit in three bytes)." }
+        this.timestamp = timestamp
+        this.counter = counter and LOW_ORDER_THREE_BYTES
+        this.randomValue1 = randomValue1
+        this.randomValue2 = randomValue2
+    }
+
+    override fun toString(): String = toHexString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as TwelveByteId
+
+        if (timestamp != other.timestamp) return false
+        if (counter != other.counter) return false
+        if (randomValue1 != other.randomValue1) return false
+        if (randomValue2 != other.randomValue2) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = timestamp
+        result = 31 * result + counter
+        result = 31 * result + randomValue1
+        result = 31 * result + randomValue2
+        return result
+    }
+
+    private fun toHexString(): String {
+        val chars = CharArray(OBJECT_ID_LENGTH * 2)
+        var i = 0
+        for (b in toByteArray()) {
+            chars[i++] = HEX_CHARS[b.toInt() shr 4 and 0xF]
+            chars[i++] = HEX_CHARS[b.toInt() and 0xF]
+        }
+        return String(chars)
+    }
+
+    private fun toByteArray(): ByteArray {
+        val buffer = ByteBuffer.allocate(OBJECT_ID_LENGTH)
+        putToByteBuffer(buffer)
+        return buffer.array()
+    }
+
+    private fun putToByteBuffer(buffer: ByteBuffer) {
+        requireNotNull(buffer) { "buffer cannot be null" }
+        require(buffer.remaining() >= OBJECT_ID_LENGTH) { "buffer.remaining() >=12" }
+
+        buffer
+            .put(int3(timestamp))
+            .put(int2(timestamp))
+            .put(int1(timestamp))
+            .put(int0(timestamp))
+            .put(int2(randomValue1))
+            .put(int1(randomValue1))
+            .put(int0(randomValue1))
+            .put(short1(randomValue2))
+            .put(short0(randomValue2))
+            .put(int2(counter))
+            .put(int1(counter))
+            .put(int0(counter))
+    }
+
+    private fun int3(x: Int): Byte = (x shr 24).toByte()
+
+    private fun int2(x: Int): Byte = (x shr 16).toByte()
+
+    private fun int1(x: Int): Byte = (x shr 8).toByte()
+
+    private fun int0(x: Int): Byte = x.toByte()
+
+    private fun short1(x: Short): Byte = (x.toInt() shr 8).toByte()
+
+    private fun short0(x: Short): Byte = x.toByte()
+}


### PR DESCRIPTION
This PR introduces a new "id" class which is very similar (heavily based on) Mongo's `ObjectId` class.
The reason for this is as follows:

* `print-api` needs to generate an ID as part of writing a record to it's database (which is why the class is in the `database` package - the rest of the DB stuff will come later)
* The ID itself has some specific requirements in that it has to be less than 25 characters (because it will be printed on an envelope and there is a physical restriction as to the number or printable characters)
* A mongo ID was suggested as a suitable ID because its is a 12 byte / 24 character (hex string) ID

I am not keen on using a mongo ID because it means we have a gradle dependency on their jar , which adds bloat to our distributable, plus loads of classes we wont be using; and of course it feels plain wrong to have a mongo dependency when we are not using mongo!

What I've done here is copy & paste 😁 the relevant parts of mongo's `ObjectId` class into a class of our own. Their class has more methods and functionality than this proposed version. This is very much a cut down version.

Now, there are some bits I'm not entirely happy with and would welcome some thoughts / opinions :

1. Should we even bother? Am I losing too much sleep over using the mongo class and dependency?
2. What to call it and what package? 
Naming is hard!. I've called it `TwelveByteId` because thats what it is (`ObjectId` is only relevant and makes sense in a mongo environment, so I don't want to call it that)
In terms of its use case in `print-api` it will only be used as part of creating a database record, so I've put it in the `database` package. Don't know if that is right? In terms of what it represents in the `print-api` database record it will be a `requestId`, so perhaps the classname should be `RequestId` ?
3. Unit tests! I can't write any for it! (not any meaningful ones anyway)
mongo have written unit tests for their `ObjectId` class .... but they really only work because they've got overloaded public constructors, where you can construct an `ObjectId` from a variety of factors, including the 12 bytes that form the ID!
To me it feels like they've created constructors for the purpose of tests 😢 
4. Constructor overloads .... related to the above, I have implemented a number of constructor overloads because I copy and pasted what mongo do. The difference is that I've made the constructor overloads private; and really I want to get rid of them altogether, and just do everything in the main no-args constructor.
It was very much a case of copy method by method, constructor by constructor; just to get the basic class working. I dont want to implement everything that they do.

There are some other questions that come up from this as well ....
Can we get re-use from this? At the moment we don't have a shared/common library repo; but VCA has a similar requirement. I wonder if @vishalgupta-valtech and @sentioservices could make use of a copy of this class re: their PR https://github.com/cabinetoffice/eip-ero-voter-card-applications-api/pull/232#discussion_r996938364

Open to the floor - what do we think?

---

Mongo classes:
`ObjectId`: https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/types/ObjectId.java
`ObjectIdTest`:  https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/test/unit/org/bson/types/ObjectIdTest.java