### PR TITLE
EIP1-2131 - Addition of CertificateNumberGenerator

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateNumberGenerator.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateNumberGenerator.kt
@@ -1,0 +1,77 @@
+package uk.gov.dluhc.printapi.service
+
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+import java.time.Clock
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * A generator of globally unique Certificate Numbers, heavily based on [mongodb's ObjectId class](https://github.com/mongodb/mongo-java-driver/blob/master/bson/src/main/org/bson/types/ObjectId.java)
+ *
+ * A Certificate Number is a 20 character string using the character set `0123456789ACDEFGHJKLMNPQRTUVWXYZ`
+ * (specifically B, I, O and S are excluded as they can be misread as numbers)
+ *
+ * The Certificate Number is derived from 12 bytes, arranged as follows:
+ *
+ * ```
+ *   | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 |
+ *   |---------------|-----------|-------|-------------|
+ *   | time          |rnd 1      | rnd 2 | increment   |
+ * ```
+ *
+ * Where:
+ *   * `time` is the timestamp since epoch rounded to second precision. The first 4 bytes of the integer are used.
+ *   * `rnd 1` is a random integer. This is a static member. The first 3 bytes of the integer are used.
+ *   * `rnd 2` is a random short. This is a static member. The first 2 bytes of the short are used.
+ *   * `increment` is a sequential increment, starting from a random integer. The first 3 bytes of the integer are used.
+ *
+ *  `rnd 1` and `rnd 2` are static members, meaning that all Certificate Numbers generated in the same JVM will have
+ *  the same `rnd 1` and `rnd 2` values. The net result is that bytes [4, 5, 6, 7, 8] of 2 instances generated in the same JVM
+ *  will be the same.
+ *
+ *  `increment` is an [AtomicInteger] and is a static member seeded from a random number. The use of `getAndIncrement()` means
+ *  this is a thread safe way of generating an incremental counter.
+ *
+ * The generated Certificate Number is a serialization of the 12 bytes.
+ */
+@Component
+class CertificateNumberGenerator(private val clock: Clock) {
+
+    companion object {
+        // Use primitives to represent the 5-byte random value.
+        private val RANDOM_VALUE1: Int = SecureRandom().nextInt(0x01000000)
+        private val RANDOM_VALUE2: Short = SecureRandom().nextInt(0x00008000).toShort()
+
+        private val NEXT_COUNTER = AtomicInteger(SecureRandom().nextInt(0x01000000))
+
+        private val ALPHABET = charArrayOf(
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+            'A', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L',
+            'M', 'N', 'P', 'Q', 'R', 'T', 'U', 'V', 'W', 'X',
+            'Y', 'Z'
+        )
+    }
+
+    fun generateCertificateNumber(): String {
+        val timestamp = dateToTimestampSeconds(Instant.now(clock))
+        val randomValue1 = RANDOM_VALUE1
+        val randomValue2 = RANDOM_VALUE2
+        val counter = NEXT_COUNTER.getAndIncrement()
+
+        val ninetySixBits = "${timestamp.asBinaryString(32)}${randomValue1.asBinaryString(24)}${randomValue2.asBinaryString(16)}${counter.asBinaryString(24)}"
+        return ninetySixBits.chunked(5) {
+            val fiveBits = Integer.parseInt(it.toString(), 2)
+            ALPHABET[fiveBits]
+        }.joinToString("")
+    }
+
+    private fun dateToTimestampSeconds(date: Instant): Int =
+        date.epochSecond.toInt()
+
+    private fun Int.asBinaryString(numberOfBits: Int): String =
+        this.toString(2).padStart(numberOfBits, '0')
+
+    private fun Short.asBinaryString(numberOfBits: Int): String =
+        this.toString(2).padStart(numberOfBits, '0')
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/IdFactory.kt
@@ -1,6 +1,5 @@
 package uk.gov.dluhc.printapi.service
 
-import org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric
 import org.bson.types.ObjectId
 import org.springframework.stereotype.Component
 
@@ -8,8 +7,8 @@ import org.springframework.stereotype.Component
  * Simple factory bean for creating different types of IDs and reference numbers.
  */
 @Component
-class IdFactory {
+class IdFactory(private val certificateNumberGenerator: CertificateNumberGenerator) {
     fun requestId(): String = ObjectId().toString()
 
-    fun vacNumber(): String = randomAlphanumeric(20)
+    fun vacNumber(): String = certificateNumberGenerator.generateCertificateNumber()
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateNumberGeneratorTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateNumberGeneratorTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+
+internal class CertificateNumberGeneratorTest {
+
+    private val fixedClock = Clock.fixed(Instant.MIN, ZoneId.of("UTC"))
+    private val certificateNumberGenerator = CertificateNumberGenerator(fixedClock)
+
+    @Test
+    fun `should generate certificate number`() {
+        // Given
+
+        // When
+        val certificateNumber = certificateNumberGenerator.generateCertificateNumber()
+
+        // Then
+        assertThat(certificateNumber).containsPattern(Regex("^[0-9AC-HJ-NP-RT-Z]{20}$").pattern)
+    }
+
+    @Test
+    fun `should generate unique certificate numbers`() {
+        // Given
+        val vacNumbers = mutableListOf<String>()
+
+        // When
+        repeat(100) {
+            vacNumbers.add(certificateNumberGenerator.generateCertificateNumber())
+        }
+
+        // Then
+        assertThat(vacNumbers).doesNotHaveDuplicates()
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/IdFactoryTest.kt
@@ -1,52 +1,58 @@
 package uk.gov.dluhc.printapi.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.given
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateNumber
 
+@ExtendWith(MockitoExtension::class)
 internal class IdFactoryTest {
 
-    private val idFactory = IdFactory()
+    @Mock
+    private lateinit var certificateNumberGenerator: CertificateNumberGenerator
 
-    @Nested
-    inner class RequestId {
-        @Test
-        fun `should generate requestId`() {
-            // Given
+    @InjectMocks
+    private lateinit var idFactory: IdFactory
 
-            // When
-            val requestId = idFactory.requestId()
+    @Test
+    fun `should generate requestId`() {
+        // Given
 
-            // Then
-            assertThat(requestId).hasSize(24)
-        }
+        // When
+        val requestId = idFactory.requestId()
 
-        @Test
-        fun `should generate unique requestId with each call`() {
-            // Given
-            val requestIds = mutableSetOf<String>() // store request IDs in a set to ensure unique entries
-
-            // When
-            repeat(10) { requestIds.add(idFactory.requestId()) }
-
-            // Then
-            assertThat(requestIds).hasSize(10) // 10 elements in the set mean that there were no duplicates
-        }
+        // Then
+        assertThat(requestId).hasSize(24)
     }
 
-    @Nested
-    inner class VacNumber {
-        @Test
-        fun `should generate unique vacNumber`() {
-            // Given
-            val vacNumbers = mutableListOf<String>()
+    @Test
+    fun `should generate unique requestId with each call`() {
+        // Given
+        val requestIds = mutableListOf<String>()
 
-            // When
-            repeat(100) { vacNumbers.add(idFactory.vacNumber()) }
-
-            // Then
-            assertThat(vacNumbers).doesNotHaveDuplicates()
-                .allSatisfy { assertThat(it).containsPattern(Regex("^[A-Za-z\\d]{20}$").pattern) }
+        // When
+        repeat(100) {
+            requestIds.add(idFactory.requestId())
         }
+
+        // Then
+        assertThat(requestIds).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `should generate vacNumber`() {
+        // Given
+        val expectedCertificateNumber = aValidCertificateNumber()
+        given(certificateNumberGenerator.generateCertificateNumber()).willReturn(expectedCertificateNumber)
+
+        // When
+        val certificateNumber = idFactory.vacNumber()
+
+        // Then
+        assertThat(certificateNumber).isEqualTo(expectedCertificateNumber)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/CertificateNumberBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/CertificateNumberBuilder.kt
@@ -1,0 +1,3 @@
+package uk.gov.dluhc.printapi.testsupport.testdata
+
+fun aValidCertificateNumber(): String = "GZZZZZZZZZZQZZZZZZZ1"


### PR DESCRIPTION
This PR is similar to my [previous PR](https://github.com/cabinetoffice/eip-ero-print-api/pull/27) in that it allows for the generation of Certificate Numbers, but this one uses a `CertificateNumberGenerator` bean rather than a `CertificateNumber` value object.

The concept and algorithm is identical though - the earlier PR uses a value object (where we are only interested in the toString() method); this PR uses a generator that returns the string

Which do we prefer?

The version using the value object has better tests as it is easier to test (via its overloaded constructors, which are really only there to support the tests. With the generator version we do not have that luxury