### PR TITLE
[DRAFT] POC for adding correlation id to logging

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
@@ -1,10 +1,13 @@
 package uk.gov.dluhc.printapi.config
 
 import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.aspectj.lang.annotation.Before
 import org.slf4j.MDC
 import org.springframework.messaging.Message
+import org.springframework.messaging.support.GenericMessage
 import org.springframework.stereotype.Component
 import org.springframework.web.servlet.HandlerInterceptor
 import java.lang.Exception
@@ -51,7 +54,7 @@ class CorrelationIdMdcInterceptor : HandlerInterceptor {
 class CorrelationIdMdcMessageListenerAspect {
 
     /**
-     * Pointcut for inbound [Message]s (ie. SQS Message's being directed to a listener class) that sets the correlation ID
+     * Before Advice for inbound [Message]s (ie. SQS Message's being directed to a listener class) that sets the correlation ID
      * MDC variable to the value found in the Message header `x-correlation-id` if set, or a new value.
      * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
      */
@@ -62,27 +65,38 @@ class CorrelationIdMdcMessageListenerAspect {
     }
 
     /**
-     * Pointcut for outbound [Message]s (ie. SQS Message's being sent) that sets the correlation ID
-     * header on the [Message] to either the existing MDC variable or a new value if not set in MDC.
+     * Around Advice for outbound [Message]s (ie. SQS Message's being sent) that sets the correlation ID
+     * header on a new [Message] to either the existing MDC variable or a new value if not set in MDC.
      * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+     *
+     * The reason this Advice is an Around is because [Message] and it's headers are immutable, so we cannot add
+     * the correlation ID header on the passed [Message]. Therefore we need to create new message with the same
+     * payload and a modified collection of headers.
      */
-    @Before("execution(* org.springframework.messaging.support.AbstractMessageChannel.send(..))")
-    // @Before("execution(* io.awspring.cloud.messaging.core.QueueMessageChannel.send(..))")
-    fun beforeSendMessage(joinPoint: JoinPoint) {
-        val message = joinPoint.args[0] as Message<*>?
-        message?.headers?.put(CORRELATION_ID_HEADER, getCurrentCorrelationId())
+    @Around("execution(* io.awspring.cloud.messaging.core.support.AbstractMessageChannelMessagingSendingTemplate.send(..))")
+    fun aroundSendMessage(proceedingJoinPoint: ProceedingJoinPoint): Any? {
+        val queue = proceedingJoinPoint.args[0]
+        val originalMessage = proceedingJoinPoint.args[1] as Message<*>
+        val newMessage = GenericMessage(
+            originalMessage.payload,
+            originalMessage.headers.toMutableMap().plus(CORRELATION_ID_HEADER to getCurrentCorrelationId())
+        )
+        return proceedingJoinPoint.proceed(arrayOf(queue, newMessage))
     }
 }
 
 /**
  * AOP Aspect for Scheduled tasks (ie. cron tasks) that sets the correlation ID MDC variable.
- * Due to the invocation semantics of a Scheduled task it does not make sense to pass a correlation ID from another
- * system or process into it.
  */
 @Aspect
 @Component
 class CorrelationIdMdcScheduledAspect {
 
+    /**
+     * Before Advice for Scheduled tasks (ie. cron tasks) that sets the correlation ID MDC variable to a new value.
+     * Due to the invocation semantics of a Scheduled task it does not make sense to pass a correlation ID from another
+     * system or process into it.
+     */
     @Before("@annotation(org.springframework.scheduling.annotation.Scheduled)")
     fun before(joinPoint: JoinPoint) {
         MDC.put(CORRELATION_ID, generateCorrelationId())
@@ -92,5 +106,5 @@ class CorrelationIdMdcScheduledAspect {
 private fun generateCorrelationId(): String =
     UUID.randomUUID().toString().replace("-", "")
 
-private fun getCurrentCorrelationId() : String =
+private fun getCurrentCorrelationId(): String =
     MDC.get(CORRELATION_ID_HEADER) ?: generateCorrelationId()

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
@@ -1,0 +1,96 @@
+package uk.gov.dluhc.printapi.config
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.slf4j.MDC
+import org.springframework.messaging.Message
+import org.springframework.stereotype.Component
+import org.springframework.web.servlet.HandlerInterceptor
+import java.lang.Exception
+import java.util.UUID
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+/**
+ * MVC Interceptor and AOP beans that set the correlation ID MDC variable for inclusion in all log statements.
+ */
+
+const val CORRELATION_ID = "correlationId"
+const val CORRELATION_ID_HEADER = "x-correlation-id"
+
+/**
+ * MVC Interceptor that sets the correlation ID MDC variable of either a new value, or the value found in the
+ * HTTP header `x-correlation-id` if set. This allows for passing and logging a consistent correlation ID between
+ * disparate systems or processes.
+ */
+@Component
+class CorrelationIdMdcInterceptor : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        MDC.put(CORRELATION_ID, request.getHeader(CORRELATION_ID_HEADER) ?: generateCorrelationId())
+        return true
+    }
+
+    override fun afterCompletion(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        ex: Exception?
+    ) {
+        MDC.remove(CORRELATION_ID)
+    }
+}
+
+/**
+ * AOP Aspect to read and set the correlation ID on inbound (received) and outbound SQS [Message]s respectively.
+ * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+ */
+@Aspect
+@Component
+class CorrelationIdMdcMessageListenerAspect {
+
+    /**
+     * Pointcut for inbound [Message]s (ie. SQS Message's being directed to a listener class) that sets the correlation ID
+     * MDC variable to the value found in the Message header `x-correlation-id` if set, or a new value.
+     * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+     */
+    @Before("execution(* org.springframework.messaging.handler.invocation.AbstractMethodMessageHandler.handleMessage(..))")
+    fun beforeHandleMessage(joinPoint: JoinPoint) {
+        val message = joinPoint.args[0] as Message<*>?
+        MDC.put(CORRELATION_ID, message?.headers?.get(CORRELATION_ID_HEADER)?.toString() ?: generateCorrelationId())
+    }
+
+    /**
+     * Pointcut for outbound [Message]s (ie. SQS Message's being sent) that sets the correlation ID
+     * header on the [Message] to either the existing MDC variable or a new value if not set in MDC.
+     * This allows for passing and logging a consistent correlation ID between disparate systems or processes.
+     */
+    @Before("execution(* org.springframework.messaging.support.AbstractMessageChannel.send(..))")
+    // @Before("execution(* io.awspring.cloud.messaging.core.QueueMessageChannel.send(..))")
+    fun beforeSendMessage(joinPoint: JoinPoint) {
+        val message = joinPoint.args[0] as Message<*>?
+        message?.headers?.put(CORRELATION_ID_HEADER, getCurrentCorrelationId())
+    }
+}
+
+/**
+ * AOP Aspect for Scheduled tasks (ie. cron tasks) that sets the correlation ID MDC variable.
+ * Due to the invocation semantics of a Scheduled task it does not make sense to pass a correlation ID from another
+ * system or process into it.
+ */
+@Aspect
+@Component
+class CorrelationIdMdcScheduledAspect {
+
+    @Before("@annotation(org.springframework.scheduling.annotation.Scheduled)")
+    fun before(joinPoint: JoinPoint) {
+        MDC.put(CORRELATION_ID, generateCorrelationId())
+    }
+}
+
+private fun generateCorrelationId(): String =
+    UUID.randomUUID().toString().replace("-", "")
+
+private fun getCurrentCorrelationId() : String =
+    MDC.get(CORRELATION_ID_HEADER) ?: generateCorrelationId()

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/WebMvcConfig.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/WebMvcConfig.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.printapi.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebMvcConfig(private val correlationIdMdcInterceptor: CorrelationIdMdcInterceptor) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(correlationIdMdcInterceptor)
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/MessageQueue.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/MessageQueue.kt
@@ -1,12 +1,24 @@
 package uk.gov.dluhc.printapi.messaging
 
 import io.awspring.cloud.messaging.core.QueueMessagingTemplate
+import org.springframework.messaging.Message
+import org.springframework.messaging.core.MessagePostProcessor
 
 class MessageQueue<T : Any>(
     private val queueName: String,
-    private val queueMessagingTemplate: QueueMessagingTemplate
+    private val queueMessagingTemplate: QueueMessagingTemplate,
 ) {
 
-    fun submit(message: T) =
-        queueMessagingTemplate.convertAndSend(queueName, message)
+    fun submit(payload: T) =
+        queueMessagingTemplate.send(queueName, queueMessagingTemplate.convertToMessage(payload))
+
+    /**
+     * Extension function on [QueueMessagingTemplate] to allow invocation of it's protected `doConvert` method to
+     * get convert the payload into a [Message] with all the default headers etc.
+     */
+    private fun QueueMessagingTemplate.convertToMessage(payload: T): Message<T> =
+        javaClass.getDeclaredMethod("doConvert", Any::class.java, Map::class.java, MessagePostProcessor::class.java).let {
+            it.isAccessible = true
+            it.invoke(this, payload, null, null) as Message<T>
+        }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,8 @@ thread-pool:
     max-size: 5
 
 logging:
+  pattern:
+    level: "%X{correlationId}%5p"
   level:
     com:
       jcraft:

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,13 +1,7 @@
 <configuration>
     <include resource="org/springframework/boot/logging/logback/base.xml" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
-        </encoder>
-    </appender>
     <appender name="testLogAppender" class="uk.gov.dluhc.printapi.testsupport.TestLogAppender"/>
     <root level="info">
-        <appender-ref ref="STDOUT"/>
         <appender-ref ref="testLogAppender"/>
     </root>
 


### PR DESCRIPTION
Draft PR for discussion

This is a POC that aims to add a correlation ID to all log messages using an MCD variable, Interceptors and some AOP

I'm trying to think about this in a generic way so that it could be added to all of our apps, and it would "just work" .... 🤔 

So, my thinking is that there are 3 "starting" points for our apps:
* an incoming HTTP request ie. a REST API
* a consumed (received) SQS message
* a scheduled task (`@Scheduler`)

for each of these 3 "starting" points we can use an Interceptor (http requests) or AOP (SQS and scheduled tasks) to generate a correlation ID and add it to MDC. We can then include the MDC variable in the log pattern. Simple stuff

But, we also want to be able to pass around / maintain a correlation ID across threads, and even across apps.

So, the Interceptor (http requests) and AOP (SQS) need to look at a header on the inbound request (HTTP request or SQS Message), and if there is a header `x-correlation-id` then set that value in the MDC, else set a new correlation ID in the MDC
We don't need to do this on the AOP aspect for scheduled tasks because nothing "calls" it - there is nothing upstream of it that would have set a correlation ID that we need to maintain

Next we need some way of passing the existing correlation ID from MDC into a header `x-correlation-id` when making outbound HTTP requests or producing (sending) SQS messages.
For SQS we can do that with more AOP (though I haven't actually got that working yet!)
For outbound HTTP requests I imagine we'd use another interceptor (though I've not written that yet)

Thats the rough idea anyway;
Thoughts?

