### PR TITLE
EIP1-385 - correct `requestId` data type in yamlschema; codegen to use java8 dates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,6 +181,10 @@ jsonSchema2Pojo {
     includeJsr303Annotations.set(true)
     includeGeneratedAnnotation.set(false)
     includeToString.set(false)
+    dateTimeType.set("java.time.OffsetDateTime")
+    dateType.set("java.time.LocalDate")
+    formatDateTimes.set(true)
+    formatDates.set(true)
 }
 
 // Add the generated code to the source sets

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsFileProducer.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsFileProducer.kt
@@ -7,7 +7,6 @@ import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.nio.charset.StandardCharsets
-import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
 @Component
@@ -83,9 +82,9 @@ class PrintRequestsFileProducer {
                 requestId,
                 issuingAuthorityEn,
                 issuingAuthorityCy ?: "",
-                issueDate,
-                suggestedExpiryDate,
-                requestDateTime.toInstant().atOffset(ZoneOffset.UTC).format(DATE_TIMESTAMP_FORMATTER),
+                issueDate.format(DATE_FORMATTER),
+                suggestedExpiryDate.format(DATE_FORMATTER),
+                requestDateTime.format(DATE_TIMESTAMP_FORMATTER),
                 cardFirstname,
                 cardMiddleNames ?: "",
                 cardSurname,
@@ -126,6 +125,7 @@ class PrintRequestsFileProducer {
         }
 
     companion object {
+        private val DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd")
         private val DATE_TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     }
 }

--- a/src/main/resources/yamlschema/BatchResponse.yaml
+++ b/src/main/resources/yamlschema/BatchResponse.yaml
@@ -1,24 +1,26 @@
-#version: 0.0.3
+#version: 0.0.4
 title: BatchResponse
 type: object
 description: Represents the response from the print provider in response to recieving a batch file from EROP
 properties:
   batchId:
     type: string
-    example: 1000-2000
+    example: 2e7642a405ac49219b004e812bfcf86b
+    description: The unique identifier of the print batch. A 32 character hex string
   status:
     type: string
     enum:
       - SUCCESS
       - FAILED
-    description: Indicates success or failure recieving the batch
+    description: Indicates success or failure receiving the batch
   timestamp:
     type: string
     format: date-time
+    example: '2022-06-01T14:23:03.000Z'
   message:
     type: string
     maxLength: 255
-    description: Error description
+    description: Error description. Only populated if `status` is `FAILED`
 required:
   - batchId
   - status

--- a/src/main/resources/yamlschema/PrintRequest.yaml
+++ b/src/main/resources/yamlschema/PrintRequest.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.3
+#version: 0.0.4
 title: PrintRequest
 type: object
 description: Represents a single print request
@@ -6,9 +6,9 @@ properties:
   requestId:
     type: string
     description: |-
-      The request identifier of the print request
-      Mongo GUID (needs to be under 25 chars long)
-    example: 14ab70e8-bd3b-400f-bd95-246caf9e4810
+      The unique identifier of the print request
+      A 24 character hex string
+    example: 14ab70e8bd3b400fbd95246c
   issuingAuthorityEn:
     type: string
     maxLength: 255

--- a/src/main/resources/yamlschema/PrintResponse.yaml
+++ b/src/main/resources/yamlschema/PrintResponse.yaml
@@ -1,13 +1,14 @@
-#version: 0.0.3
+#version: 0.0.4
 title: PrintResponse
 type: object
 description: 'Represents a print response, status update for a single print request'
 properties:
   requestId:
     type: string
-    format: uuid
-    description: The request identifier of the print request
-    example: 14ab70e8-bd3b-400f-bd95-246caf9e4810
+    description: |-
+      The unique identifier of the print request
+      A 24 character hex string
+    example: 14ab70e8bd3b400fbd95246c
   timestamp:
     type: string
     format: date-time
@@ -26,11 +27,11 @@ properties:
     enum:
       - SUCCESS
       - FAILED
-    description: Indicates if the step change was sucessful or not.
+    description: Indicates if the step change was successful or not.
   message:
     type: string
     maxLength: 255
-    description: Failure message
+    description: Error description. Only populated if `status` is `FAILED`
 required:
   - requestId
   - timestamp

--- a/src/main/resources/yamlschema/PrintResponses.yaml
+++ b/src/main/resources/yamlschema/PrintResponses.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.3
+#version: 0.0.4
 title: PrintResponses
 type: object
 description: 'A response from the print provider to EROP, can contain either batch or print responses, or both.'

--- a/src/main/resources/yamlschema/README.md
+++ b/src/main/resources/yamlschema/README.md
@@ -1,5 +1,5 @@
 # Print Provider Schema
