### PR TITLE
EIP1-2471: EIP1-2780: Add supportingInformationFormat to SendApplicationToPrintMessage

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/JacksonConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/JacksonConfiguration.kt
@@ -21,6 +21,7 @@ class JacksonConfiguration {
             .addModule(KotlinModule.Builder().build())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             .disable(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS)
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
             .serializationInclusion(Include.NON_NULL)
             .build()
 

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.8.0'
+  version: '1.7.0'
   description: |-
     Print API SQS Message Types
     
@@ -109,8 +109,6 @@ components:
           example: Smith
         certificateLanguage:
           $ref: '#/components/schemas/CertificateLanguage'
-        supportingInformationFormat:
-          $ref: '#/components/schemas/SupportingInformationFormat'
         photoLocation:
           type: string
           description: The location of the Elector's photo. Typically an S3 ARN
@@ -151,15 +149,6 @@ components:
         - cy
         - en
       default: en
-
-    SupportingInformationFormat:
-      type: string
-      description: The format of the supporting information sent with the Voter Authority Certificate.
-      enum:
-        - standard
-        - braille
-        - large-print
-        - easy-read
 
     CertificateDelivery:
       title: CertificateDelivery

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.7.0'
+  version: '1.8.0'
   description: |-
     Print API SQS Message Types
     
@@ -109,6 +109,8 @@ components:
           example: Smith
         certificateLanguage:
           $ref: '#/components/schemas/CertificateLanguage'
+        supportingInformationFormat:
+          $ref: '#/components/schemas/SupportingInformationFormat'
         photoLocation:
           type: string
           description: The location of the Elector's photo. Typically an S3 ARN
@@ -149,6 +151,15 @@ components:
         - cy
         - en
       default: en
+
+    SupportingInformationFormat:
+      type: string
+      description: The format of the supporting information sent with the Voter Authority Certificate.
+      enum:
+        - standard
+        - braille
+        - large-print
+        - easy-read
 
     CertificateDelivery:
       title: CertificateDelivery


### PR DESCRIPTION
This PR is to add the supporting information format to `SendApplicationToPrintMessage`, so the value can be received from VCA and later persisted and sent to print provider in the agreed format.