### PR TITLE
EIP1-1878 Add creation of file details

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/ClockConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/ClockConfiguration.kt
@@ -1,0 +1,12 @@
+package uk.gov.dluhc.printapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.Clock
+
+@Configuration
+class ClockConfiguration {
+
+    @Bean
+    fun clock(): Clock = Clock.systemUTC()
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 @Component
-class FilenameFactory(val clock: Clock) {
+class FilenameFactory(private val clock: Clock) {
 
     fun createZipFilename(batchId: String, count: Int): String = createFilename(batchId, count, "zip")
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
@@ -1,0 +1,19 @@
+package uk.gov.dluhc.printapi.service
+
+import org.springframework.stereotype.Component
+import java.time.Clock
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+@Component
+class FilenameFactory(val clock: Clock) {
+
+    fun createZipFilename(batchId: String, count: Int): String = createFilename(batchId, count, "zip")
+
+    fun createPrintRequestsFilename(batchId: String, count: Int): String = createFilename(batchId, count, "psv")
+
+    private fun createFilename(batchId: String, count: Int, ext: String): String {
+        val timestamp = LocalDateTime.now(clock).toInstant(ZoneOffset.UTC)
+        return "$batchId-$timestamp-$count.$ext"
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactory.kt
@@ -1,0 +1,21 @@
+package uk.gov.dluhc.printapi.service
+
+import org.springframework.stereotype.Component
+import software.amazon.awssdk.arns.Arn
+
+@Component
+class PhotoLocationFactory {
+
+    fun create(batchId: String, requestId: String, photoArn: String): PhotoLocation {
+        val s3Photo = Arn.fromString(photoArn)
+        val bucket = s3Photo.resource().resourceType().get()
+        val path = createPath(s3Photo)
+        val zipPhotoPath = "$batchId-$requestId.${path.substringAfterLast('.')}"
+        return PhotoLocation(zipPhotoPath, bucket, path)
+    }
+
+    private fun createPath(s3Photo: Arn): String =
+        if (s3Photo.resource().qualifier().isPresent)
+            "${s3Photo.resource().resource()}/${s3Photo.resource().qualifier().get()}"
+        else s3Photo.resource().resource()
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
@@ -1,0 +1,59 @@
+package uk.gov.dluhc.printapi.service
+
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.database.entity.PrintDetails
+import uk.gov.dluhc.printapi.mapper.PrintDetailsToPrintRequestMapper
+import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+
+@Component
+class PrintFileDetailsFactory(
+    private val filenameFactory: FilenameFactory,
+    private val photoLocationFactory: PhotoLocationFactory,
+    private val printDetailsToPrintRequestMapper: PrintDetailsToPrintRequestMapper
+) {
+
+    fun createFileDetails(batchId: String, printList: List<PrintDetails>): FileDetails {
+        val fileContents = createFrom(printList)
+        return FileDetails(
+            printRequestsFilename = filenameFactory.createPrintRequestsFilename(batchId, printList.size),
+            printRequests = fileContents.printRequests,
+            photoLocations = fileContents.photoLocations
+        )
+    }
+
+    private fun createFrom(printList: List<PrintDetails>): FileContents {
+        val printRequests = mutableListOf<PrintRequest>()
+        val photoLocations = mutableListOf<PhotoLocation>()
+        printList.forEach { printDetails -> parsePrintDetails(printDetails, printRequests, photoLocations) }
+        return FileContents(printRequests, photoLocations)
+    }
+
+    private fun parsePrintDetails(
+        details: PrintDetails,
+        requests: MutableList<PrintRequest>,
+        photos: MutableList<PhotoLocation>
+    ) {
+        val photoArn = details.photoLocation!!
+        val photoLocation = photoLocationFactory.create(details.batchId!!, details.requestId!!, photoArn)
+        val printRequest = printDetailsToPrintRequestMapper.map(details, photoLocation.zipPath)
+        requests.add(printRequest)
+        photos.add(photoLocation)
+    }
+}
+
+data class FileDetails(
+    val printRequestsFilename: String,
+    val printRequests: List<PrintRequest>,
+    val photoLocations: List<PhotoLocation>
+)
+
+private class FileContents(
+    val printRequests: List<PrintRequest>,
+    val photoLocations: List<PhotoLocation>
+)
+
+data class PhotoLocation(
+    val zipPath: String,
+    val sourceBucket: String,
+    val sourcePath: String
+)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
@@ -3,13 +3,10 @@ package uk.gov.dluhc.printapi.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.junit.jupiter.MockitoExtension
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
 
-@ExtendWith(MockitoExtension::class)
 internal class FilenameFactoryTest {
 
     private lateinit var filenameFactory: FilenameFactory

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+@ExtendWith(MockitoExtension::class)
+internal class FilenameFactoryTest {
+
+    private lateinit var filenameFactory: FilenameFactory
+    private val fixedClock = Clock.fixed(Instant.parse("2022-10-18T11:22:32.123Z"), ZoneId.of("UTC"))
+
+    @BeforeEach
+    fun setUp() {
+        filenameFactory = FilenameFactory(fixedClock)
+    }
+
+    @Test
+    fun `should create zip filename`() {
+        // Given
+        val batchId = "05372cf5339447b39f98b248c2217b9f"
+        val count = 10
+
+        // When
+        val filename = filenameFactory.createZipFilename(batchId, count)
+
+        // Then
+        assertThat(filename).isEqualTo("05372cf5339447b39f98b248c2217b9f-2022-10-18T11:22:32.123Z-10.zip")
+    }
+
+    @Test
+    fun `should create print requests filename`() {
+        // Given
+        val batchId = "49825273c8e64dd885886b74883b8bb3"
+        val count = 19
+
+        // When
+        val filename = filenameFactory.createPrintRequestsFilename(batchId, count)
+
+        // Then
+        assertThat(filename).isEqualTo("49825273c8e64dd885886b74883b8bb3-2022-10-18T11:22:32.123Z-19.psv")
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactoryTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class PhotoLocationFactoryTest {
+
+    private val factory = PhotoLocationFactory()
+
+    @Test
+    fun `should populate photo ARN with qualifier`() {
+        // Given
+        val batchId = "05372cf5339447b39f98b248c2217b9f"
+        val requestId = "635abe7eda1fd8437a09fb74"
+        val photoArn = "arn:aws:s3:::dev-vca-api-vca-target-bucket/E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+
+        // When
+        val photoLocation = factory.create(batchId, requestId, photoArn)
+
+        // Then
+        assertThat(photoLocation).isEqualTo(
+            PhotoLocation(
+                "05372cf5339447b39f98b248c2217b9f-635abe7eda1fd8437a09fb74.png",
+                "dev-vca-api-vca-target-bucket",
+                "E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+            )
+        )
+    }
+
+    @Test
+    fun `should populate photo ARN without qualifier`() {
+        // Given
+        val photoArn = "arn:aws:s3:::dev-vca-api-vca-target-bucket/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+        val batchId = "05372cf5339447b39f98b248c2217b9f"
+        val requestId = "635abede7c432c0aaeeeba47"
+
+        // When
+        val photoLocation = factory.create(batchId, requestId, photoArn)
+
+        // Then
+        assertThat(photoLocation).isEqualTo(
+            PhotoLocation(
+                "05372cf5339447b39f98b248c2217b9f-635abede7c432c0aaeeeba47.png",
+                "dev-vca-api-vca-target-bucket",
+                "8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+            )
+        )
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
@@ -1,0 +1,64 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.mapper.PrintDetailsToPrintRequestMapper
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPrintRequestsFilename
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.model.aPrintRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoZipPath
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.photoLocationBuilder
+
+@ExtendWith(MockitoExtension::class)
+internal class PrintFileDetailsFactoryTest {
+
+    @Mock
+    private lateinit var filenameFactory: FilenameFactory
+
+    @Mock
+    private lateinit var photoLocationFactory: PhotoLocationFactory
+
+    @Mock
+    private lateinit var printDetailsToPrintRequestMapper: PrintDetailsToPrintRequestMapper
+
+    @InjectMocks
+    private lateinit var printFileDetailsFactory: PrintFileDetailsFactory
+
+    @Test
+    fun `should create file details`() {
+        // Given
+        val batchId = aValidBatchId()
+        val requestId = aValidRequestId()
+        val photoArn = aPhotoArn()
+        val printDetails = buildPrintDetails(batchId = batchId, requestId = requestId, photoLocation = photoArn)
+        val printDetailsList = listOf(printDetails)
+        val psvFilename = aValidPrintRequestsFilename()
+        given(filenameFactory.createPrintRequestsFilename(any(), any())).willReturn(psvFilename)
+        val zipPath = aPhotoZipPath()
+        val photoLocation = photoLocationBuilder(zipPath = zipPath)
+        given(photoLocationFactory.create(any(), any(), any())).willReturn(photoLocation)
+        val printRequest = aPrintRequest()
+        given(printDetailsToPrintRequestMapper.map(any(), any())).willReturn(printRequest)
+
+        // When
+        val fileDetails = printFileDetailsFactory.createFileDetails(batchId, printDetailsList)
+
+        // Then
+        verify(filenameFactory).createPrintRequestsFilename(batchId, 1)
+        verify(photoLocationFactory).create(batchId, requestId, photoArn)
+        verify(printDetailsToPrintRequestMapper).map(printDetails, zipPath)
+        assertThat(fileDetails.printRequestsFilename).isEqualTo(psvFilename)
+        assertThat(fileDetails.photoLocations).containsExactly(photoLocation)
+        assertThat(fileDetails.printRequests).containsExactly(printRequest)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
@@ -1,5 +1,17 @@
 package uk.gov.dluhc.printapi.testsupport.testdata.zip
 
+import uk.gov.dluhc.printapi.service.PhotoLocation
+
+fun photoLocationBuilder(
+    zipPath: String = aPhotoZipPath(),
+    sourceBucket: String = aPhotoBucket(),
+    sourcePath: String = aPhotoBucketPath()
+) = PhotoLocation(zipPath, sourceBucket, sourcePath)
+
+fun aPhotoLocation(): PhotoLocation = photoLocationBuilder()
+
+fun aPhotoLocationList(): List<PhotoLocation> = listOf(aPhotoLocation())
+
 fun aPhotoArn() = "arn:aws:s3:::dev-vca-api-vca-target-bucket/E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
 
 fun aPhotoBucket() = "dev-vca-api-vca-target-bucket"


### PR DESCRIPTION
PR to create the file details that includes filename, print requests and photo locations - the `FileDetails` is used in subsequent PR that creates the ZIP output stream.