### PR TITLE
EIP1-2386 Persist print request batches before sending SQS messages and reject empty batches

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/EmptyBatchException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/EmptyBatchException.kt
@@ -1,0 +1,9 @@
+package uk.gov.dluhc.printapi.exception
+
+import uk.gov.dluhc.printapi.database.entity.Status
+import java.lang.RuntimeException
+
+data class EmptyBatchException(
+    private val batchId: String,
+    private val status: Status
+) : RuntimeException("No certificates found for batchId = $batchId and status = $status")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -1,0 +1,40 @@
+package uk.gov.dluhc.printapi.service
+
+import mu.KotlinLogging
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
+import javax.transaction.Transactional
+
+private val logger = KotlinLogging.logger { }
+
+@Service
+class CertificateBatchingService(
+    private val idFactory: IdFactory,
+    private val certificateRepository: CertificateRepository
+) {
+
+    @Transactional
+    fun batchPendingCertificates(batchSize: Int): Set<String> {
+        val batches = batchCertificates(batchSize)
+        batches.forEach { (batchId, batchOfCertificates) ->
+            batchOfCertificates.forEach { certificate ->
+                certificateRepository.save(certificate)
+                logger.info { "Certificate with id [${certificate.id}] assigned to batch [$batchId]" }
+            }
+        }
+        return batches.keys
+    }
+
+    fun batchCertificates(batchSize: Int): Map<String, List<Certificate>> {
+        val certificatesPendingAssignment = certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
+        return certificatesPendingAssignment.chunked(batchSize).associate { batchOfCertificates ->
+            val batchId = idFactory.batchId()
+            batchId to batchOfCertificates.onEach {
+                it.getCurrentPrintRequest().batchId = batchId
+                it.addStatus(Status.ASSIGNED_TO_BATCH)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -2,44 +2,26 @@ package uk.gov.dluhc.printapi.service
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Component
-import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
-import uk.gov.dluhc.printapi.rds.entity.Certificate
-import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
-import javax.transaction.Transactional
 
 private val logger = KotlinLogging.logger { }
 
 @Component
 class PrintRequestsService(
-    private val certificateRepository: CertificateRepository,
-    private val idFactory: IdFactory,
     private val processPrintRequestQueue: MessageQueue<ProcessPrintRequestBatchMessage>,
+    private val certificateBatchingService: CertificateBatchingService
 ) {
 
-    @Transactional
     fun processPrintRequests(batchSize: Int) {
         logger.info { "Looking for certificate Print Requests to assign to a new batch" }
-        batchCertificates(batchSize).forEach { (batchId, batchOfCertificates) ->
-            batchOfCertificates.forEach { certificate ->
-                certificateRepository.save(certificate)
-                logger.info { "Certificate with id [${certificate.id}] assigned to batch [$batchId]" }
-            }
-            processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
-            logger.info { "Batch [$batchId] submitted to queue" }
-        }
-        logger.info { "Completed batching certificate Print Requests" }
-    }
 
-    fun batchCertificates(batchSize: Int): Map<String, List<Certificate>> {
-        val certificatesPendingAssignment = certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
-        return certificatesPendingAssignment.chunked(batchSize).associate { batchOfCertificates ->
-            val batchId = idFactory.batchId()
-            batchId to batchOfCertificates.onEach {
-                it.getCurrentPrintRequest().batchId = batchId
-                it.addStatus(Status.ASSIGNED_TO_BATCH)
+        // split into batches and save to database before sending messages to SQS
+        certificateBatchingService.batchPendingCertificates(batchSize)
+            .onEach { batchId ->
+                processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
+                logger.info { "Batch [$batchId] submitted to queue" }
             }
-        }
+        logger.info { "Completed batching certificate Print Requests" }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.capture
+import org.mockito.kotlin.given
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.rds.entity.Certificate
+import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestBuilder
+import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestStatusBuilder
+
+@ExtendWith(MockitoExtension::class)
+internal class CertificateBatchingServiceTest {
+
+    @InjectMocks
+    private lateinit var certificateBatchingService: CertificateBatchingService
+
+    @Mock
+    private lateinit var idFactory: IdFactory
+
+    @Mock
+    private lateinit var certificateRepository: CertificateRepository
+
+    @Captor
+    private lateinit var savedCertificateArgumentCaptor: ArgumentCaptor<Certificate>
+
+    @Test
+    fun `should batch multiple print requests and save each`() {
+        // Given
+        val batchSize = 5
+        val numOfRequests = 12
+        val certificates = (1..numOfRequests).map { certificateBuilder(status = Status.PENDING_ASSIGNMENT_TO_BATCH) }
+
+        val batchId1 = aValidBatchId()
+        val batchId2 = aValidBatchId()
+        val batchId3 = aValidBatchId()
+        given(certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
+        given(idFactory.batchId()).willReturn(batchId1, batchId2, batchId3)
+
+        // When
+        val batchIds = certificateBatchingService.batchPendingCertificates(batchSize)
+
+        // Then
+        verify(certificateRepository).findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
+        verify(idFactory, times(3)).batchId()
+        verify(certificateRepository, times(12)).save(any())
+        assertThat(batchIds).containsExactly(batchId1, batchId2, batchId3)
+    }
+
+    @Test
+    fun `should batch one print request and save`() {
+        // Given
+        val batchSize = 5
+
+        val printRequests = listOf(
+            printRequestBuilder(
+                printRequestStatuses = listOf(printRequestStatusBuilder(status = Status.PENDING_ASSIGNMENT_TO_BATCH)),
+                batchId = null
+            )
+        )
+        val certificates = listOf(certificateBuilder(printRequests = printRequests))
+        given(certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
+
+        val batchId = aValidBatchId()
+        given(idFactory.batchId()).willReturn(batchId)
+
+        // When
+        val batchIds = certificateBatchingService.batchPendingCertificates(batchSize)
+
+        // Then
+        verify(certificateRepository).findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)
+        verify(idFactory).batchId()
+        verify(certificateRepository).save(capture(savedCertificateArgumentCaptor))
+        assertThat(batchIds).containsExactly(batchId)
+        val savedCertificates = savedCertificateArgumentCaptor.value!!
+        assertThat(
+            savedCertificates.getCurrentPrintRequest().statusHistory.sortedBy { it.eventDateTime }
+                .map { it.status }
+        )
+            .containsExactly(Status.PENDING_ASSIGNMENT_TO_BATCH, Status.ASSIGNED_TO_BATCH)
+
+        assertThat(savedCertificates.status).isEqualTo(Status.ASSIGNED_TO_BATCH)
+    }
+
+    @Test
+    fun `should correctly batch print requests`() {
+        // Given
+        val batchSize = 10
+        val numOfRequests = 23
+        val certificates = (1..numOfRequests).map { certificateBuilder() }
+        given(certificateRepository.findByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
+        given(idFactory.batchId()).willReturn(aValidBatchId(), aValidBatchId(), aValidBatchId())
+
+        // When
+        val batches = certificateBatchingService.batchCertificates(batchSize)
+
+        // Then
+        assertThat(batches).hasSize(3)
+        batches.map { (id, items) ->
+            assert(items.all { it.status == Status.ASSIGNED_TO_BATCH })
+            assert(items.all { it.getCurrentPrintRequest().batchId == id })
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.dluhc.printapi.service
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
@@ -1,28 +1,17 @@
 package uk.gov.dluhc.printapi.service
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.ArgumentCaptor
-import org.mockito.Captor
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.capture
 import org.mockito.kotlin.given
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
-import uk.gov.dluhc.printapi.database.entity.Status.PENDING_ASSIGNMENT_TO_BATCH
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
-import uk.gov.dluhc.printapi.rds.entity.Certificate
-import uk.gov.dluhc.printapi.rds.repository.CertificateRepository
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
-import uk.gov.dluhc.printapi.testsupport.testdata.rds.certificateBuilder
-import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestBuilder
-import uk.gov.dluhc.printapi.testsupport.testdata.rds.printRequestStatusBuilder
 
 @ExtendWith(MockitoExtension::class)
 class PrintRequestsServiceTest {
@@ -31,93 +20,29 @@ class PrintRequestsServiceTest {
     private lateinit var printRequestsService: PrintRequestsService
 
     @Mock
-    private lateinit var idFactory: IdFactory
-
-    @Mock
-    private lateinit var certificateRepository: CertificateRepository
+    private lateinit var certificateBatchingService: CertificateBatchingService
 
     @Mock
     private lateinit var processPrintRequestQueue: MessageQueue<ProcessPrintRequestBatchMessage>
 
-    @Captor
-    private lateinit var savedCertificateArgumentCaptor: ArgumentCaptor<Certificate>
-
     @Test
-    fun `should batch multiple print requests, save and submit to queue`() {
+    fun `should process print requests and submit to queue`() {
         // Given
         val batchSize = 5
-        val numOfRequests = 12
-        val certificates = (1..numOfRequests).map { certificateBuilder(status = PENDING_ASSIGNMENT_TO_BATCH) }
-
         val batchId1 = aValidBatchId()
         val batchId2 = aValidBatchId()
         val batchId3 = aValidBatchId()
-        given(certificateRepository.findByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
-        given(idFactory.batchId()).willReturn(batchId1, batchId2, batchId3)
+        val batchIds = setOf(batchId1, batchId2, batchId3)
+        given(certificateBatchingService.batchPendingCertificates(any())).willReturn(batchIds)
 
         // When
         printRequestsService.processPrintRequests(batchSize)
 
         // Then
-        verify(certificateRepository).findByStatus(PENDING_ASSIGNMENT_TO_BATCH)
-        verify(idFactory, times(3)).batchId()
-        verify(certificateRepository, times(12)).save(any())
+        verify(certificateBatchingService).batchPendingCertificates(batchSize)
         verify(processPrintRequestQueue, times(3)).submit(any())
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId1))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId2))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId3))
-    }
-
-    @Test
-    fun `should batch one print request, save and submit to queue`() {
-        // Given
-        val batchSize = 5
-
-        val printRequests = listOf(
-            printRequestBuilder(
-                printRequestStatuses = listOf(printRequestStatusBuilder(status = PENDING_ASSIGNMENT_TO_BATCH)),
-                batchId = null
-            )
-        )
-        val certificates = listOf(certificateBuilder(printRequests = printRequests))
-        given(certificateRepository.findByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
-
-        val batchId = aValidBatchId()
-        given(idFactory.batchId()).willReturn(batchId)
-        val expectedMessage = ProcessPrintRequestBatchMessage(batchId)
-
-        // When
-        printRequestsService.processPrintRequests(batchSize)
-
-        // Then
-        verify(certificateRepository).findByStatus(PENDING_ASSIGNMENT_TO_BATCH)
-        verify(idFactory).batchId()
-        verify(processPrintRequestQueue).submit(expectedMessage)
-
-        verify(certificateRepository).save(capture(savedCertificateArgumentCaptor))
-        val savedCertificates = savedCertificateArgumentCaptor.value!!
-        assertThat(savedCertificates.getCurrentPrintRequest().statusHistory.sortedBy { it.eventDateTime }.map { it.status })
-            .containsExactly(PENDING_ASSIGNMENT_TO_BATCH, ASSIGNED_TO_BATCH)
-        assertThat(savedCertificates.status).isEqualTo(ASSIGNED_TO_BATCH)
-    }
-
-    @Test
-    fun `should correctly batch print requests`() {
-        // Given
-        val batchSize = 10
-        val numOfRequests = 23
-        val certificates = (1..numOfRequests).map { certificateBuilder() }
-        given(certificateRepository.findByStatus(PENDING_ASSIGNMENT_TO_BATCH)).willReturn(certificates)
-        given(idFactory.batchId()).willReturn(aValidBatchId(), aValidBatchId(), aValidBatchId())
-
-        // When
-        val batches = printRequestsService.batchCertificates(batchSize)
-
-        // Then
-        assertThat(batches).hasSize(3)
-        batches.map { (id, items) ->
-            assert(items.all { it.status == ASSIGNED_TO_BATCH })
-            assert(items.all { it.getCurrentPrintRequest().batchId == id })
-        }
     }
 }


### PR DESCRIPTION
Batches need to be saved to database before SQS messages related to the batches are queued.  Attempting to process a print batch containing no certificates should result in an error so SQS message is retried in a race-condition.