### PR TITLE
EIP1-2131 - Addition of CertificateNumber

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.printapi.domain
 
 import java.security.SecureRandom
+import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -68,7 +69,7 @@ class CertificateNumber {
     }
 
     constructor() : this(
-        timestamp = dateToTimestampSeconds(Instant.now()),
+        timestamp = dateToTimestampSeconds(Instant.now(Clock.systemUTC())),
         randomValue1 = RANDOM_VALUE1,
         randomValue2 = RANDOM_VALUE2,
         counter = NEXT_COUNTER.getAndIncrement(),

--- a/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
@@ -28,9 +28,11 @@ import java.util.concurrent.atomic.AtomicInteger
  *  `increment` is an [AtomicInteger] and is a static member seeded from a random number. The use of `getAndIncrement()` means
  *  this is a thread safe way of generating an incremental counter.
  *
- * An instance of [CertificateNumber] is a 12 byte identifier which serializes via it's `toString()` method into a 20
- * character string using the character set `0123456789ACDEFGHJKLMNPQRTUVWXYZ` (specifically B, I, O and S are excluded
- * as they can be misread as numbers)
+ * An instance of [CertificateNumber] is a 12 byte identifier which serializes as a 20 character string using the character
+ * set `0123456789ACDEFGHJKLMNPQRTUVWXYZ` (specifically B, I, O and S are excluded as they can be misread as numbers)
+ *
+ * Class constructors are convenience constructors for the purpose of tests. The public API and preferred method of
+ * creating a new Certificate Number is to use the static factory method [CertificateNumber.create]
  */
 class CertificateNumber {
 
@@ -57,6 +59,12 @@ class CertificateNumber {
 
         private fun dateToTimestampSeconds(date: Instant): Int =
             date.epochSecond.toInt()
+
+        /**
+         * Creates a new 20 character string Certificate Number.
+         */
+        fun create(): String =
+            CertificateNumber().toString()
     }
 
     constructor() : this(
@@ -88,10 +96,7 @@ class CertificateNumber {
         this.counter = counter
     }
 
-    /**
-     * Convenience constructor used by tests to create CertificateNumber with known internal values.
-     */
-    internal constructor(timestamp: Int, randomValue1: Int, randomValue2: Short, counter: Int) {
+    constructor(timestamp: Int, randomValue1: Int, randomValue2: Short, counter: Int) {
         validateValues(randomValue1, counter)
         this.timestamp = timestamp
         this.randomValue1 = randomValue1

--- a/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumber.kt
@@ -1,0 +1,142 @@
+package uk.gov.dluhc.printapi.domain
+
+import java.security.SecureRandom
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A globally unique identifier, heavily based on [mongodb's ObjectId class](https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/types/ObjectId.java)
+ *
+ * Consists of 12 bytes, divided as follows:
+ *
+ * ```
+ *   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
+ *   |---------------|-----------|-------|-------------|
+ *   | time          |rnd 1      | rnd 2 | increment   |
+ * ```
+ *
+ * Where:
+ *   * `time` is the timestamp since epoch rounded to second precision. The first 4 bytes of the integer are used.
+ *   * `rnd 1` is a random integer. This is a static member. The first 3 bytes of the integer are used.
+ *   * `rnd 2` is a random short. This is a static member. The first 2 bytes of the short are used.
+ *   * `increment` is a sequential increment, starting from a random integer. The first 3 bytes of the integer are used.
+ *
+ *  `rnd 1` and `rnd 2` are static members, meaning that all instances of [CertificateNumber] generated in the same JVM will have
+ *  the same `rnd 1` and `rnd 2` values. The net result is that bytes [4, 5, 6, 7, 8] of 2 instances generated in the same JVM
+ *  will be the same.
+ *
+ *  `increment` is an [AtomicInteger] and is a static member seeded from a random number. The use of `getAndIncrement()` means
+ *  this is a thread safe way of generating an incremental counter.
+ *
+ * An instance of [CertificateNumber] is a 12 byte identifier which serializes via it's `toString()` method into a 20
+ * character string using the character set `0123456789ACDEFGHJKLMNPQRTUVWXYZ` (specifically B, I, O and S are excluded
+ * as they can be misread as numbers)
+ */
+class CertificateNumber {
+
+    private val timestamp: Int
+    private val randomValue1: Int
+    private val randomValue2: Short
+    private val counter: Int
+
+    companion object {
+        private const val LOW_ORDER_THREE_BYTES = 0x00ffffff
+
+        // Use primitives to represent the 5-byte random value.
+        private val RANDOM_VALUE1: Int = SecureRandom().nextInt(0x01000000)
+        private val RANDOM_VALUE2: Short = SecureRandom().nextInt(0x00008000).toShort()
+
+        private val NEXT_COUNTER = AtomicInteger(SecureRandom().nextInt(0x01000000))
+
+        private val ALPHABET = charArrayOf(
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L',
+            'M', 'N', 'P', 'Q', 'R', 'T', 'U', 'V', 'W', 'X',
+            'Y', 'Z'
+        )
+
+        private fun dateToTimestampSeconds(date: Instant): Int =
+            date.epochSecond.toInt()
+    }
+
+    constructor() : this(
+        timestamp = dateToTimestampSeconds(Instant.now()),
+        randomValue1 = RANDOM_VALUE1,
+        randomValue2 = RANDOM_VALUE2,
+        counter = NEXT_COUNTER.getAndIncrement(),
+    )
+
+    constructor(value: String) {
+        require(value.length == 20) { "CertificateNumber value length must be 20" }
+        require(value.toCharArray().all { it in ALPHABET }) { "CertificateNumber value must only contain characters from [${ALPHABET.joinToString("")}]" }
+        require(with(value[19]) { this == '0' || this == '1' }) { "CertificateNumber value last character must be a 0 or 1" }
+
+        val ninetySixBits = value.toCharArray().mapIndexed { idx, char ->
+            // map each character in the string to the index of the char in the alphabet - 5 bits for all but the last which is 1 bit = 96 bits
+            ALPHABET.indexOf(char).asBinaryString(if (idx < 19) 5 else 1)
+        }.joinToString("")
+
+        val timestamp = Integer.parseInt(ninetySixBits.substring(0, 32), 2) // first 32 bits (4 bytes) is the timestamp
+        val randomValue1 = Integer.parseInt(ninetySixBits.substring(32, 56), 2) // next 24 bits (3 bytes) is random 1
+        val randomValue2 = Integer.parseInt(ninetySixBits.substring(56, 72), 2).toShort() // next 16 bits (2 bytes) is random 2
+        val counter = Integer.parseInt(ninetySixBits.substring(72, 96), 2) // last 24 bits (3 bytes) is the counter
+
+        validateValues(randomValue1, counter)
+        this.timestamp = timestamp
+        this.randomValue1 = randomValue1
+        this.randomValue2 = randomValue2
+        this.counter = counter
+    }
+
+    /**
+     * Convenience constructor used by tests to create CertificateNumber with known internal values.
+     */
+    internal constructor(timestamp: Int, randomValue1: Int, randomValue2: Short, counter: Int) {
+        validateValues(randomValue1, counter)
+        this.timestamp = timestamp
+        this.randomValue1 = randomValue1
+        this.randomValue2 = randomValue2
+        this.counter = counter and LOW_ORDER_THREE_BYTES
+    }
+
+    override fun toString(): String {
+        val ninetySixBits = "${timestamp.asBinaryString(32)}${randomValue1.asBinaryString(24)}${randomValue2.asBinaryString(16)}${counter.asBinaryString(24)}"
+        return ninetySixBits.chunked(5) {
+            val fiveBits = Integer.parseInt(it.toString(), 2)
+            ALPHABET[fiveBits]
+        }.joinToString("")
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as CertificateNumber
+
+        if (timestamp != other.timestamp) return false
+        if (counter != other.counter) return false
+        if (randomValue1 != other.randomValue1) return false
+        if (randomValue2 != other.randomValue2) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = timestamp
+        result = 31 * result + counter
+        result = 31 * result + randomValue1
+        result = 31 * result + randomValue2
+        return result
+    }
+
+    private fun validateValues(randomValue1: Int, counter: Int) {
+        require(randomValue1 and -0x1000000 == 0) { "The random value must be between 0 and 16777215 (it must fit in three bytes)." }
+        require(counter and -0x1000000 == 0) { "The counter must be between 0 and 16777215 (it must fit in three bytes)." }
+    }
+
+    private fun Int.asBinaryString(numberOfBits: Int): String =
+        this.toString(2).padStart(numberOfBits, '0')
+
+    private fun Short.asBinaryString(numberOfBits: Int): String =
+        this.toString(2).padStart(numberOfBits, '0')
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
@@ -1,8 +1,8 @@
 package uk.gov.dluhc.printapi.service
 
-import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.domain.CertificateNumber
 
 /**
  * Simple factory bean for creating different types of IDs and reference numbers.
@@ -11,5 +11,5 @@ import org.springframework.stereotype.Component
 class IdFactory {
     fun requestId(): String = ObjectId().toString()
 
-    fun vacNumber(): String = randomAlphanumeric(20)
+    fun vacNumber(): String = CertificateNumber().toString()
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
@@ -11,5 +11,5 @@ import uk.gov.dluhc.printapi.domain.CertificateNumber
 class IdFactory {
     fun requestId(): String = ObjectId().toString()
 
-    fun vacNumber(): String = CertificateNumber().toString()
+    fun vacNumber(): String = CertificateNumber.create()
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumberTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumberTest.kt
@@ -9,14 +9,14 @@ internal class CertificateNumberTest {
     @Test
     fun `should create unique Certificate Number`() {
         // Given
-        val certificateNumbers = mutableListOf<CertificateNumber>()
+        val certificateNumbers = mutableListOf<String>()
 
         // When
-        repeat(100) { certificateNumbers.add(CertificateNumber()) }
+        repeat(100) { certificateNumbers.add(CertificateNumber.create()) }
 
         // Then
         assertThat(certificateNumbers).doesNotHaveDuplicates()
-            .allSatisfy { assertThat(it.toString()).containsPattern(Regex("^[0-9AC-HJ-NP-RT-Z]{20}$").pattern) }
+            .allSatisfy { assertThat(it).containsPattern(Regex("^[0-9AC-HJ-NP-RT-Z]{20}$").pattern) }
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumberTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/domain/CertificateNumberTest.kt
@@ -1,0 +1,102 @@
+package uk.gov.dluhc.printapi.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Test
+
+internal class CertificateNumberTest {
+
+    @Test
+    fun `should create unique Certificate Number`() {
+        // Given
+        val certificateNumbers = mutableListOf<CertificateNumber>()
+
+        // When
+        repeat(100) { certificateNumbers.add(CertificateNumber()) }
+
+        // Then
+        assertThat(certificateNumbers).doesNotHaveDuplicates()
+            .allSatisfy { assertThat(it.toString()).containsPattern(Regex("^[0-9AC-HJ-NP-RT-Z]{20}$").pattern) }
+    }
+
+    @Test
+    fun `should create Certificate Number with lowest possible value`() {
+        // Given
+        val timestamp = 0
+        val randomValue1 = 0
+        val randomValue2: Short = 0
+        val counter = 0
+
+        // When
+        val certificateNumber = CertificateNumber(timestamp, randomValue1, randomValue2, counter)
+
+        // Then
+        assertThat(certificateNumber.toString()).isEqualTo("00000000000000000000")
+    }
+
+    @Test
+    fun `should create Certificate Number with highest possible value`() {
+        // Given
+        val timestamp = 2147483647
+        val randomValue1 = 16777215
+        val randomValue2: Short = 32767
+        val counter = 16777215
+
+        // When
+        val certificateNumber = CertificateNumber(timestamp, randomValue1, randomValue2, counter)
+
+        // Then
+        assertThat(certificateNumber.toString()).isEqualTo("GZZZZZZZZZZQZZZZZZZ1")
+    }
+
+    @Test
+    fun `should not create Certificate Number given value is not 20 characters in length`() {
+        // Given
+        val proposedCertificateNumber = "123XYZ"
+
+        // When
+        val ex =
+            catchThrowableOfType({ CertificateNumber(proposedCertificateNumber) }, IllegalArgumentException::class.java)
+
+        // Then
+        assertThat(ex.message).isEqualTo("CertificateNumber value length must be 20")
+    }
+
+    @Test
+    fun `should not create Certificate Number given value contains characters not in the character set`() {
+        // Given
+        val proposedCertificateNumber = "gZZZZZZZZZZZxZZZZZZ7"
+
+        // When
+        val ex =
+            catchThrowableOfType({ CertificateNumber(proposedCertificateNumber) }, IllegalArgumentException::class.java)
+
+        // Then
+        assertThat(ex.message).isEqualTo("CertificateNumber value must only contain characters from [0123456789ACDEFGHJKLMNPQRTUVWXYZ]")
+    }
+
+    @Test
+    fun `should not create Certificate Number given values last character is not a 0 or 1`() {
+        // Given
+        val proposedCertificateNumber = "1ZZZZZZZZZZZ3ZZZZZZ7"
+
+        // When
+        val ex =
+            catchThrowableOfType({ CertificateNumber(proposedCertificateNumber) }, IllegalArgumentException::class.java)
+
+        // Then
+        assertThat(ex.message).isEqualTo("CertificateNumber value last character must be a 0 or 1")
+    }
+
+    @Test
+    fun `should create Certificate Number from other value`() {
+        // Given
+        val firstCertificateNumber = CertificateNumber()
+
+        // When
+        val certificateNumber = CertificateNumber(firstCertificateNumber.toString())
+
+        // Then
+        assertThat(certificateNumber).isEqualTo(firstCertificateNumber)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
@@ -46,7 +46,7 @@ internal class IdFactoryTest {
 
             // Then
             assertThat(vacNumbers).doesNotHaveDuplicates()
-                .allSatisfy { assertThat(it).containsPattern(Regex("^[A-Za-z\\d]{20}$").pattern) }
+                .allSatisfy { assertThat(it).containsPattern(Regex("^[0-9AC-HJ-NP-RT-Z]{20}$").pattern) }
         }
     }
 }


### PR DESCRIPTION
As discussed in the tech forum just now 😁 I present my finest nerdiness 👍 
This PR adds in a class called `CertificateNumber` that works in a very similar way to `ObjectId` (in that you new one up when you want a new certificate number). Internally it works the same way of holding the value in 12 bytes. The difference is how the 12 byte ID is serialized - `ObjectId` serializes as 24 hex chars. `CertificateNumber` serializes as 20 characters from its own alphabet