### PR TITLE
EIP1-1364 - Introduction of IdFactory to build requestIds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     implementation("software.amazon.awssdk:dynamodb")
     implementation("software.amazon.awssdk:dynamodb-enhanced")
 
+    // mongo core datatypes, so that we can generate a Mongo ObjectId (a 12 byte/24 char hex string ID)
+    implementation("org.mongodb:bson:4.7.1")
+
     // Test implementations
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
@@ -1,0 +1,18 @@
+package uk.gov.dluhc.printapi.service
+
+import org.bson.types.ObjectId
+import org.springframework.stereotype.Component
+
+/**
+ * Simple factory bean for creating different types of IDs and reference numbers.
+ */
+@Component
+class IdFactory {
+
+    fun requestId(): String =
+        ObjectId().toString()
+
+    fun certificateReference(): String {
+        TODO("To be implemented in EIP1-2131")
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class IdFactoryTest {
+
+    private val idFactory = IdFactory()
+
+    @Test
+    fun `should generate requestId`() {
+        // Given
+
+        // When
+        val requestId = idFactory.requestId()
+
+        // Then
+        assertThat(requestId).hasSize(24)
+    }
+
+    @Test
+    fun `should generate unique requestId with each call`() {
+        // Given
+        val requestIds = mutableSetOf<String>() // store request IDs in a set to ensure unique entries
+
+        // When
+        repeat(10) { requestIds.add(idFactory.requestId()) }
+
+        // Then
+        assertThat(requestIds).hasSize(10) // 10 elements in the set mean that there were no duplicates
+    }
+}


### PR DESCRIPTION
Following the decision in my earlier to PR to use the mongo library and its `ObjectId` class, this PR introduces a simple "ID Factory" that has methods to build a `requestId` (mongo ObjectId), and also a method ready to be implemented to build a VAC Certificate Reference Number (which is essentially an ID, hence its in the ID Factory)

The factory is a bean because it will be injected into the components that use it. I could have opted for a simple file exposing simple functions, but a bean felt better as it will be easier to mock for the purpose of tests (we would have difficulty with assertions if it were a function that could not be mocked); plus the generation of a certificate reference via `certificateReference` is likely to be fairly complex and may involve other collaborators (not sure yet, but again, the mocking argument wins 😁 )