### PR TITLE
EIP1-2471 - rename print_request certificate_format column

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
@@ -65,7 +65,7 @@ class PrintRequest(
 
     @field:NotNull
     @Enumerated(EnumType.STRING)
-    var certificateFormat: CertificateFormat? = null,
+    var supportingInformationFormat: SupportingInformationFormat? = null,
 
     @field:NotNull
     @field:Size(max = 255)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SupportingInformationFormat.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SupportingInformationFormat.kt
@@ -1,5 +1,5 @@
 package uk.gov.dluhc.printapi.database.entity
 
-enum class CertificateFormat {
+enum class SupportingInformationFormat {
     STANDARD
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
@@ -24,7 +24,7 @@ abstract class PrintRequestMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "vacVersion", constant = "A")
-    @Mapping(target = "certificateFormat", constant = "STANDARD")
+    @Mapping(target = "supportingInformationFormat", constant = "STANDARD")
     @Mapping(target = "requestId", expression = "java( idFactory.requestId() )")
     @Mapping(source = "message.photoLocation", target = "photoLocationArn")
     @Mapping(target = "statusHistory", expression = "java( initialStatus() )")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -12,4 +12,5 @@
     <include relativeToChangelogFile="true" file="ddl/0004_change_shedlock_table_name.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0005_add_index_gss_code_source_type_source_reference.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0006_add_index_event_date_time_status_to_print_request_status.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0007_EIP1-2781_alter_print_request.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0007_EIP1-2781_alter_print_request.xml
+++ b/src/main/resources/db/changelog/ddl/0007_EIP1-2781_alter_print_request.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="nathan.russell@valtech.com" id="0007_EIP1-2781_alter_print_request - rename certificateFormat column" context="ddl">
+
+        <renameColumn
+            tableName="print_request"
+            oldColumnName="certificate_format"
+            newColumnName="supporting_information_format"
+            columnDataType="varchar(20)"
+        />
+
+        <rollback>
+            <renameColumn
+                tableName="print_request"
+                oldColumnName="supporting_information_format"
+                newColumnName="certificate_format"
+                columnDataType="varchar(20)"
+            />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
@@ -97,7 +97,7 @@ internal class CertificateRepositoryIntegrationTest : IntegrationTest() {
                 firstName = aValidFirstName(),
                 surname = aValidSurname(),
                 certificateLanguage = aValidCertificateLanguage(),
-                certificateFormat = aValidCertificateFormat(),
+                supportingInformationFormat = aValidCertificateFormat(),
                 photoLocationArn = aPhotoArn(),
                 delivery = delivery,
                 eroEnglish = eroEnglish,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.database.entity.CertificateFormat
 import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
 import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
@@ -66,7 +66,7 @@ class CertificateToPrintRequestMapperTest {
         val middleNames = "Anthony Barry"
         val surname = "Doe"
         val certificateLanguage = CertificateLanguage.EN
-        val certificateFormat = CertificateFormat.STANDARD
+        val supportingInformationFormat = SupportingInformationFormat.STANDARD
         val delivery = buildDelivery()
         val gssCode: String = getRandomGssCode()
         val issuingAuthority: String = aValidLocalAuthorityName()
@@ -89,7 +89,7 @@ class CertificateToPrintRequestMapperTest {
             middleNames = middleNames,
             surname = surname,
             certificateLanguage = certificateLanguage,
-            certificateFormat = certificateFormat,
+            supportingInformationFormat = supportingInformationFormat,
             photoLocationArn = photoLocation,
             delivery = delivery,
             eroEnglish = eroEnglish,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.dluhc.printapi.database.entity.Address
-import uk.gov.dluhc.printapi.database.entity.CertificateFormat
 import uk.gov.dluhc.printapi.database.entity.Delivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
 import uk.gov.dluhc.printapi.database.entity.DeliveryMethod
@@ -20,6 +19,7 @@ import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
 import uk.gov.dluhc.printapi.messaging.models.CertificateLanguage
 import uk.gov.dluhc.printapi.service.IdFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
@@ -103,7 +103,7 @@ class PrintRequestMapperTest {
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = certificateLanguageEntity,
-                certificateFormat = CertificateFormat.STANDARD,
+                supportingInformationFormat = SupportingInformationFormat.STANDARD,
                 photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.database.entity.Address
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.database.entity.CertificateFormat
 import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
 import uk.gov.dluhc.printapi.database.entity.Delivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
@@ -17,6 +16,7 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
 import uk.gov.dluhc.printapi.testsupport.TestLogAppender.Companion.hasLog
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
@@ -75,7 +75,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = CertificateLanguage.EN,
-                certificateFormat = CertificateFormat.STANDARD,
+                supportingInformationFormat = SupportingInformationFormat.STANDARD,
                 photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/TestFixedDataFactory.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/TestFixedDataFactory.kt
@@ -1,11 +1,11 @@
 package uk.gov.dluhc.printapi.testsupport.testdata
 
-import uk.gov.dluhc.printapi.database.entity.CertificateFormat
 import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
 import uk.gov.dluhc.printapi.database.entity.DeliveryMethod
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
 
 fun aValidSourceType() = SourceType.VOTER_CARD
 
@@ -15,7 +15,7 @@ fun aDifferentValidCertificateStatus() = Status.DISPATCHED
 
 fun aValidCertificateLanguage() = CertificateLanguage.EN
 
-fun aValidCertificateFormat() = CertificateFormat.STANDARD
+fun aValidCertificateFormat() = SupportingInformationFormat.STANDARD
 
 fun aValidDeliveryClass(): DeliveryClass = DeliveryClass.STANDARD
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -86,7 +86,7 @@ fun buildPrintRequest(
         firstName = aValidFirstName(),
         surname = aValidSurname(),
         certificateLanguage = aValidCertificateLanguage(),
-        certificateFormat = aValidCertificateFormat(),
+        supportingInformationFormat = aValidCertificateFormat(),
         photoLocationArn = photoLocationArn,
         delivery = delivery,
         eroEnglish = eroEnglish,


### PR DESCRIPTION
This PR renames the `print_request` field `certificate_format` to `supporting_information_format`; and associated entity property name and enum class.
