### PR TITLE
EIP1-2386 Process batch responses file with MySQL

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
@@ -116,6 +116,7 @@ class PrintResponseProcessingService(
         }
     }
 
+    @Transactional
     fun processPrintResponse(printResponse: ProcessPrintResponseMessage) {
         val newStatus = statusMapper.toStatusEntityEnum(printResponse.statusStep, printResponse.status)
         processPrintResponseDynamo(printResponse, newStatus)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.printapi.rds.entity.Certificate
 import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import java.time.Clock
 import java.time.OffsetDateTime
+import javax.transaction.Transactional
 
 @Service
 class PrintResponseProcessingService(
@@ -29,6 +30,7 @@ class PrintResponseProcessingService(
     private val processPrintResponseQueue: MessageQueue<ProcessPrintResponseMessage>
 ) {
 
+    @Transactional
     fun processBatchAndPrintResponses(printResponses: PrintResponses) {
         processBatchResponses(printResponses.batchResponses)
         printResponses.printResponses.forEach {
@@ -47,6 +49,7 @@ class PrintResponseProcessingService(
      * dateCreated will be the timestamp the new printRequestStatus is created and eventDateTime will be the timestamp from
      * the print provider's batch response.
      */
+    @Transactional
     fun processBatchResponses(batchResponses: List<BatchResponse>) {
         processBatchResponsesDynamo(batchResponses)
         processBatchResponsesMySql(batchResponses)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -47,7 +47,7 @@ class ProcessPrintBatchService(
         val certificates = certificateRepository.findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
         val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
 
-        val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(dynamoFileContents)
+        val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
         val sftpFilename = filenameFactory.createZipFilename(batchId, printList.size)
         sftpService.sendFile(sftpInputStream, sftpFilename)
         printDetailsRepository.updateItems(updateBatch(printList))


### PR DESCRIPTION
Adds processing of response file using the MySQL database records.

Subsequent PR will remove the Dynamo interactions.