### PR TITLE
EIP1-2386 Refactor to flush database updates before SQS messages are sent.

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileService.kt
@@ -20,7 +20,8 @@ class PrintResponseFileService(
     fun processPrintResponseFile(directory: String, fileName: String) {
         val printResponsesString = sftpService.fetchFileFromOutBoundDirectory(directory, fileName)
         val printResponses = parsePrintResponseContent(printResponsesString)
-        printResponseProcessingService.processBatchAndPrintResponses(printResponses)
+        printResponseProcessingService.processBatchResponses(printResponses.batchResponses)
+        printResponseProcessingService.processPrintResponses(printResponses.printResponses)
         removeFile(directory, fileName)
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
@@ -12,7 +12,7 @@ import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseMessage
 import uk.gov.dluhc.printapi.printprovider.models.BatchResponse
 import uk.gov.dluhc.printapi.printprovider.models.BatchResponse.Status.SUCCESS
-import uk.gov.dluhc.printapi.printprovider.models.PrintResponses
+import uk.gov.dluhc.printapi.printprovider.models.PrintResponse
 import uk.gov.dluhc.printapi.rds.entity.Certificate
 import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import javax.transaction.Transactional
@@ -28,10 +28,8 @@ class PrintResponseProcessingService(
     private val processPrintResponseQueue: MessageQueue<ProcessPrintResponseMessage>
 ) {
 
-    @Transactional
-    fun processBatchAndPrintResponses(printResponses: PrintResponses) {
-        processBatchResponses(printResponses.batchResponses)
-        printResponses.printResponses.forEach {
+    fun processPrintResponses(printResponses: List<PrintResponse>) {
+        printResponses.forEach {
             processPrintResponseQueue.submit(processPrintResponseMessageMapper.toProcessPrintResponseMessage(it))
         }
     }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseFileServiceTest.kt
@@ -51,7 +51,8 @@ internal class PrintResponseFileServiceTest {
         val inOrder = inOrder(sftpService, objectMapper, printResponseProcessingService)
         inOrder.verify(sftpService).fetchFileFromOutBoundDirectory(directory, fileName)
         inOrder.verify(objectMapper).readValue(fileContent, PrintResponses::class.java)
-        inOrder.verify(printResponseProcessingService).processBatchAndPrintResponses(expectedPrintResponses)
+        inOrder.verify(printResponseProcessingService).processBatchResponses(expectedPrintResponses.batchResponses)
+        inOrder.verify(printResponseProcessingService).processPrintResponses(expectedPrintResponses.printResponses)
         inOrder.verify(sftpService).removeFileFromOutBoundDirectory(directory, fileName)
     }
 
@@ -81,7 +82,8 @@ internal class PrintResponseFileServiceTest {
         val inOrder = inOrder(sftpService, objectMapper, printResponseProcessingService)
         inOrder.verify(sftpService).fetchFileFromOutBoundDirectory(directory, fileName)
         inOrder.verify(objectMapper).readValue(fileContent, PrintResponses::class.java)
-        inOrder.verify(printResponseProcessingService).processBatchAndPrintResponses(expectedPrintResponses)
+        inOrder.verify(printResponseProcessingService).processBatchResponses(expectedPrintResponses.batchResponses)
+        inOrder.verify(printResponseProcessingService).processPrintResponses(expectedPrintResponses.printResponses)
         inOrder.verify(sftpService).removeFileFromOutBoundDirectory(directory, fileName)
         assertThat(
             TestLogAppender.hasLog(
@@ -114,7 +116,8 @@ internal class PrintResponseFileServiceTest {
         val inOrder = inOrder(sftpService, objectMapper, printResponseProcessingService)
         inOrder.verify(sftpService).fetchFileFromOutBoundDirectory(directory, fileName)
         inOrder.verify(objectMapper).readValue(fileContent, PrintResponses::class.java)
-        inOrder.verify(printResponseProcessingService).processBatchAndPrintResponses(expectedPrintResponses)
+        inOrder.verify(printResponseProcessingService).processBatchResponses(expectedPrintResponses.batchResponses)
+        inOrder.verify(printResponseProcessingService).processPrintResponses(expectedPrintResponses.printResponses)
         inOrder.verify(sftpService).removeFileFromOutBoundDirectory(directory, fileName)
         assertThat(
             TestLogAppender.hasLogMatchingRegex(


### PR DESCRIPTION
DynamoDB updates were being done inside the method and then SQS messages sent, with MySQL and the `@Transaction` annotation the semantics had changed so SQS messages were sent before the database updates were made.  Refactored for database updates to happen before SQS messages are sent.