### PR TITLE
EIP1-1878 - Fixes how the ASSIGNED_TO_BATCH status is set

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -3,13 +3,10 @@ package uk.gov.dluhc.printapi.service
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.database.entity.PrintDetails
-import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
-import java.time.Clock
-import java.time.OffsetDateTime
 
 private val logger = KotlinLogging.logger { }
 
@@ -18,25 +15,14 @@ class PrintRequestsService(
     private val printDetailsRepository: PrintDetailsRepository,
     private val idFactory: IdFactory,
     private val processPrintRequestQueue: MessageQueue<ProcessPrintRequestBatchMessage>,
-    private val clock: Clock,
 ) {
 
     fun processPrintRequests(batchSize: Int) {
-        batchPrintRequests(batchSize).map { (batchId, printDetails) ->
-            printDetails.map {
-                it.copy(
-                    batchId = batchId,
-                    printRequestStatuses = it.printRequestStatuses?.plus(
-                        PrintRequestStatus(Status.ASSIGNED_TO_BATCH, OffsetDateTime.now(clock))
-                    )?.toMutableList()
-                )
-            }
-        }.forEach { batch ->
-            batch.forEach { pd ->
+        batchPrintRequests(batchSize).forEach { (batchId, batchOfPrintDetails) ->
+            batchOfPrintDetails.forEach { pd ->
                 printDetailsRepository.save(pd)
                 logger.info { "Print request with id [${pd.id}] assigned to batch [${pd.batchId}]" }
             }
-            val batchId = batch.first().batchId!!
             processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
             logger.info { "Batch [$batchId] submitted to queue" }
         }
@@ -44,9 +30,12 @@ class PrintRequestsService(
 
     fun batchPrintRequests(batchSize: Int): Map<String, List<PrintDetails>> {
         val printDetailsPendingAssignment = printDetailsRepository.getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
-        return printDetailsPendingAssignment.chunked(batchSize).associate { batch ->
+        return printDetailsPendingAssignment.chunked(batchSize).associate { batchOfPrintDetails ->
             val batchId = idFactory.batchId()
-            batchId to batch.map { it.copy(batchId = batchId) }
+            batchId to batchOfPrintDetails.onEach {
+                it.batchId = batchId
+                it.addStatus(Status.ASSIGNED_TO_BATCH)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR changes how the ASSIGNED_TO_BATCH status is set on a PrintDetails entity when it is assigned to batch

The problem was we were not setting the `eventDateTime` field when adding the status. I have simplified (IMHO) the code to move away from a functional approach, and change to mutating the PrintDetails via its addStatus method
(I know, I know! immutability rocks, but the functional approach was making it hard in this case to grok and do what we needed to do)