### PR TITLE
NO-JIRA - Version bumps to fix OWASP dependency report issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,17 +5,17 @@ import org.owasp.dependencycheck.reporting.ReportGenerator.Format.HTML
 import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
 plugins {
-    id("org.springframework.boot") version "2.7.4"
-    id("io.spring.dependency-management") version "1.0.14.RELEASE"
-    kotlin("jvm") version "1.7.0"
-    kotlin("kapt") version "1.7.10"
+    id("org.springframework.boot") version "2.7.5"
+    id("io.spring.dependency-management") version "1.1.0"
+    kotlin("jvm") version "1.7.20"
+    kotlin("kapt") version "1.7.20"
     kotlin("plugin.spring") version "1.7.0"
-    kotlin("plugin.jpa") version "1.7.0"
-    kotlin("plugin.allopen") version "1.7.0"
+    kotlin("plugin.jpa") version "1.7.20"
+    kotlin("plugin.allopen") version "1.7.20"
     id("org.jlleitschuh.gradle.ktlint") version "10.3.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "10.3.0"
-    id("org.openapi.generator") version "6.0.1"
-    id("org.owasp.dependencycheck") version "7.1.2"
+    id("org.openapi.generator") version "6.2.0"
+    id("org.owasp.dependencycheck") version "7.2.0"
     id("org.jsonschema2dataclass") version "4.5.0"
 }
 
@@ -24,8 +24,9 @@ version = "latest"
 java.sourceCompatibility = JavaVersion.VERSION_17
 
 ext["snakeyaml.version"] = "1.33"
+ext["spring-security.version"] = "5.7.5" // Fixed CVE-2022-31690 and CVE-2022-31692 - https://spring.io/blog/2022/10/31/cve-2022-31690-privilege-escalation-in-spring-security-oauth2-client
 extra["springCloudVersion"] = "2.4.2"
-extra["awsSdkVersion"] = "2.17.284"
+extra["awsSdkVersion"] = "2.18.9"
 
 allOpen {
     annotations("javax.persistence.Entity", "javax.persistence.MappedSuperclass", "javax.persistence.Embedabble")
@@ -50,15 +51,15 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
-    implementation("io.github.microutils:kotlin-logging-jvm:2.1.23")
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.2")
     implementation("org.apache.commons:commons-lang3:3.12.0")
-    implementation("org.mapstruct:mapstruct:1.5.2.Final")
-    kapt("org.mapstruct:mapstruct-processor:1.5.2.Final")
+    implementation("org.mapstruct:mapstruct:1.5.3.Final")
+    kapt("org.mapstruct:mapstruct-processor:1.5.3.Final")
 
     // api
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springdoc:springdoc-openapi-ui:1.6.11")
+    implementation("org.springdoc:springdoc-openapi-ui:1.6.12")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("com.opencsv:opencsv:5.7.0") {
         exclude("commons-collections", "commons-collections")
@@ -94,17 +95,14 @@ dependencies {
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
 
-    testImplementation("org.testcontainers:junit-jupiter:1.17.3")
+    testImplementation("org.testcontainers:junit-jupiter:1.17.5")
     testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:4.0.0")
 
     testImplementation("org.testcontainers:testcontainers:1.17.4")
 
-    testImplementation("com.github.tomakehurst:wiremock-jre8:2.33.2")
+    testImplementation("com.github.tomakehurst:wiremock-jre8:2.34.0")
     testImplementation("net.datafaker:datafaker:1.6.0")
-
-    // mongo core datatypes, so that our tests can generate a Mongo ObjectId (which is what IER uses)
-    testImplementation("org.mongodb:bson:4.7.1")
 
     // Libraries to support creating JWTs in tests
     testImplementation("io.jsonwebtoken:jjwt-impl:0.11.5")

--- a/owasp.suppressions.xml
+++ b/owasp.suppressions.xml
@@ -1,4 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-
+    <suppress until="2023-09-07Z">
+        <notes>
+            <![CDATA[ file name: spring-security-crypto-5.7.4.jar]]>
+            The method with the vulnerability is deprecated now, but not removed yet.
+            It will be removed as part of Spring 6.
+            The warning is suppressed until then.
+            https://github.com/spring-projects/spring-security/issues/8980
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/spring\-security\-crypto@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-5408</vulnerabilityName>
+    </suppress>
+    <suppress until="2023-09-07Z">
+        <notes>
+            <![CDATA[file name: spring-web-5.3.23.jar]]>
+            The vulnerability is on Spring HTTP Invoker, and it is deprecated by Spring, but not removed yet.
+            It is not used in our code base and seen as a JVM deserialization issue rather than a Spring one by the Spring team.
+            It doesn't look like it will be address any time soon, and since we don't use it, it is suppressed as well.
+            https://docs.spring.io/spring-framework/docs/current/reference/html/integration.html#remoting-httpinvoker
+            https://github.com/spring-projects/spring-framework/issues/24434#issuecomment-744519525
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-web@.*$</packageUrl>
+        <cve>CVE-2016-1000027</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Version bumps to fix OWASP dependency report issues

`print-api` is now down to just 1 reported vulnerability (kapt related) 🎉 

The version bump to Spring Security is important - we need to roll that out into all our other apps