### PR TITLE
EIP1-2262 - Added queue and basic listener for processing print response message

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following environment variables must be set in order to run the application:
 * `SQS_SEND_APPLICATION_TO_PRINT_QUEUE_NAME` - the queue name for sending application to print
 * `SQS_PROCESS_PRINT_REQUEST_BATCH_QUEUE_NAME` - the queue name for processing print request batches
 * `SQS_PROCESS_PRINT_RESPONSE_FILE_QUEUE_NAME` - the queue name for processing print response files
+* `SQS_PROCESS_PRINT_RESPONSE_QUEUE_NAME` - the queue name for processing individual print responses
 * `API_ERO_MANAGEMENT_URL` - the base URL of the ERO Management REST API service.
 * `DYNAMODB_ENDPOINT` - the localstack endpoint
 * `DYNAMODB_PRINT_DETAILS_TABLE_NAME` - table name to persist print details

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/MessagingConfiguration.kt
@@ -15,6 +15,7 @@ import org.springframework.validation.Validator
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
+import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseMessage
 
 @Configuration
 class MessagingConfiguration {
@@ -25,6 +26,9 @@ class MessagingConfiguration {
     @Value("\${sqs.process-print-response-file-queue-name}")
     private lateinit var processPrintResponseFileQueueName: String
 
+    @Value("\${sqs.process-print-response-queue-name}")
+    private lateinit var processPrintResponseQueueName: String
+
     @Bean
     fun processPrintRequestBatchQueue(queueMessagingTemplate: QueueMessagingTemplate) =
         MessageQueue<ProcessPrintRequestBatchMessage>(processPrintRequestBatchQueueName, queueMessagingTemplate)
@@ -32,6 +36,10 @@ class MessagingConfiguration {
     @Bean
     fun processPrintResponseFileQueue(queueMessagingTemplate: QueueMessagingTemplate) =
         MessageQueue<ProcessPrintResponseFileMessage>(processPrintResponseFileQueueName, queueMessagingTemplate)
+
+    @Bean
+    fun processPrintResponseQueue(queueMessagingTemplate: QueueMessagingTemplate) =
+        MessageQueue<ProcessPrintResponseMessage>(processPrintResponseQueueName, queueMessagingTemplate)
 
     @Bean
     fun queueMessageHandlerFactory(

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintResponseMessageListener.kt
@@ -1,0 +1,24 @@
+package uk.gov.dluhc.printapi.messaging
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener
+import mu.KotlinLogging
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseMessage
+import javax.validation.Valid
+
+private val logger = KotlinLogging.logger { }
+
+/**
+ * Implementation of [MessageListener] to handle [ProcessPrintResponseMessage] messages
+ */
+@Component
+class ProcessPrintResponseMessageListener : MessageListener<ProcessPrintResponseMessage> {
+
+    @SqsListener("\${sqs.process-print-response-queue-name}")
+    override fun handleMessage(@Valid @Payload payload: ProcessPrintResponseMessage) {
+        with(payload) {
+            logger.info { "Begin processing PrintResponse with requestId ${payload.requestId}" }
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,7 @@ sqs:
   send-application-to-print-queue-name: ${SQS_SEND_APPLICATION_TO_PRINT_QUEUE_NAME}
   process-print-request-batch-queue-name: ${SQS_PROCESS_PRINT_REQUEST_BATCH_QUEUE_NAME}
   process-print-response-file-queue-name: ${SQS_PROCESS_PRINT_RESPONSE_FILE_QUEUE_NAME}
+  process-print-response-queue-name: ${SQS_PROCESS_PRINT_RESPONSE_QUEUE_NAME}
 
 api:
   ero-management:

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.6.0'
+  version: '1.7.0'
   description: |-
     Print API SQS Message Types
     
@@ -49,6 +49,16 @@ paths:
       responses:
         '204':
           description: No response content.
+  '/process-print-response':
+    post:
+      tags:
+        - SQS Queues
+      requestBody:
+        $ref: '#/components/requestBodies/ProcessPrintResponseMessage'
+      responses:
+        '204':
+          description: No response content.
+
 components:
   #
   # Schema and Enum Definitions
@@ -242,6 +252,46 @@ components:
       required:
         - directory
         - fileName
+
+    ProcessPrintResponseMessage:
+      description: The SQS message for processing the status change for an individual Print Request
+      type: object
+      properties:
+        requestId:
+          type: string
+          description: |-
+            The unique identifier of the Print Request
+            A 24 character hex string
+          example: 14ab70e8bd3b400fbd95246c
+        timestamp:
+          type: string
+          format: date-time
+          description: The date time the Print Provider issued this status change for the Print Request.
+          example: '2022-06-01T14:23:03.000Z'
+        statusStep:
+          type: string
+          description: The current print step this update relates to
+          enum:
+            - PROCESSED
+            - IN-PRODUCTION
+            - DISPATCHED
+            - NOT-DELIVERED
+        status:
+          type: string
+          enum:
+            - SUCCESS
+            - FAILED
+          description: Indicates if the step change was successful or not.
+        message:
+          type: string
+          maxLength: 255
+          description: Error description. Only populated if `status` is `FAILED`
+      required:
+        - requestId
+        - timestamp
+        - statusStep
+        - status
+
   #
   # Response Body Definitions
   # --------------------------------------------------------------------------------
@@ -266,3 +316,8 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ProcessPrintResponseFileMessage'
+    ProcessPrintResponseMessage:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ProcessPrintResponseMessage'

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -35,6 +35,7 @@ import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.jobs.ProcessPrintResponsesBatchJob
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
+import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseMessage
 import uk.gov.dluhc.printapi.service.SftpService
 import uk.gov.dluhc.printapi.testsupport.TestLogAppender
 import uk.gov.dluhc.printapi.testsupport.WiremockService
@@ -91,6 +92,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var processPrintResponseFileMessageQueue: MessageQueue<ProcessPrintResponseFileMessage>
+
+    @Autowired
+    protected lateinit var processPrintResponseMessageQueue: MessageQueue<ProcessPrintResponseMessage>
 
     @Autowired
     protected lateinit var objectMapper: ObjectMapper

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,7 @@ sqs:
   send-application-to-print-queue-name: send-application-to-print
   process-print-request-batch-queue-name: process-print-request-batch
   process-print-response-file-queue-name: process-print-response-file
+  process-print-response-queue-name: process-print-response
 
 api:
   ero-management:


### PR DESCRIPTION
This PR is an enabler for the real work thats being done in EIP1-2262

It:
* adds a new message type `ProcessPrintResponseMessage` to the SQS schema and codegens it
* adds a new queue bean for the new type, so that messages can be sent to it (future work in 2262)
* adds a new listener for the new type, so that messages can be consumed (future work on 2262)
* documents the environment variable required for the queue name

The corresponding infra changes (create the queue, wire the env var into the container) have already been done and merged

Next tasks after this are to:
* Add the updated SQS schema to VCA (even though VCA wont be publishing or consuming messages of this type)
* Add the queue and env var to our docker-compose setup

