### PR TITLE
EIP1-1878 - Logging in scheduled services; adjusted cron times in dev

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/ProcessPrintResponsesBatchJob.kt
@@ -1,12 +1,9 @@
 package uk.gov.dluhc.printapi.jobs
 
-import mu.KotlinLogging
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.service.PrintResponseFileReadinessService
-
-private val logger = KotlinLogging.logger {}
 
 @Component
 class ProcessPrintResponsesBatchJob(
@@ -16,8 +13,6 @@ class ProcessPrintResponsesBatchJob(
     @Scheduled(cron = "\${jobs.process-print-responses.cron}")
     @SchedulerLock(name = "\${jobs.process-print-responses.name}")
     fun pollAndProcessPrintResponses() {
-        logger.info { "Polling for print responses from outbound directory" }
         printResponseFileReadinessService.markAndSubmitPrintResponseFileForProcessing()
-        logger.info { "Completed print response polling job from outbound directory" }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -20,6 +20,7 @@ class PrintRequestsService(
 
     @Transactional
     fun processPrintRequests(batchSize: Int) {
+        logger.info { "Looking for certificate Print Requests to assign to a new batch" }
         batchCertificates(batchSize).forEach { (batchId, batchOfCertificates) ->
             batchOfCertificates.forEach { certificate ->
                 certificateRepository.save(certificate)
@@ -28,6 +29,7 @@ class PrintRequestsService(
             processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
             logger.info { "Batch [$batchId] submitted to queue" }
         }
+        logger.info { "Completed batching certificate Print Requests" }
     }
 
     fun batchCertificates(batchSize: Int): Map<String, List<Certificate>> {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,4 +1,7 @@
 jobs:
   process-print-responses:
     name: "ProcessPrintResponses"
-    cron: "0 */5 * ? * *" # every 5 minutes by default
+    cron: "0 */10 * ? * *" # every 10 minutes
+  batch-print-requests:
+    name: "BatchPrintRequests"
+    cron: "0 */10 * ? * *" # every 10 minutes


### PR DESCRIPTION
This PR changes the cron times in `dev` for both cron jobs to every 10 minutes
Plus removes the logging from the `ProcessPrintResponsesBatchJob` (because the service method that it calls also logs, so this was pure noise)
I've also added logging to the service class that the batch cron job calls so that we can see when it is invoked etc.
