### PR TITLE
EIP1-2413 Add userId to SendApplicationToPrintMessage

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintDetails.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintDetails.kt
@@ -32,6 +32,7 @@ data class PrintDetails(
     var suggestedExpiryDate: LocalDate = issueDate.plusYears(10),
     var eroEnglish: ElectoralRegistrationOffice? = null,
     var eroWelsh: ElectoralRegistrationOffice? = null,
+    var userId: String? = null,
     @get:DynamoDbSecondaryPartitionKey(indexNames = [STATUS_BATCH_ID_INDEX_NAME]) var status: Status = Status.PENDING_ASSIGNMENT_TO_BATCH,
     @get:DynamoDbSecondarySortKey(indexNames = [STATUS_BATCH_ID_INDEX_NAME])var batchId: String? = null
 ) {

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -105,6 +105,12 @@ components:
           maxLength: 1024
         delivery:
           $ref: '#/components/schemas/CertificateDelivery'
+        userId:
+          type: string
+          format: email
+          maxLength: 1024
+          description: The userId (email address) of the EROP user requesting the print
+          example: fred.bloggs@some-domain.co.uk
       required:
         - sourceReference
         - sourceType
@@ -116,6 +122,7 @@ components:
         - certificateLanguage
         - photoLocation
         - delivery
+        - userId
 
     SourceType:
       title: SourceType

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.5.0'
+  version: '1.6.0'
   description: |-
     Print API SQS Message Types
     

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapperTest.kt
@@ -107,8 +107,25 @@ class PrintDetailsMapperTest {
                 gssCode = gssCode,
                 issuingAuthority = localAuthority.name,
                 issueDate = LocalDate.now(),
-                eroEnglish = electoralRegistrationOffice,
-                eroWelsh = if (certificateLanguageModel == CertificateLanguage.EN) null else electoralRegistrationOffice
+                eroEnglish = with(ero) {
+                    ElectoralRegistrationOffice(
+                        name = name,
+                        phoneNumber = null,
+                        emailAddress = null,
+                        website = null,
+                        address = null
+                    )
+                },
+                eroWelsh = if (certificateLanguageModel == CertificateLanguage.EN) null else with(ero) {
+                    ElectoralRegistrationOffice(
+                        name = name,
+                        phoneNumber = null,
+                        emailAddress = null,
+                        website = null,
+                        address = null
+                    )
+                },
+                userId = userId
             )
         }
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapperTest.kt
@@ -107,24 +107,8 @@ class PrintDetailsMapperTest {
                 gssCode = gssCode,
                 issuingAuthority = localAuthority.name,
                 issueDate = LocalDate.now(),
-                eroEnglish = with(ero) {
-                    ElectoralRegistrationOffice(
-                        name = name,
-                        phoneNumber = null,
-                        emailAddress = null,
-                        website = null,
-                        address = null
-                    )
-                },
-                eroWelsh = if (certificateLanguageModel == CertificateLanguage.EN) null else with(ero) {
-                    ElectoralRegistrationOffice(
-                        name = name,
-                        phoneNumber = null,
-                        emailAddress = null,
-                        website = null,
-                        address = null
-                    )
-                },
+                eroEnglish = electoralRegistrationOffice,
+                eroWelsh = if (certificateLanguageModel == CertificateLanguage.EN) null else electoralRegistrationOffice,
                 userId = userId
             )
         }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -77,7 +77,8 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                         )
                     )
                 },
-                eroWelsh = null
+                eroWelsh = null,
+                userId = userId
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/SendApplicationToPrintMessageBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/SendApplicationToPrintMessageBuilder.kt
@@ -26,7 +26,8 @@ fun buildSendApplicationToPrintMessage(
     delivery: CertificateDelivery = buildCertificateDelivery(),
     gssCode: String = getRandomGssCode(),
     photoLocation: String = "arn:aws:s3:::source-document-storage/$gssCode/$sourceReference/${UUID.randomUUID()}/" +
-        faker.file().fileName("", null, "jpg", "")
+        faker.file().fileName("", null, "jpg", ""),
+    userId: String = faker.internet().emailAddress()
 ) = SendApplicationToPrintMessage(
     sourceReference = sourceReference,
     applicationReference = applicationReference,
@@ -40,4 +41,5 @@ fun buildSendApplicationToPrintMessage(
     photoLocation = photoLocation,
     delivery = delivery,
     gssCode = gssCode,
+    userId = userId
 )


### PR DESCRIPTION
Future stories will expose REST APIs on the print-api that need to return data about the print request (VAC Certificate). The data that these REST APIs need to return include attributes relating to the Voter Card Application as well as the certificate print request.

A previous PR added `applicationReceivedDateTime` and `deliveryMethod` to the SQS message which VCA will need to send to this API. This PR adds the ID of the user that is requesting the print.

Corresponds to https://github.com/cabinetoffice/eip-ero-voter-card-applications-api/pull/272
