### PR TITLE
EIP1-2386 Integrate MySQL in process to send printer zip file or print requests

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/PrintDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/PrintDetailsRepository.kt
@@ -60,12 +60,8 @@ class PrintDetailsRepository(client: DynamoDbEnhancedClient, tableConfig: Dynamo
     fun getAllByStatus(status: Status): List<PrintDetails> {
         val expression = Expression.builder()
             .expression("#print_status = :status")
-            .expressionNames(mapOf(Pair("#print_status", "status")))
-            .expressionValues(
-                mapOf(
-                    Pair(":status", AttributeValue.builder().s(status.toString()).build())
-                )
-            )
+            .expressionNames(mapOf("#print_status" to "status"))
+            .expressionValues(mapOf(":status" to AttributeValue.builder().s(status.toString()).build()))
             .build()
         return table.scan(ScanEnhancedRequest.builder().filterExpression(expression).build()).items().toList()
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/PrintDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/PrintDetailsRepository.kt
@@ -63,7 +63,7 @@ class PrintDetailsRepository(client: DynamoDbEnhancedClient, tableConfig: Dynamo
             .expressionNames(mapOf(Pair("#print_status", "status")))
             .expressionValues(
                 mapOf(
-                    Pair(":status", AttributeValue.builder().s(Status.PENDING_ASSIGNMENT_TO_BATCH.toString()).build())
+                    Pair(":status", AttributeValue.builder().s(status.toString()).build())
                 )
             )
             .build()

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rds/entity/PrintRequestStatus.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rds/entity/PrintRequestStatus.kt
@@ -13,6 +13,8 @@ import java.time.Instant
 import java.util.UUID
 import javax.persistence.Entity
 import javax.persistence.EntityListeners
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
 import javax.persistence.Id
@@ -32,6 +34,7 @@ class PrintRequestStatus(
     var id: UUID? = null,
 
     @field:NotNull
+    @Enumerated(EnumType.STRING)
     var status: Status? = null,
 
     @field:NotNull

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepository.kt
@@ -9,9 +9,9 @@ import java.util.UUID
 @Repository
 interface CertificateRepository : JpaRepository<Certificate, UUID> {
 
-    fun getByPrintRequestsRequestIdIs(requestId: String): Certificate
+    fun getByPrintRequestsRequestId(requestId: String): Certificate
 
-    fun findByStatusAndPrintRequestsBatchIdIs(certificateStatus: Status, batchId: String): List<Certificate>
+    fun findByStatusAndPrintRequestsBatchId(certificateStatus: Status, batchId: String): List<Certificate>
 
-    fun findByStatusIs(certificateStatus: Status): List<Certificate>
+    fun findByStatus(certificateStatus: Status): List<Certificate>
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepository.kt
@@ -2,8 +2,16 @@ package uk.gov.dluhc.printapi.rds.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.rds.entity.Certificate
 import java.util.UUID
 
 @Repository
-interface CertificateRepository : JpaRepository<Certificate, UUID>
+interface CertificateRepository : JpaRepository<Certificate, UUID> {
+
+    fun getByPrintRequestsRequestIdIs(requestId: String): Certificate
+
+    fun findByStatusAndPrintRequestsBatchIdIs(certificateStatus: Status, batchId: String): List<Certificate>
+
+    fun findByStatusIs(certificateStatus: Status): List<Certificate>
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
@@ -64,7 +64,7 @@ class PrintFileDetailsFactory(
         requests: MutableList<PrintRequest>,
         photos: MutableList<PhotoLocation>
     ) {
-        val latestRequest = certificate.getCurrentPrintRequest()!!
+        val latestRequest = certificate.getCurrentPrintRequest()
         val photoArn = latestRequest.photoLocationArn!!
         val photoLocation = photoLocationFactory.create(latestRequest.batchId!!, latestRequest.requestId!!, photoArn)
         val printRequest = certificateToPrintRequestMapper.map(certificate, latestRequest, photoLocation.zipPath)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -37,7 +37,7 @@ class PrintRequestsService(
     }
 
     fun batchCertificates(batchSize: Int): Map<String, List<Certificate>> {
-        val certificatesPendingAssignment = certificateRepository.findByStatusIs(Status.PENDING_ASSIGNMENT_TO_BATCH)
+        val certificatesPendingAssignment = certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
         return certificatesPendingAssignment.chunked(batchSize).associate { batchOfCertificates ->
             val batchId = idFactory.batchId()
             batchId to batchOfCertificates.onEach {

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -7,17 +7,47 @@ import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 
 private val logger = KotlinLogging.logger { }
 
 @Component
 class PrintRequestsService(
     private val printDetailsRepository: PrintDetailsRepository,
+    private val certificateRepository: CertificateRepository,
     private val idFactory: IdFactory,
     private val processPrintRequestQueue: MessageQueue<ProcessPrintRequestBatchMessage>,
 ) {
 
     fun processPrintRequests(batchSize: Int) {
+        processDynamoBatch(batchSize)
+        processBatch(batchSize)
+    }
+
+    private fun processBatch(batchSize: Int) {
+        batchCertificates(batchSize).forEach { (batchId, batchOfCertificates) ->
+            batchOfCertificates.forEach { certificate ->
+                certificateRepository.save(certificate)
+                logger.info { "Certificate with id [${certificate.id}] assigned to batch [$batchId]" }
+            }
+            processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
+            logger.info { "Batch [$batchId] submitted to queue" }
+        }
+    }
+
+    fun batchCertificates(batchSize: Int): Map<String, List<Certificate>> {
+        val certificatesPendingAssignment = certificateRepository.findByStatusIs(Status.PENDING_ASSIGNMENT_TO_BATCH)
+        return certificatesPendingAssignment.chunked(batchSize).associate { batchOfCertificates ->
+            val batchId = idFactory.batchId()
+            batchId to batchOfCertificates.onEach {
+                it.getCurrentPrintRequest().batchId = batchId
+                it.addStatus(Status.ASSIGNED_TO_BATCH)
+            }
+        }
+    }
+
+    private fun processDynamoBatch(batchSize: Int) {
         batchPrintRequests(batchSize).forEach { (batchId, batchOfPrintDetails) ->
             batchOfPrintDetails.forEach { pd ->
                 printDetailsRepository.save(pd)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintService.kt
@@ -4,18 +4,25 @@ import org.springframework.stereotype.Service
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.mapper.PrintDetailsMapper
 import uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage
+import uk.gov.dluhc.printapi.rds.mapper.CertificateMapper
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import uk.gov.dluhc.printapi.client.ElectoralRegistrationOfficeManagementApiClient as EroClient
 
 @Service
 class PrintService(
     private val eroClient: EroClient,
     private val printDetailsMapper: PrintDetailsMapper,
-    private val printDetailsRepository: PrintDetailsRepository
+    private val printDetailsRepository: PrintDetailsRepository,
+    private val certificateMapper: CertificateMapper,
+    private val certificateRepository: CertificateRepository
 ) {
     fun savePrintMessage(message: SendApplicationToPrintMessage) {
         val ero = eroClient.getElectoralRegistrationOffice(message.gssCode!!)
         val localAuthority = ero.localAuthorities.first { it.gssCode == message.gssCode }
         val printDetails = printDetailsMapper.toPrintDetails(message, ero, localAuthority.name)
         printDetailsRepository.save(printDetails)
+
+        val certificate = certificateMapper.toCertificate(message, ero, localAuthority.name)
+        certificateRepository.save(certificate)
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -44,7 +44,7 @@ class ProcessPrintBatchService(
         val printList = printDetailsRepository.getAllByStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
         val dynamoFileContents = printFileDetailsFactory.createFileDetails(batchId, printList)
 
-        val certificates = certificateRepository.findByStatusAndPrintRequestsBatchIdIs(ASSIGNED_TO_BATCH, batchId)
+        val certificates = certificateRepository.findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
         val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
 
         val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(dynamoFileContents)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -47,7 +47,7 @@ class ProcessPrintBatchService(
         val certificates = certificateRepository.findByStatusAndPrintRequestsBatchIdIs(ASSIGNED_TO_BATCH, batchId)
         val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
 
-        val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
+        val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(dynamoFileContents)
         val sftpFilename = filenameFactory.createZipFilename(batchId, printList.size)
         sftpService.sendFile(sftpInputStream, sftpFilename)
         printDetailsRepository.updateItems(updateBatch(printList))

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -5,6 +5,9 @@ import uk.gov.dluhc.printapi.database.entity.PrintDetails
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
+import javax.transaction.Transactional
 
 /**
  * Processes a print batch request by streaming a zip file containing manifest and photo images
@@ -14,6 +17,7 @@ import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 class ProcessPrintBatchService(
     private val printDetailsRepository: PrintDetailsRepository,
     private val printFileDetailsFactory: PrintFileDetailsFactory,
+    private val certificateRepository: CertificateRepository,
     private val sftpZipInputStreamProvider: SftpInputStreamProvider,
     private val filenameFactory: FilenameFactory,
     private val sftpService: SftpService
@@ -35,17 +39,29 @@ class ProcessPrintBatchService(
      *
      * Step 4: Update Dynamo batch records with new status
      */
+    @Transactional
     fun processBatch(batchId: String) {
         val printList = printDetailsRepository.getAllByStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
-        val fileContents = printFileDetailsFactory.createFileDetails(batchId, printList)
+        val dynamoFileContents = printFileDetailsFactory.createFileDetails(batchId, printList)
+
+        val certificates = certificateRepository.findByStatusAndPrintRequestsBatchIdIs(ASSIGNED_TO_BATCH, batchId)
+        val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
+
         val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
         val sftpFilename = filenameFactory.createZipFilename(batchId, printList.size)
         sftpService.sendFile(sftpInputStream, sftpFilename)
         printDetailsRepository.updateItems(updateBatch(printList))
+        updateCertificates(certificates)
     }
 
     private fun updateBatch(printList: List<PrintDetails>): List<PrintDetails> {
         printList.forEach { printDetails -> printDetails.addStatus(Status.SENT_TO_PRINT_PROVIDER) }
         return printList
+    }
+
+    private fun updateCertificates(certificates: List<Certificate>) {
+        certificates.forEach { certificate ->
+            certificate.addStatus(Status.SENT_TO_PRINT_PROVIDER)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.springframework.integration.file.remote.InputStreamCallback
+import org.springframework.test.context.transaction.TestTransaction
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import uk.gov.dluhc.printapi.config.IntegrationTest
@@ -14,6 +15,11 @@ import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_R
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
+import uk.gov.dluhc.printapi.rds.entity.Address
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.entity.Delivery
+import uk.gov.dluhc.printapi.rds.entity.ElectoralRegistrationOffice
+import uk.gov.dluhc.printapi.rds.entity.PrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildElectoralRegistrationOffice
@@ -24,11 +30,13 @@ import java.time.OffsetDateTime
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
+import javax.transaction.Transactional
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : IntegrationTest() {
 
     @Test
+    @Transactional
     fun `should process print request batch message`() {
         // Given
         val printDetailsId = UUID.randomUUID()
@@ -54,28 +62,118 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
             id = printDetailsId,
             batchId = batchId,
             printRequestStatuses = mutableListOf(
-                PrintRequestStatus(ASSIGNED_TO_BATCH, OffsetDateTime.now(clock))
+                PrintRequestStatus(ASSIGNED_TO_BATCH, OffsetDateTime.now(clock), OffsetDateTime.now(clock))
             ),
             requestId = requestId,
             eroWelsh = buildElectoralRegistrationOffice(),
             photoLocation = "arn:aws:s3:::$s3Bucket/$s3Path"
         )
         printDetailsRepository.save(details)
+
+        // save certificates in MySQL
+        var certificate = Certificate(
+            vacNumber = details.vacNumber,
+            sourceType = details.sourceType,
+            sourceReference = details.sourceReference,
+            applicationReference = details.applicationReference,
+            applicationReceivedDateTime = details.applicationReceivedDateTime?.toInstant(),
+            issuingAuthority = details.issuingAuthority,
+            issueDate = details.issueDate,
+            suggestedExpiryDate = details.suggestedExpiryDate,
+            gssCode = details.gssCode,
+            status = details.printRequestStatuses!![0].status,
+            printRequests = mutableListOf(
+                PrintRequest(
+                    requestId = details.requestId,
+                    vacVersion = details.vacVersion,
+                    requestDateTime = details.requestDateTime!!.toInstant(),
+                    firstName = details.firstName,
+                    middleNames = details.middleNames,
+                    surname = details.surname,
+                    certificateLanguage = details.certificateLanguage,
+                    certificateFormat = details.certificateFormat,
+                    photoLocationArn = details.photoLocation,
+                    delivery = Delivery(
+                        address = Address(
+                            street = details.delivery?.address?.street,
+                            postcode = details.delivery?.address?.postcode,
+                            property = details.delivery?.address?.property,
+                            locality = details.delivery?.address?.locality,
+                            town = details.delivery?.address?.town,
+                            area = details.delivery?.address?.area,
+                            uprn = details.delivery?.address?.uprn,
+                        ),
+                        addressee = details.delivery?.addressee,
+                        deliveryClass = details.delivery?.deliveryClass,
+                        deliveryMethod = details.delivery?.deliveryMethod
+                    ),
+                    eroEnglish = ElectoralRegistrationOffice(
+                        name = details.eroEnglish?.name,
+                        phoneNumber = details.eroEnglish?.phoneNumber,
+                        emailAddress = details.eroEnglish?.emailAddress,
+                        website = details.eroEnglish?.website,
+                        address = Address(
+                            street = details.eroEnglish?.address?.street,
+                            postcode = details.eroEnglish?.address?.postcode,
+                            property = details.eroEnglish?.address?.property,
+                            locality = details.eroEnglish?.address?.locality,
+                            town = details.eroEnglish?.address?.town,
+                            area = details.eroEnglish?.address?.area,
+                            uprn = details.eroEnglish?.address?.uprn,
+                        )
+                    ),
+                    eroWelsh = ElectoralRegistrationOffice(
+                        name = details.eroWelsh?.name,
+                        phoneNumber = details.eroWelsh?.phoneNumber,
+                        emailAddress = details.eroWelsh?.emailAddress,
+                        website = details.eroWelsh?.website,
+                        address = Address(
+                            street = details.eroWelsh?.address?.street,
+                            postcode = details.eroWelsh?.address?.postcode,
+                            property = details.eroWelsh?.address?.property,
+                            locality = details.eroWelsh?.address?.locality,
+                            town = details.eroWelsh?.address?.town,
+                            area = details.eroWelsh?.address?.area,
+                            uprn = details.eroWelsh?.address?.uprn,
+                        )
+                    ),
+                    batchId = details.batchId,
+                    userId = details.userId,
+                    statusHistory = mutableListOf(
+                        uk.gov.dluhc.printapi.rds.entity.PrintRequestStatus(
+                            status = details.printRequestStatuses!![0].status,
+                            eventDateTime = details.printRequestStatuses!![0].eventDateTime?.toInstant(),
+                            message = details.printRequestStatuses!![0].message
+                        )
+                    )
+                )
+            )
+        )
+        certificate = certificateRepository.save(certificate)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
+
         assertThat(filterListForName(batchId)).isEmpty()
 
         // add message to queue for processing
         val payload = buildProcessPrintRequestBatchMessage(batchId = batchId)
 
         // When
+        TestTransaction.start()
         sqsMessagingTemplate.convertAndSend(processPrintRequestBatchQueueName, payload)
+        TestTransaction.flagForCommit()
+        TestTransaction.end()
 
         // Then
+        TestTransaction.start()
         await.atMost(5, TimeUnit.SECONDS).untilAsserted {
             val sftpDirectoryList = filterListForName(batchId)
             assertThat(sftpDirectoryList).hasSize(1)
             verifySftpZipFile(sftpDirectoryList, batchId, requestId, s3ResourceContents)
             val processedPrintDetails = printDetailsRepository.get(printDetailsId)
             assertThat(processedPrintDetails.status).isEqualTo(Status.SENT_TO_PRINT_PROVIDER)
+            val processedCertificate = certificateRepository.findById(certificate.id!!).get()
+            assertThat(processedCertificate.status).isEqualTo(Status.SENT_TO_PRINT_PROVIDER)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/entity/CertificateTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/entity/CertificateTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.dluhc.printapi.rds.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchException
+import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.dluhc.printapi.database.entity.Status
@@ -16,15 +18,15 @@ internal class CertificateTest {
     inner class GetCurrentPrintRequest {
 
         @Test
-        fun `should get latest print request for Certificate with no Print Requests`() {
+        fun `should fail to get latest print request for Certificate with no Print Requests`() {
             // Given
-            val certificate = certificateBuilder(printRequests = listOf())
+            val certificate = certificateBuilder(printRequests = emptyList())
 
             // When
-            val actual = certificate.getCurrentPrintRequest()
+            val actual = catchException { certificate.getCurrentPrintRequest() }
 
             // Then
-            assertThat(actual).isNull()
+            assertThat(actual).isInstanceOf(NoSuchElementException::class.java)
         }
 
         @Test
@@ -56,75 +58,74 @@ internal class CertificateTest {
     }
 
     @Nested
-    inner class PrePersist {
+    inner class AddStatus {
 
         @Test
-        fun `should determine latest status for Certificate with no Print Requests`() {
+        fun `should fail to add status for Certificate with no existing Print Requests`() {
             // Given
-            val certificate = certificateBuilder(printRequests = listOf())
+            val certificate = certificateBuilder(printRequests = emptyList())
+            val status = Status.VALIDATED_BY_PRINT_PROVIDER
 
             // When
-            certificate.prePersist()
+            val actual = catchException { certificate.addStatus(status) }
 
             // Then
-            assertThat(certificate.status).isEqualTo(Status.PENDING_ASSIGNMENT_TO_BATCH)
+            assertThat(actual).isInstanceOf(NoSuchElementException::class.java)
         }
 
         @Test
-        fun `should determine latest status for Certificate with one Print Request with one status`() {
+        fun `should add status for Certificate with one Print Request with one status`() {
             // Given
-            val certificate = certificateBuilder(
-                printRequests = listOf(
-                    printRequestBuilder(
-                        printRequestStatuses = listOf(
-                            printRequestStatusBuilder(
-                                status = Status.ASSIGNED_TO_BATCH
-                            )
-                        )
+            val printRequest = printRequestBuilder(
+                printRequestStatuses = listOf(
+                    printRequestStatusBuilder(
+                        status = Status.ASSIGNED_TO_BATCH
                     )
                 )
             )
+            val certificate = certificateBuilder(printRequests = listOf(printRequest))
+            val status = Status.VALIDATED_BY_PRINT_PROVIDER
 
             // When
-            certificate.prePersist()
+            certificate.addStatus(status)
 
             // Then
-            assertThat(certificate.status).isEqualTo(Status.ASSIGNED_TO_BATCH)
+            assertThat(certificate.status).isEqualTo(status)
+            assertThat(printRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
         }
 
         @Test
-        fun `should determine latest status for Certificate with one Print Request with multiple statuses`() {
+        fun `should add status for Certificate with one Print Request with multiple statuses`() {
             // Given
-            val certificate = certificateBuilder(
-                printRequests = listOf(
-                    printRequestBuilder(
-                        printRequestStatuses = listOf(
-                            printRequestStatusBuilder(
-                                status = Status.PENDING_ASSIGNMENT_TO_BATCH,
-                                eventDateTime = Instant.now().minus(10, ChronoUnit.DAYS)
-                            ),
-                            printRequestStatusBuilder(
-                                status = Status.ASSIGNED_TO_BATCH,
-                                eventDateTime = Instant.now().minus(9, ChronoUnit.DAYS)
-                            ),
-                            printRequestStatusBuilder(
-                                status = Status.SENT_TO_PRINT_PROVIDER,
-                                eventDateTime = Instant.now().minus(8, ChronoUnit.DAYS)
-                            ),
-                        )
-                    )
+            val printRequest = printRequestBuilder(
+                printRequestStatuses = listOf(
+                    printRequestStatusBuilder(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(10, ChronoUnit.DAYS)
+                    ),
+                    printRequestStatusBuilder(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(9, ChronoUnit.DAYS)
+                    ),
+                    printRequestStatusBuilder(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(8, ChronoUnit.DAYS)
+                    ),
                 )
             )
+            val certificate = certificateBuilder(printRequests = listOf(printRequest))
+            val status = Status.VALIDATED_BY_PRINT_PROVIDER
 
             // When
-            certificate.prePersist()
+            certificate.addStatus(status)
 
             // Then
-            assertThat(certificate.status).isEqualTo(Status.SENT_TO_PRINT_PROVIDER)
+            assertThat(certificate.status).isEqualTo(status)
+            assertThat(printRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
         }
 
         @Test
-        fun `should determine latest status for Certificate with multiple Print Requests with multiple statuses`() {
+        fun `should add status for Certificate with multiple Print Requests with multiple statuses`() {
             // Given
             val firstPrintRequest = printRequestBuilder(
                 requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
@@ -170,12 +171,14 @@ internal class CertificateTest {
                 )
             )
             val certificate = certificateBuilder(printRequests = listOf(firstPrintRequest, secondPrintRequest))
+            val status = Status.VALIDATED_BY_PRINT_PROVIDER
 
             // When
-            certificate.prePersist()
+            certificate.addStatus(status)
 
             // Then
-            assertThat(certificate.status).isEqualTo(Status.DISPATCHED)
+            assertThat(certificate.status).isEqualTo(status)
+            assertThat(secondPrintRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/CertificateMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/CertificateMapperTest.kt
@@ -128,7 +128,8 @@ class CertificateMapperTest {
                 gssCode = gssCode,
                 issuingAuthority = localAuthority.name,
                 issueDate = LocalDate.now(),
-                printRequests = mutableListOf(printRequest)
+                printRequests = mutableListOf(printRequest),
+                status = Status.PENDING_ASSIGNMENT_TO_BATCH,
             )
         }
 
@@ -136,9 +137,7 @@ class CertificateMapperTest {
         val actual = mapper.toCertificate(message, ero, localAuthority.name)
 
         // Then
-        assertThat(actual).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected)
-        assertThat(actual.status).isNull()
-        assertThat(actual.id).isNull()
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
         verify(sourceTypeMapper).toSourceTypeEntity(SourceTypeModel.VOTER_MINUS_CARD)
         verify(idFactory).vacNumber()
         verify(printRequestMapper).toPrintRequest(message, ero)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/CertificateToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/CertificateToPrintRequestMapperTest.kt
@@ -116,8 +116,8 @@ class CertificateToPrintRequestMapperTest {
         val expected = uk.gov.dluhc.printapi.printprovider.models.PrintRequest()
         expected.requestId = requestId
         expected.issuingAuthorityEn = eroEnglish.name
-        expected.issueDate = LocalDate.parse("2022-10-21")
-        expected.suggestedExpiryDate = LocalDate.parse("2032-10-21")
+        expected.issueDate = issueDate
+        expected.suggestedExpiryDate = suggestedExpiryDate
         expected.requestDateTime = requestDateTime.atOffset(UTC)
         expected.cardFirstname = firstName
         expected.cardMiddleNames = middleNames

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/InstantMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/mapper/InstantMapperTest.kt
@@ -72,6 +72,18 @@ class InstantMapperTest {
     inner class FromInstantToOffsetDateTime {
 
         @Test
+        fun `should convert null`() {
+            // Given
+            val instant = null
+
+            // When
+            val actual = instantMapper.toOffsetDateTime(instant)
+
+            // Then
+            assertThat(actual).isNull()
+        }
+
+        @Test
         fun `should convert Instant to UTC OffsetDateTime`() {
             // Given
             val instant = Instant.now()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
@@ -121,7 +121,7 @@ internal class CertificateRepositoryTest : IntegrationTest() {
         val expected = certificateRepository.save(certificate)
 
         // When
-        val actual = certificateRepository.getByPrintRequestsRequestIdIs(requestId)
+        val actual = certificateRepository.getByPrintRequestsRequestId(requestId)
 
         // Given
         assertCertificateRecursiveEqual(actual, expected)
@@ -139,7 +139,7 @@ internal class CertificateRepositoryTest : IntegrationTest() {
         val expected = certificateRepository.save(certificate)
 
         // When
-        val actual = certificateRepository.findByStatusAndPrintRequestsBatchIdIs(status, batchId)
+        val actual = certificateRepository.findByStatusAndPrintRequestsBatchId(status, batchId)
 
         // Given
         assertThat(actual).hasSize(1)
@@ -158,7 +158,7 @@ internal class CertificateRepositoryTest : IntegrationTest() {
         val expected = certificateRepository.save(certificate)
 
         // When
-        val actual = certificateRepository.findByStatusIs(status)
+        val actual = certificateRepository.findByStatus(status)
 
         // Given
         assertThat(actual).hasSize(1)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
@@ -166,24 +166,6 @@ internal class CertificateRepositoryTest : IntegrationTest() {
         assertCertificateRecursiveEqual(actual[0], expected)
     }
 
-    // @Test
-    // fun `should batch update certificates`() {
-    //     // Given
-    //     val status = aValidCertificateStatus()
-    //     val certificate = certificateBuilder(
-    //         status = status,
-    //     )
-    //     val expected = certificateRepository.save(certificate)
-    //
-    //     // When
-    //     val actual = certificateRepository.saveAll(mutableListOf(certificate))
-    //
-    //     // Given
-    //     assertThat(actual).hasSize(1)
-    //     assertThat(actual[0].status).isEqualTo(status)
-    //     assertCertificateRecursiveEqual(actual[0], expected)
-    // }
-
     private fun assertCertificateRecursiveEqual(actual: Certificate, expected: Certificate) {
         val offsetEqualToRoundedSeconds: BiPredicate<OffsetDateTime, OffsetDateTime> =
             BiPredicate<OffsetDateTime, OffsetDateTime> { a, b -> withinSecond(a.toEpochSecond(), b.toEpochSecond()) }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rds/repository/CertificateRepositoryTest.kt
@@ -14,6 +14,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidAddressPostcode
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidAddressStreet
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReceivedDateTime
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateFormat
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateLanguage
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateStatus
@@ -37,6 +38,8 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacVersion
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidWebsite
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestBuilder
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
 import java.time.Instant
 import java.time.OffsetDateTime
@@ -105,16 +108,91 @@ internal class CertificateRepositoryTest : IntegrationTest() {
         val actual = certificateRepository.findById(expected.id!!)
 
         // Then
+        assertThat(actual).isPresent
+        assertCertificateRecursiveEqual(actual.get(), expected)
+        assertThat(actual.get().status).isEqualTo(printRequestStatus.status)
+    }
+
+    @Test
+    fun `should get by requestId given one exists`() {
+        // Given
+        val requestId = aValidRequestId()
+        val certificate = certificateBuilder(printRequests = listOf(printRequestBuilder(requestId = requestId)))
+        val expected = certificateRepository.save(certificate)
+
+        // When
+        val actual = certificateRepository.getByPrintRequestsRequestIdIs(requestId)
+
+        // Given
+        assertCertificateRecursiveEqual(actual, expected)
+    }
+
+    @Test
+    fun `should get by status and batchId`() {
+        // Given
+        val batchId = aValidBatchId()
+        val status = aValidCertificateStatus()
+        val certificate = certificateBuilder(
+            status = status,
+            printRequests = listOf(printRequestBuilder(batchId = batchId))
+        )
+        val expected = certificateRepository.save(certificate)
+
+        // When
+        val actual = certificateRepository.findByStatusAndPrintRequestsBatchIdIs(status, batchId)
+
+        // Given
+        assertThat(actual).hasSize(1)
+        assertThat(actual[0].status).isEqualTo(status)
+        assertThat(actual[0].printRequests[0].batchId).isEqualTo(batchId)
+        assertCertificateRecursiveEqual(actual[0], expected)
+    }
+
+    @Test
+    fun `should get by status`() {
+        // Given
+        val status = aValidCertificateStatus()
+        val certificate = certificateBuilder(
+            status = status,
+        )
+        val expected = certificateRepository.save(certificate)
+
+        // When
+        val actual = certificateRepository.findByStatusIs(status)
+
+        // Given
+        assertThat(actual).hasSize(1)
+        assertThat(actual[0].status).isEqualTo(status)
+        assertCertificateRecursiveEqual(actual[0], expected)
+    }
+
+    // @Test
+    // fun `should batch update certificates`() {
+    //     // Given
+    //     val status = aValidCertificateStatus()
+    //     val certificate = certificateBuilder(
+    //         status = status,
+    //     )
+    //     val expected = certificateRepository.save(certificate)
+    //
+    //     // When
+    //     val actual = certificateRepository.saveAll(mutableListOf(certificate))
+    //
+    //     // Given
+    //     assertThat(actual).hasSize(1)
+    //     assertThat(actual[0].status).isEqualTo(status)
+    //     assertCertificateRecursiveEqual(actual[0], expected)
+    // }
+
+    private fun assertCertificateRecursiveEqual(actual: Certificate, expected: Certificate) {
         val offsetEqualToRoundedSeconds: BiPredicate<OffsetDateTime, OffsetDateTime> =
             BiPredicate<OffsetDateTime, OffsetDateTime> { a, b -> withinSecond(a.toEpochSecond(), b.toEpochSecond()) }
         val instantEqualToRoundedSeconds: BiPredicate<Instant, Instant> =
             BiPredicate<Instant, Instant> { a, b -> withinSecond(a.epochSecond, b.epochSecond) }
-        assertThat(actual).isPresent
-        assertThat(actual.get()).usingRecursiveComparison()
+        assertThat(actual).usingRecursiveComparison()
             .withEqualsForType(offsetEqualToRoundedSeconds, OffsetDateTime::class.java)
             .withEqualsForType(instantEqualToRoundedSeconds, Instant::class.java)
             .isEqualTo(expected)
-        assertThat(actual.get().status).isEqualTo(printRequestStatus.status)
     }
 
     fun withinSecond(actual: Long, epochSeconds: Long): Boolean {

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
@@ -15,11 +15,17 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.database.entity.PrintDetails
 import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.database.entity.Status.PENDING_ASSIGNMENT_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestBuilder
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestStatusBuilder
 
 @ExtendWith(MockitoExtension::class)
 class PrintRequestsServiceTest {
@@ -31,6 +37,9 @@ class PrintRequestsServiceTest {
     private lateinit var idFactory: IdFactory
 
     @Mock
+    private lateinit var certificateRepository: CertificateRepository
+
+    @Mock
     private lateinit var printDetailsRepository: PrintDetailsRepository
 
     @Mock
@@ -39,31 +48,44 @@ class PrintRequestsServiceTest {
     @Captor
     private lateinit var savedRecordArgumentCaptor: ArgumentCaptor<PrintDetails>
 
+    @Captor
+    private lateinit var savedCertificateArgumentCaptor: ArgumentCaptor<Certificate>
+
     @Test
     fun `should batch multiple print requests, save and submit to queue`() {
         // Given
         val batchSize = 5
         val numOfRequests = 12
         val items = (1..numOfRequests).map { buildPrintDetails() }
+        val certificates = (1..numOfRequests).map { certificateBuilder(status = PENDING_ASSIGNMENT_TO_BATCH) }
 
         val batchId1 = aValidBatchId()
         val batchId2 = aValidBatchId()
         val batchId3 = aValidBatchId()
+        val batchId4 = aValidBatchId()
+        val batchId5 = aValidBatchId()
+        val batchId6 = aValidBatchId()
 
-        given(printDetailsRepository.getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
-        given(idFactory.batchId()).willReturn(batchId1, batchId2, batchId3)
+        given(printDetailsRepository.getAllByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
+        given(certificateRepository.findByStatusIs(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
+        given(idFactory.batchId()).willReturn(batchId1, batchId2, batchId3, batchId4, batchId5, batchId6)
 
         // When
         printRequestsService.processPrintRequests(batchSize)
 
         // Then
-        verify(printDetailsRepository).getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
-        verify(idFactory, times(3)).batchId()
+        verify(printDetailsRepository).getAllByStatus(PENDING_ASSIGNMENT_TO_BATCH)
+        verify(certificateRepository).findByStatusIs(PENDING_ASSIGNMENT_TO_BATCH)
+        verify(idFactory, times(3 * 2)).batchId()
         verify(printDetailsRepository, times(12)).save(any())
-        verify(processPrintRequestQueue, times(3)).submit(any())
+        verify(certificateRepository, times(12)).save(any())
+        verify(processPrintRequestQueue, times(3 * 2)).submit(any())
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId1))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId2))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId3))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId4))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId5))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId6))
     }
 
     @Test
@@ -73,10 +95,19 @@ class PrintRequestsServiceTest {
 
         val aPrintDetailsRecord = buildPrintDetails(
             batchId = null,
-            status = Status.PENDING_ASSIGNMENT_TO_BATCH
+            status = PENDING_ASSIGNMENT_TO_BATCH
         )
         val items = listOf(aPrintDetailsRecord)
-        given(printDetailsRepository.getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
+        given(printDetailsRepository.getAllByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
+
+        val printRequests = listOf(
+            printRequestBuilder(
+                printRequestStatuses = listOf(printRequestStatusBuilder(status = PENDING_ASSIGNMENT_TO_BATCH)),
+                batchId = null
+            )
+        )
+        val certificates = listOf(certificateBuilder(printRequests = printRequests))
+        given(certificateRepository.findByStatusIs(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
 
         val batchId = aValidBatchId()
         given(idFactory.batchId()).willReturn(batchId)
@@ -86,15 +117,22 @@ class PrintRequestsServiceTest {
         printRequestsService.processPrintRequests(batchSize)
 
         // Then
-        verify(printDetailsRepository).getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
-        verify(idFactory).batchId()
-        verify(processPrintRequestQueue).submit(expectedMessage)
+        verify(printDetailsRepository).getAllByStatus(PENDING_ASSIGNMENT_TO_BATCH)
+        verify(certificateRepository).findByStatusIs(PENDING_ASSIGNMENT_TO_BATCH)
+        verify(idFactory, times(2)).batchId()
+        verify(processPrintRequestQueue, times(2)).submit(expectedMessage)
 
         verify(printDetailsRepository).save(capture(savedRecordArgumentCaptor))
         val savedPrintDetails = savedRecordArgumentCaptor.value!!
         assertThat(savedPrintDetails.printRequestStatuses!!.sortedBy { it.eventDateTime }.map { it.status })
-            .containsExactly(Status.PENDING_ASSIGNMENT_TO_BATCH, Status.ASSIGNED_TO_BATCH)
+            .containsExactly(PENDING_ASSIGNMENT_TO_BATCH, Status.ASSIGNED_TO_BATCH)
         assertThat(savedPrintDetails.status).isEqualTo(Status.ASSIGNED_TO_BATCH)
+
+        verify(certificateRepository).save(capture(savedCertificateArgumentCaptor))
+        val savedCertificates = savedCertificateArgumentCaptor.value!!
+        assertThat(savedCertificates.getCurrentPrintRequest().statusHistory.sortedBy { it.eventDateTime }.map { it.status })
+            .containsExactly(PENDING_ASSIGNMENT_TO_BATCH, Status.ASSIGNED_TO_BATCH)
+        assertThat(savedCertificates.status).isEqualTo(Status.ASSIGNED_TO_BATCH)
     }
 
     @Test
@@ -103,7 +141,7 @@ class PrintRequestsServiceTest {
         val batchSize = 10
         val numOfRequests = 23
         val items = (1..numOfRequests).map { buildPrintDetails() }
-        given(printDetailsRepository.getAllByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
+        given(printDetailsRepository.getAllByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(items)
         given(idFactory.batchId()).willReturn(aValidBatchId(), aValidBatchId(), aValidBatchId())
 
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintServiceTest.kt
@@ -11,9 +11,12 @@ import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.client.ElectoralRegistrationOfficeManagementApiClient
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
 import uk.gov.dluhc.printapi.mapper.PrintDetailsMapper
+import uk.gov.dluhc.printapi.rds.mapper.CertificateMapper
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroManagementApiEroDto
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintDetails
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildSendApplicationToPrintMessage
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
 
 @ExtendWith(MockitoExtension::class)
 class PrintServiceTest {
@@ -29,8 +32,14 @@ class PrintServiceTest {
     @Mock
     private lateinit var printDetailsRepository: PrintDetailsRepository
 
+    @Mock
+    private lateinit var certificateMapper: CertificateMapper
+
+    @Mock
+    private lateinit var certificateRepository: CertificateRepository
+
     @Test
-    fun `should save send application to print message`() {
+    fun `should save send application to DynamoDB print message`() {
         // Given
         val ero = buildEroManagementApiEroDto()
         val localAuthority = ero.localAuthorities[1]
@@ -46,5 +55,24 @@ class PrintServiceTest {
         verify(eroClient).getElectoralRegistrationOffice(message.gssCode!!)
         verify(printDetailsMapper).toPrintDetails(message, ero, localAuthority.name)
         verify(printDetailsRepository).save(printDetails)
+    }
+
+    @Test
+    fun `should save send application to certificate`() {
+        // Given
+        val ero = buildEroManagementApiEroDto()
+        val localAuthority = ero.localAuthorities[1]
+        val message = buildSendApplicationToPrintMessage(gssCode = localAuthority.gssCode)
+        val certificate = certificateBuilder()
+        given(eroClient.getElectoralRegistrationOffice(any())).willReturn(ero)
+        given(certificateMapper.toCertificate(any(), any(), any())).willReturn(certificate)
+
+        // When
+        printService.savePrintMessage(message)
+
+        // Then
+        verify(eroClient).getElectoralRegistrationOffice(message.gssCode!!)
+        verify(printDetailsMapper).toPrintDetails(message, ero, localAuthority.name)
+        verify(certificateRepository).save(certificate)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
@@ -53,7 +53,7 @@ internal class ProcessPrintBatchServiceTest {
         val zipFilename = aValidZipFilename()
         val sftpPath = aValidSftpPath()
         given(printDetailsRepository.getAllByStatusAndBatchId(any(), any())).willReturn(printList)
-        given(certificateRepository.findByStatusAndPrintRequestsBatchIdIs(any(), any())).willReturn(certificates)
+        given(certificateRepository.findByStatusAndPrintRequestsBatchId(any(), any())).willReturn(certificates)
         given(printFileDetailsFactory.createFileDetails(any(), any())).willReturn(fileDetails)
         given(printFileDetailsFactory.createFileDetailsFromCertificates(any(), any())).willReturn(fileDetails)
         given(sftpZipInputStreamProvider.createSftpInputStream(any())).willReturn(sftpInputStream)
@@ -65,7 +65,7 @@ internal class ProcessPrintBatchServiceTest {
 
         // Then
         verify(printDetailsRepository).getAllByStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
-        verify(certificateRepository).findByStatusAndPrintRequestsBatchIdIs(ASSIGNED_TO_BATCH, batchId)
+        verify(certificateRepository).findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
         verify(printFileDetailsFactory).createFileDetails(batchId, printList)
         verify(printFileDetailsFactory).createFileDetailsFromCertificates(batchId, certificates)
         verify(sftpZipInputStreamProvider).createSftpInputStream(fileDetails)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
@@ -10,17 +10,22 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.PrintDetailsRepository
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidInputStream
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSftpPath
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidZipFilename
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.aPrintDetailsList
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aFileDetails
 
 @ExtendWith(MockitoExtension::class)
 internal class ProcessPrintBatchServiceTest {
     @Mock
     private lateinit var printDetailsRepository: PrintDetailsRepository
+
+    @Mock
+    private lateinit var certificateRepository: CertificateRepository
 
     @Mock
     private lateinit var printFileDetailsFactory: PrintFileDetailsFactory
@@ -42,12 +47,15 @@ internal class ProcessPrintBatchServiceTest {
         // Given
         val batchId = aValidBatchId()
         val printList = aPrintDetailsList()
+        val certificates = listOf(certificateBuilder())
         val fileDetails = aFileDetails()
         val sftpInputStream = aValidInputStream()
         val zipFilename = aValidZipFilename()
         val sftpPath = aValidSftpPath()
         given(printDetailsRepository.getAllByStatusAndBatchId(any(), any())).willReturn(printList)
+        given(certificateRepository.findByStatusAndPrintRequestsBatchIdIs(any(), any())).willReturn(certificates)
         given(printFileDetailsFactory.createFileDetails(any(), any())).willReturn(fileDetails)
+        given(printFileDetailsFactory.createFileDetailsFromCertificates(any(), any())).willReturn(fileDetails)
         given(sftpZipInputStreamProvider.createSftpInputStream(any())).willReturn(sftpInputStream)
         given(filenameFactory.createZipFilename(any(), any())).willReturn(zipFilename)
         given(sftpService.sendFile(any(), any())).willReturn(sftpPath)
@@ -57,7 +65,9 @@ internal class ProcessPrintBatchServiceTest {
 
         // Then
         verify(printDetailsRepository).getAllByStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
+        verify(certificateRepository).findByStatusAndPrintRequestsBatchIdIs(ASSIGNED_TO_BATCH, batchId)
         verify(printFileDetailsFactory).createFileDetails(batchId, printList)
+        verify(printFileDetailsFactory).createFileDetailsFromCertificates(batchId, certificates)
         verify(sftpZipInputStreamProvider).createSftpInputStream(fileDetails)
         verify(filenameFactory).createZipFilename(batchId, printList.size)
         verify(sftpService).sendFile(sftpInputStream, zipFilename)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateDeliveryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateDeliveryBuilder.kt
@@ -3,11 +3,18 @@ package uk.gov.dluhc.printapi.testsupport.testdata.entity
 import uk.gov.dluhc.printapi.database.entity.Address
 import uk.gov.dluhc.printapi.database.entity.CertificateDelivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
+import uk.gov.dluhc.printapi.database.entity.DeliveryMethod
 import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
 
 fun buildCertificateDelivery(
     addressee: String = faker.name().fullName(),
     address: Address = buildAddress(),
-    deliveryClass: DeliveryClass = DeliveryClass.STANDARD
+    deliveryClass: DeliveryClass = DeliveryClass.STANDARD,
+    deliveryMethod: DeliveryMethod = DeliveryMethod.DELIVERY,
 ) =
-    CertificateDelivery(addressee = addressee, address = address, deliveryClass = deliveryClass)
+    CertificateDelivery(
+        addressee = addressee,
+        address = address,
+        deliveryClass = deliveryClass,
+        deliveryMethod = deliveryMethod
+    )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/PrintDetailsBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/PrintDetailsBuilder.kt
@@ -14,6 +14,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.getRandomGssCode
 import java.time.Instant
@@ -27,6 +28,7 @@ fun buildPrintDetails(
     requestId: String = aValidRequestId(),
     sourceReference: String = aValidSourceReference(),
     applicationReference: String = aValidApplicationReference(),
+    applicationReceivedDateTime: OffsetDateTime = OffsetDateTime.now(),
     vacNumber: String = aValidVacNumber(),
     vacVersion: String = "1",
     sourceType: SourceType = SourceType.VOTER_CARD,
@@ -49,11 +51,13 @@ fun buildPrintDetails(
         PrintRequestStatus(Status.PENDING_ASSIGNMENT_TO_BATCH, OffsetDateTime.now(UTC))
     ),
     batchId: String? = aValidBatchId(),
+    userId: String = aValidUserId()
 ) = PrintDetails(
     id = id,
     requestId = requestId,
     sourceReference = sourceReference,
     applicationReference = applicationReference,
+    applicationReceivedDateTime = applicationReceivedDateTime,
     sourceType = sourceType,
     vacNumber = vacNumber,
     vacVersion = vacVersion,
@@ -73,6 +77,7 @@ fun buildPrintDetails(
     eroWelsh = eroWelsh,
     batchId = batchId,
     printRequestStatuses = printRequestStatuses,
+    userId = userId,
 )
 
 fun buildPrintDetails(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/rds/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/rds/CertificateBuilder.kt
@@ -37,12 +37,15 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacVersion
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidWebsite
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
 import java.time.Instant
+import java.util.UUID
 
 fun certificateBuilder(
+    id: UUID? = UUID.randomUUID(),
     status: Status = aValidCertificateStatus(),
     printRequests: List<PrintRequest> = listOf(printRequestBuilder()),
 ): Certificate {
     val certificate = Certificate(
+        id = id,
         vacNumber = aValidVacNumber(),
         sourceType = aValidSourceType(),
         sourceReference = aValidSourceReference(),


### PR DESCRIPTION
Introduced MySQL alongside the existing DynamoDB for saving a print request to the database and then using that when processing to write printer's request files.  Later the DynamoDB code will be removed once the response processing is updated to use the MySQL database.


Note that the MySQL processing is being added alongside the existing DynamoDB at this stage (response file processing still needs updating - in next PR).  At this stage:

- 1 application is saved in both DynamoDB and MySQL
- Create separate batches for Dynamo and MySQL and raise SQS for all batches
- Processing has 1 listener that skips creating zips for MySQL but updates its status

Next steps:
Update response file processing 
Switch off DynamoDB
