### PR TITLE
EIP1-564: EIP1:2369: Continue processing rest of the batch files on any file failure

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
@@ -2,45 +2,22 @@ package uk.gov.dluhc.printapi.jobs
 
 import mu.KotlinLogging
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.apache.commons.lang3.time.StopWatch
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
-import uk.gov.dluhc.printapi.config.SftpProperties
-import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
-import uk.gov.dluhc.printapi.service.PrintMessagingService
-import uk.gov.dluhc.printapi.service.SftpService
+import uk.gov.dluhc.printapi.service.PrintResponseFileReadinessService
 
 private val logger = KotlinLogging.logger {}
 
 @Component
 class ProcessPrintResponsesBatchJob(
-    private val sftpService: SftpService,
-    private val sftpProperties: SftpProperties,
-    private val printMessagingService: PrintMessagingService
+    private val printResponseFileReadinessService: PrintResponseFileReadinessService
 ) {
 
     @Scheduled(cron = "\${jobs.process-print-responses.cron}")
     @SchedulerLock(name = "\${jobs.process-print-responses.name}")
     fun pollAndProcessPrintResponses() {
-        val outboundFolderPath = sftpProperties.printResponseDownloadDirectory
-        logger.info { "Polling for print responses from directory: [$outboundFolderPath]" }
-
-        val stopWatch = StopWatch.createStarted()
-        val unprocessedFiles = sftpService.identifyFilesToBeProcessed(outboundFolderPath)
-        logger.info { "Found [${unprocessedFiles.size}] unprocessed print responses" }
-
-        unprocessedFiles.forEachIndexed { index, unprocessedFile ->
-            sftpService.markFileForProcessing(
-                directory = outboundFolderPath,
-                originalFileName = unprocessedFile.filename
-            ).also {
-                val messagePayload = ProcessPrintResponseFileMessage(outboundFolderPath, it)
-                logger.info { "Submitting SQS message for file: [${index + 1} of ${unprocessedFiles.size}] with payload: $messagePayload" }
-                printMessagingService.submitPrintResponseFileForProcessing(messagePayload)
-            }
-        }
-
-        stopWatch.stop()
-        logger.info { "Completed print response processing job from directory: [$outboundFolderPath] in [$stopWatch]" }
+        logger.info { "Polling for print responses from outbound directory" }
+        printResponseFileReadinessService.markPrintResponseFileForProcessing()
+        logger.info { "Completed print response polling job from outbound directory" }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
@@ -17,7 +17,7 @@ class ProcessPrintResponsesBatchJob(
     @SchedulerLock(name = "\${jobs.process-print-responses.name}")
     fun pollAndProcessPrintResponses() {
         logger.info { "Polling for print responses from outbound directory" }
-        printResponseFileReadinessService.markPrintResponseFileForProcessing()
+        printResponseFileReadinessService.markAndSubmitPrintResponseFileForProcessing()
         logger.info { "Completed print response polling job from outbound directory" }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileReadinessService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileReadinessService.kt
@@ -1,0 +1,43 @@
+package uk.gov.dluhc.printapi.service
+
+import mu.KotlinLogging
+import org.apache.commons.lang3.time.StopWatch
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.printapi.config.SftpProperties
+import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
+
+private val logger = KotlinLogging.logger {}
+
+@Service
+class PrintResponseFileReadinessService(
+    private val sftpService: SftpService,
+    private val sftpProperties: SftpProperties,
+    private val printMessagingService: PrintMessagingService
+) {
+
+    fun markPrintResponseFileForProcessing() {
+        val stopWatch = StopWatch.createStarted()
+        val outboundFolderPath = sftpProperties.printResponseDownloadDirectory
+        logger.info { "Finding matching print responses from directory: [$outboundFolderPath]" }
+
+        val unprocessedFiles = sftpService.identifyFilesToBeProcessed(outboundFolderPath)
+        logger.info { "Found [${unprocessedFiles.size}] unprocessed print responses" }
+
+        unprocessedFiles.forEachIndexed { index, unprocessedFileName ->
+            try {
+                sftpService.markFileForProcessing(
+                    directory = outboundFolderPath,
+                    originalFileName = unprocessedFileName
+                ).also {
+                    val messagePayload = ProcessPrintResponseFileMessage(outboundFolderPath, it)
+                    logger.info { "Submitting SQS message for file: [${index + 1} of ${unprocessedFiles.size}] with payload: $messagePayload" }
+                    printMessagingService.submitPrintResponseFileForProcessing(messagePayload)
+                }
+            } catch (e: RuntimeException) {
+                logger.warn { "Error renaming [$unprocessedFileName] due to [${e.message}]. Processing will continue for rest of the files" }
+            }
+        }
+        stopWatch.stop()
+        logger.info { "Completed marking and processing all print response files in [$stopWatch]" }
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/SftpService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/SftpService.kt
@@ -1,6 +1,5 @@
 package uk.gov.dluhc.printapi.service
 
-import com.jcraft.jsch.ChannelSftp
 import mu.KotlinLogging
 import org.apache.commons.io.IOUtils
 import org.springframework.beans.factory.annotation.Qualifier
@@ -32,14 +31,15 @@ class SftpService(
         )
 
     /**
-     * Returns list entry for all files present in the directory
+     * Returns list of all files present in the directory
      * @param filesDirectoryPath the location of the status files
      */
-    fun identifyFilesToBeProcessed(filesDirectoryPath: String): List<ChannelSftp.LsEntry> =
+    fun identifyFilesToBeProcessed(filesDirectoryPath: String): List<String> =
         sftpOutboundTemplate
             .list(filesDirectoryPath)
             .filterNot { lsEntry -> lsEntry.filename.endsWith(PROCESSING_SUFFIX) }
             .filter { lsEntry -> lsEntry.filename.matches(STATUS_RESPONSE_FILE_REGEX) }
+            .map { it.filename }
 
     /**
      * Renames the file by suffixing ".processing" to its original name. Returns the newly renamed file name

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileReadinessServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileReadinessServiceTest.kt
@@ -1,0 +1,113 @@
+package uk.gov.dluhc.printapi.service
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.dluhc.printapi.config.SftpProperties
+import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
+
+@ExtendWith(MockitoExtension::class)
+internal class PrintResponseFileReadinessServiceTest {
+
+    @Mock
+    private lateinit var sftpService: SftpService
+
+    @Mock
+    private lateinit var sftpProperties: SftpProperties
+
+    @Mock
+    private lateinit var printMessagingService: PrintMessagingService
+
+    @InjectMocks
+    private lateinit var printResponseFileReadinessService: PrintResponseFileReadinessService
+
+    companion object {
+        const val DIRECTORY = "/some-directory"
+    }
+
+    @Test
+    fun `should not mark print response file and not send to queue when no files are present`() {
+        // Given
+
+        given(sftpProperties.printResponseDownloadDirectory).willReturn(DIRECTORY)
+        given(sftpService.identifyFilesToBeProcessed(any())).willReturn(emptyList())
+
+        // When
+        printResponseFileReadinessService.markPrintResponseFileForProcessing()
+
+        // Then
+        verify(sftpService).identifyFilesToBeProcessed(DIRECTORY)
+        verifyNoInteractions(printMessagingService)
+        verifyNoMoreInteractions(sftpService)
+    }
+
+    @Test
+    fun `should mark print response file and send to queue when files are present`() {
+        // Given
+        val matchingFileName1 = "status-20221101171156056.json"
+        val matchingFileName2 = "status-20221101171156057.json"
+        val renamedFileName1 = "$matchingFileName1.processing"
+        val renamedFileName2 = "$matchingFileName2.processing"
+
+        given(sftpProperties.printResponseDownloadDirectory).willReturn(DIRECTORY)
+        given(sftpService.identifyFilesToBeProcessed(any())).willReturn(listOf(matchingFileName1, matchingFileName2))
+        given(sftpService.markFileForProcessing(eq(DIRECTORY), eq(matchingFileName1))).willReturn(renamedFileName1)
+        given(sftpService.markFileForProcessing(eq(DIRECTORY), eq(matchingFileName2))).willReturn(renamedFileName2)
+
+        // When
+        printResponseFileReadinessService.markPrintResponseFileForProcessing()
+
+        // Then
+        verify(sftpService).identifyFilesToBeProcessed(DIRECTORY)
+        verify(sftpService).markFileForProcessing(DIRECTORY, matchingFileName1)
+        verify(sftpService).markFileForProcessing(DIRECTORY, matchingFileName2)
+        verify(printMessagingService).submitPrintResponseFileForProcessing(
+            ProcessPrintResponseFileMessage(DIRECTORY, renamedFileName1)
+        )
+        verify(printMessagingService).submitPrintResponseFileForProcessing(
+            ProcessPrintResponseFileMessage(DIRECTORY, renamedFileName2)
+        )
+        verifyNoMoreInteractions(sftpService, printMessagingService)
+    }
+
+    @Test
+    fun `should continue marking print response file and sending to queue when one of the file marking fails due to exception`() {
+        // Given
+        val matchingFileName1 = "status-20221101171156056.json"
+        val matchingFileThatThrowsException = "status-20221101171156057.json"
+        val matchingFileName3 = "status-20221101171156058.json"
+        val renamedFileName1 = "$matchingFileName1.processing"
+        val renamedFileName3 = "$matchingFileName3.processing"
+        val expectedExceptionThrown = RuntimeException("Some error")
+
+        given(sftpProperties.printResponseDownloadDirectory).willReturn(DIRECTORY)
+        given(sftpService.identifyFilesToBeProcessed(any())).willReturn(listOf(matchingFileName1, matchingFileThatThrowsException, matchingFileName3))
+        given(sftpService.markFileForProcessing(eq(DIRECTORY), eq(matchingFileName1))).willReturn(renamedFileName1)
+        given(sftpService.markFileForProcessing(eq(DIRECTORY), eq(matchingFileThatThrowsException))).willThrow(expectedExceptionThrown)
+        given(sftpService.markFileForProcessing(eq(DIRECTORY), eq(matchingFileName3))).willReturn(renamedFileName3)
+
+        // When
+        printResponseFileReadinessService.markPrintResponseFileForProcessing()
+
+        // Then
+        verify(sftpService).identifyFilesToBeProcessed(DIRECTORY)
+        verify(sftpService).markFileForProcessing(DIRECTORY, matchingFileName1)
+        verify(sftpService).markFileForProcessing(DIRECTORY, matchingFileThatThrowsException)
+        verify(sftpService).markFileForProcessing(DIRECTORY, matchingFileName3)
+        verify(printMessagingService).submitPrintResponseFileForProcessing(
+            ProcessPrintResponseFileMessage(DIRECTORY, renamedFileName1)
+        )
+        verify(printMessagingService).submitPrintResponseFileForProcessing(
+            ProcessPrintResponseFileMessage(DIRECTORY, renamedFileName3)
+        )
+        verifyNoMoreInteractions(sftpService, printMessagingService)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/SftpServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/SftpServiceTest.kt
@@ -118,8 +118,13 @@ internal class SftpServiceTest {
             // Then
             assertThat(fileList)
                 .hasSize(expectedFileCount)
-                .containsExactlyInAnyOrder(matchedFile1, matchedFile2, matchedFile3, matchedFile4)
-                .doesNotContain(alreadyProcessedFile)
+                .containsExactlyInAnyOrder(
+                    matchedFile1.filename,
+                    matchedFile2.filename,
+                    matchedFile3.filename,
+                    matchedFile4.filename
+                )
+                .doesNotContain(alreadyProcessedFile.filename)
             verify(sftpOutboundTemplate).list(filesDirectoryPath)
             verifyNoInteractions(sftpInboundTemplate)
         }


### PR DESCRIPTION
We want the ability to **continue processing** rest of the batch files, when any operation on one of the files fails.
- Also introduced `PrintResponseFileReadinessService` that takes the weight off from the `ProcessPrintResponsesBatchJob`