-# v0.0.3
+# v0.0.4
 This folder contains the Print Provider schema files.
 
 The schema is defined in `yamlschema`. Each type is defined in its own file.

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsToPrintRequestMapperTest.kt
@@ -99,9 +99,9 @@ class PrintDetailsToPrintRequestMapperTest {
         val expected = PrintRequest()
         expected.requestId = requestId
         expected.issuingAuthorityEn = eroEnglish.name
-        expected.issueDate = "2022-10-21"
-        expected.suggestedExpiryDate = "2032-10-21"
-        expected.requestDateTime = Date.from(requestDateTime.toInstant())
+        expected.issueDate = LocalDate.parse("2022-10-21")
+        expected.suggestedExpiryDate = LocalDate.parse("2032-10-21")
+        expected.requestDateTime = requestDateTime
         expected.cardFirstname = firstName
         expected.cardMiddleNames = middleNames
         expected.cardSurname = surname

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsFileProducerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsFileProducerTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildPrintRequest
 import java.io.ByteArrayOutputStream
-import java.time.Instant
-import java.util.Date
+import java.time.LocalDate
+import java.time.OffsetDateTime
 
 internal class PrintRequestsFileProducerTest {
 
@@ -21,9 +21,9 @@ internal class PrintRequestsFileProducerTest {
                 requestId = "627ab400-5ae2-4cc5-9e91-5c050e43e4c1",
                 issuingAuthorityEn = "Lake Deedra",
                 issuingAuthorityCy = "Bradtketon",
-                issueDate = "2022-06-01",
-                suggestedExpiryDate = "2032-06-01",
-                requestDateTime = Date(Instant.parse("2022-06-01T12:23:03.000Z").toEpochMilli()),
+                issueDate = LocalDate.parse("2022-06-01"),
+                suggestedExpiryDate = LocalDate.parse("2032-06-01"),
+                requestDateTime = OffsetDateTime.parse("2022-06-01T12:23:03.000Z"),
                 cardFirstname = "Otelia",
                 cardMiddleNames = "Shamika",
                 cardSurname = "Ziemann",
@@ -86,9 +86,9 @@ internal class PrintRequestsFileProducerTest {
                 requestId = "627ab400-5ae2-4cc5-9e91-5c050e43e4c1",
                 issuingAuthorityEn = "Lake Deedra",
                 issuingAuthorityCy = null,
-                issueDate = "2022-06-01",
-                suggestedExpiryDate = "2032-06-01",
-                requestDateTime = Date(Instant.parse("2022-06-01T12:23:03.000Z").toEpochMilli()),
+                issueDate = LocalDate.parse("2022-06-01"),
+                suggestedExpiryDate = LocalDate.parse("2032-06-01"),
+                requestDateTime = OffsetDateTime.parse("2022-06-01T12:23:03.000Z"),
                 cardFirstname = "Otelia",
                 cardMiddleNames = null,
                 cardSurname = "Ziemann",

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/PrintRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/PrintRequestBuilder.kt
@@ -5,8 +5,9 @@ import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildElectoralRegistrationOffice
-import java.time.Instant
-import java.util.Date
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 
 fun buildPrintRequest(
     eroEnglish: ElectoralRegistrationOffice = buildElectoralRegistrationOffice(),
@@ -14,9 +15,9 @@ fun buildPrintRequest(
     requestId: String = aValidRequestId(),
     issuingAuthorityEn: String = eroEnglish.name!!,
     issuingAuthorityCy: String? = eroWelsh?.name!!,
-    issueDate: String = "12/07/2023",
-    suggestedExpiryDate: String = "28/02/2033",
-    requestDateTime: Date = Date.from(Instant.now()),
+    issueDate: LocalDate = LocalDate.parse("2023-07-12"),
+    suggestedExpiryDate: LocalDate = LocalDate.parse("2033-02-28"),
+    requestDateTime: OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC),
     cardFirstname: String = faker.name().firstName(),
     cardMiddleNames: String? = faker.name().firstName(),
     cardSurname: String = faker.name().lastName(),
@@ -59,7 +60,7 @@ fun buildPrintRequest(
     request.issuingAuthorityEn = issuingAuthorityEn
     request.issueDate = issueDate
     request.suggestedExpiryDate = suggestedExpiryDate
-    request.requestDateTime = Date.from(requestDateTime.toInstant())
+    request.requestDateTime = requestDateTime
     request.cardFirstname = cardFirstname
     request.cardMiddleNames = cardMiddleNames
     request.cardSurname = cardSurname


### PR DESCRIPTION
The PR fixes the Print Provider API spec (yamlschema) and our codegen from it. Specifically it:

* Corrects `requestId` to not be a UUID in the `PrintResponse` object (its a 24 char hex string instead)
* Adds some examples and descriptions
* Adds config to our codegen so that date and datetime fields get generated using java8 classes rather than `java.util.Date` for date fields, and `String` (!!!) for `date-time` fields.

In respect of the contract between EROP and the Print Provider the only thing that has changed is the data type for `requestId` in `PrintResponse`