### PR TITLE
EIP1-2471 - Map the supporting information format into Print Request

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SupportingInformationFormat.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SupportingInformationFormat.kt
@@ -1,5 +1,8 @@
 package uk.gov.dluhc.printapi.database.entity
 
 enum class SupportingInformationFormat {
-    STANDARD
+    STANDARD,
+    BRAILLE,
+    LARGE_PRINT,
+    EASY_READ,
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateLanguageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateLanguageMapper.kt
@@ -1,0 +1,11 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
+import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+
+@Mapper
+interface CertificateLanguageMapper {
+
+    fun toPrintRequestApiEnum(certificateLanguage: CertificateLanguage): PrintRequest.CertificateLanguage
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
@@ -5,7 +5,13 @@ import org.mapstruct.Mapping
 import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 
-@Mapper(uses = [InstantMapper::class])
+@Mapper(
+    uses = [
+        InstantMapper::class,
+        SupportingInformationFormatMapper::class,
+        CertificateLanguageMapper::class
+    ]
+)
 abstract class CertificateToPrintRequestMapper {
 
     @Mapping(source = "certificate.vacNumber", target = "cardNumber")
@@ -23,8 +29,8 @@ abstract class CertificateToPrintRequestMapper {
     @Mapping(source = "printRequest.delivery.address.locality", target = "deliveryLocality")
     @Mapping(source = "printRequest.delivery.address.area", target = "deliveryArea")
     @Mapping(source = "printRequest.delivery.address.postcode", target = "deliveryPostcode")
-    @Mapping(expression = "java( uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateLanguage.EN )", target = "certificateLanguage")
-    @Mapping(expression = "java( uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateFormat.STANDARD )", target = "certificateFormat")
+    @Mapping(source = "printRequest.certificateLanguage", target = "certificateLanguage")
+    @Mapping(source = "printRequest.supportingInformationFormat", target = "certificateFormat")
     @Mapping(source = "printRequest.delivery.deliveryClass", target = "deliveryOption")
     @Mapping(source = "printRequest.eroEnglish.name", target = "eroNameEn")
     @Mapping(source = "printRequest.eroEnglish.phoneNumber", target = "eroPhoneNumberEn")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
+import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+
+@Mapper
+interface SupportingInformationFormatMapper {
+
+    /**
+     * Maps a [SupportingInformationFormat] to a [PrintRequest.CertificateFormat]
+     *
+     * The name CertificateFormat is misleading and is tech debt. It's value is the format of the supporting information
+     * that the elector wants with their posted certificate. It is not the format of the certificate itself.
+     * Ideally we would like to rename the enum and it's corresponding field name to better reflect it's purpose
+     * but this can only be done with agreement and coordination with the Print Provider as they will need to refactor
+     * their code at the same time.
+     */
+    fun toPrintRequestApiEnum(supportingInformationFormat: SupportingInformationFormat): PrintRequest.CertificateFormat
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateLanguageMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateLanguageMapperTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
+import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+
+class CertificateLanguageMapperTest {
+
+    private val mapper = CertificateLanguageMapperImpl()
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "EN, EN",
+            "CY, CY",
+        ]
+    )
+    fun `should map CertificateLanguage to print request api enum`(
+        source: CertificateLanguage,
+        expected: PrintRequest.CertificateLanguage
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toPrintRequestApiEnum(source)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
@@ -1,17 +1,16 @@
 package uk.gov.dluhc.printapi.mapper
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
-import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.CertificateLanguage
 import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
@@ -34,6 +33,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoZipPath
 import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.time.ZoneOffset.UTC
 import java.util.stream.Stream
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateFormat as PrintRequestCertificateFormat
@@ -42,21 +42,17 @@ import uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateLangua
 @ExtendWith(MockitoExtension::class)
 class CertificateToPrintRequestMapperTest {
 
+    @InjectMocks
     private lateinit var mapper: CertificateToPrintRequestMapperImpl
+
+    @Mock
+    private lateinit var instantMapper: InstantMapper
 
     @Mock
     private lateinit var supportingInformationFormatMapper: SupportingInformationFormatMapper
 
     @Mock
     private lateinit var certificateLanguageMapper: CertificateLanguageMapper
-
-    @BeforeEach
-    fun setup() {
-        mapper = CertificateToPrintRequestMapperImpl()
-        ReflectionTestUtils.setField(mapper, "instantMapper", InstantMapper())
-        ReflectionTestUtils.setField(mapper, "supportingInformationFormatMapper", supportingInformationFormatMapper)
-        ReflectionTestUtils.setField(mapper, "certificateLanguageMapper", certificateLanguageMapper)
-    }
 
     companion object {
         @JvmStatic
@@ -74,6 +70,7 @@ class CertificateToPrintRequestMapperTest {
         // Given
         given(supportingInformationFormatMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateFormat.STANDARD)
         given(certificateLanguageMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateLanguage.EN)
+        given(instantMapper.toOffsetDateTime(any())).willReturn(OffsetDateTime.ofInstant(Instant.ofEpochMilli(0), UTC))
 
         val requestId: String = aValidRequestId()
         val sourceReference: String = aValidSourceReference()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
@@ -1,0 +1,34 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
+import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+
+class SupportingInformationFormatMapperTest {
+
+    private val mapper = SupportingInformationFormatMapperImpl()
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "STANDARD, STANDARD",
+            "BRAILLE, BRAILLE",
+            "EASY_READ, EASY_READ",
+            "LARGE_PRINT, LARGE_PRINT",
+        ]
+    )
+    fun `should map SupportingInformationFormat to print request api enum`(
+        source: SupportingInformationFormat,
+        expected: PrintRequest.CertificateFormat
+    ) {
+        // Given
+
+        // When
+        val actual = mapper.toPrintRequestApiEnum(source)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+}


### PR DESCRIPTION
This PR maps the Supporting Information Format field from the Print Request entity into the Print Request model object (PSV)
It also maps the certificate language (not entirely sure how "create and send batch files" was system tested and integration tested without this ?? I know the integration testing was supposed to be looking at certificate language! 🤷‍♂️ )