### PR TITLE
EIP1-2471 - Update Print Provider schema `certificateFormat` enum

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
@@ -23,6 +23,8 @@ abstract class CertificateToPrintRequestMapper {
     @Mapping(source = "printRequest.delivery.address.locality", target = "deliveryLocality")
     @Mapping(source = "printRequest.delivery.address.area", target = "deliveryArea")
     @Mapping(source = "printRequest.delivery.address.postcode", target = "deliveryPostcode")
+    @Mapping(expression = "java( uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateLanguage.EN )", target = "certificateLanguage")
+    @Mapping(expression = "java( uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateFormat.STANDARD )", target = "certificateFormat")
     @Mapping(source = "printRequest.delivery.deliveryClass", target = "deliveryOption")
     @Mapping(source = "printRequest.eroEnglish.name", target = "eroNameEn")
     @Mapping(source = "printRequest.eroEnglish.phoneNumber", target = "eroPhoneNumberEn")

--- a/src/main/resources/yamlschema/BatchResponse.yaml
+++ b/src/main/resources/yamlschema/BatchResponse.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.5
+#version: 1.0.0
 title: BatchResponse
 type: object
 description: Represents the response from the print provider in response to recieving a batch file from EROP

--- a/src/main/resources/yamlschema/PrintRequest.yaml
+++ b/src/main/resources/yamlschema/PrintRequest.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.5
+#version: 1.0.0
 title: PrintRequest
 type: object
 description: Represents a single print request
@@ -64,17 +64,15 @@ properties:
     enum:
       - cy
       - en
-    default: en
     description: The Voter Authority Certificate language
   certificateFormat:
     type: string
-    default: standard
-    description: The Voter Authority Certificate format
+    description: The format of the supporting information sent with the Voter Authority Certificate. This is a misleading field name and is **not** the format of the Certificate itself.
     enum:
       - standard
       - braille
-      - largeprint
-      - audio
+      - large-print
+      - easy-read
   deliveryOption:
     type: string
     enum:

--- a/src/main/resources/yamlschema/PrintResponse.yaml
+++ b/src/main/resources/yamlschema/PrintResponse.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.5
+#version: 1.0.0
 title: PrintResponse
 type: object
 description: 'Represents a print response, status update for a single print request'

--- a/src/main/resources/yamlschema/PrintResponses.yaml
+++ b/src/main/resources/yamlschema/PrintResponses.yaml
@@ -1,4 +1,4 @@
-#version: 0.0.5
+#version: 1.0.0
 title: PrintResponses
 type: object
 description: 'A response from the print provider to EROP, can contain either batch or print responses, or both.'

--- a/src/main/resources/yamlschema/README.md
+++ b/src/main/resources/yamlschema/README.md
@@ -1,8 +1,18 @@
 # Print Provider Schema
-# v0.0.5
+# v1.0.0
 This folder contains the Print Provider schema files.
 
 The schema is defined in `yamlschema`. Each type is defined in its own file.
+
+## Change History
+| **Version** | **Date**   | **Description**                                                                                                      |
+|-------------|------------|----------------------------------------------------------------------------------------------------------------------|
+| 0.0.1       |            |                                                                                                                      |
+| 0.0.2       |            |                                                                                                                      |
+| 0.0.3       |            |                                                                                                                      |
+| 0.0.4       | 04/11/2022 | Corrected `requestId` data type. Updated descriptions and examples.                                                  |
+| 0.0.5       | 17/11/2022 | Removed `cardVersion` min/max length constraints; set example to 'A' to reflect data sent.                           |
+| 1.0.0       | 29/11/2022 | Changed to semantic versioning of the spec. Updated `certificateFormat` with options `easy-print` and `large-print`  |
 
 ## Audience
 The intended audience / users of these schema files are the Print Provider, and EROP.


### PR DESCRIPTION
This PR updates the `certificateFormat` enum as used in `PrintRequest` in the Print Provider schema; by renaming `largeprint` to `large-print` and `audio` to `easy-read`. This change is as per agreement with the Print Provider

Things to note:
* The field and enum is still called `certificateFormat` even though it is **not** the certificate format, and is in fact the format of the supporting information that is sent with the certificate.
  * I was not able to negotiate changing the field name itself as the Print Provider have already developed to the existing spec and are not open to that degree of refactoring.
  * I have updated the `description` attribute to make this as clear as possible
* I have up'versioned the spec; but also changed to semantic versioning with `1.0.0` being this version.
  * I have added a Change History table to the `README.md`
* I have removed the `default` values from the yaml schema for `certificateFormat` and `certificateLanguage` and moved these to our mapper class
  * This will make the next PR of mapping the value from the PrintRequest database entity into a PrintRequest PSV easier (`PrintRequest.supportingInformationFormat` (entity) into `PrintRequest.certificateFormat` (PSV model)) 
