### PR TITLE
EIP1-1878 - Fix mapping of ERO fields in print request entity

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/ElectoralRegistrationOfficeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/ElectoralRegistrationOfficeMapper.kt
@@ -1,0 +1,18 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
+import uk.gov.dluhc.printapi.dto.EroManagementApiEroDto
+
+@Mapper
+interface ElectoralRegistrationOfficeMapper {
+
+    @Mapping(source = "name", target = "name")
+    @Mapping(target = "phoneNumber", constant = "")
+    @Mapping(target = "emailAddress", constant = "")
+    @Mapping(target = "website", constant = "")
+    @Mapping(target = "address.street", constant = "")
+    @Mapping(target = "address.postcode", constant = "")
+    fun map(dto: EroManagementApiEroDto): ElectoralRegistrationOffice
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintDetailsMapper.kt
@@ -13,7 +13,7 @@ import uk.gov.dluhc.printapi.service.IdFactory
 import java.util.UUID
 
 @Mapper(
-    uses = [SourceTypeMapper::class],
+    uses = [SourceTypeMapper::class, ElectoralRegistrationOfficeMapper::class],
     imports = [UUID::class, ObjectId::class, RandomStringUtils::class]
 )
 abstract class PrintDetailsMapper {

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/ElectoralRegistrationOfficeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/ElectoralRegistrationOfficeMapperTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.database.entity.Address
+import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroManagementApiEroDto
+
+class ElectoralRegistrationOfficeMapperTest {
+
+    private val mapper = ElectoralRegistrationOfficeMapperImpl()
+
+    @Test
+    fun `should map`() {
+        // Given
+        val dto = buildEroManagementApiEroDto(
+            id = "croydon-london-borough-council",
+            name = "Croydon London Borough Council"
+        )
+
+        val expected = ElectoralRegistrationOffice(
+            name = "Croydon London Borough Council",
+            phoneNumber = "",
+            emailAddress = "",
+            website = "",
+            address = Address(
+                street = "",
+                postcode = ""
+            )
+        )
+
+        // When
+        val electoralRegistrationOffice = mapper.map(dto)
+
+        // Then
+        assertThat(electoralRegistrationOffice).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -68,10 +68,13 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 eroEnglish = with(ero) {
                     ElectoralRegistrationOffice(
                         name = name,
-                        phoneNumber = null,
-                        emailAddress = null,
-                        website = null,
-                        address = null
+                        phoneNumber = "",
+                        emailAddress = "",
+                        website = "",
+                        address = Address(
+                            street = "",
+                            postcode = ""
+                        )
                     )
                 },
                 eroWelsh = null


### PR DESCRIPTION
This PR fixes the mapping of the ERO fields in the `PrintRequest` entity.
At the moment the fields that were missing (ERO phone number, email address, website, address street and address postcode) are mapped to empty string as we don't have the final values yet. This will be updated in a future PR