### PR TITLE
EIP1-2529 Remove constraint of only saving welsh ERO details for welsh certificate language

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
@@ -7,7 +7,6 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.dto.EroDto
-import uk.gov.dluhc.printapi.messaging.models.CertificateLanguage
 import uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage
 import uk.gov.dluhc.printapi.service.IdFactory
 import java.time.Clock
@@ -29,15 +28,11 @@ abstract class PrintRequestMapper {
     @Mapping(source = "message.photoLocation", target = "photoLocationArn")
     @Mapping(target = "statusHistory", expression = "java( initialStatus() )")
     @Mapping(source = "ero.englishContactDetails", target = "eroEnglish")
-    @Mapping(source = "ero.welshContactDetails", target = "eroWelsh", conditionExpression = "java( isWelsh(message) )")
+    @Mapping(source = "ero.welshContactDetails", target = "eroWelsh")
     abstract fun toPrintRequest(
         message: SendApplicationToPrintMessage,
         ero: EroDto
     ): PrintRequest
-
-    protected fun isWelsh(message: SendApplicationToPrintMessage): Boolean {
-        return message.certificateLanguage == CertificateLanguage.CY
-    }
 
     protected fun initialStatus(): List<PrintRequestStatus> {
         val now = Instant.now(clock)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
@@ -20,7 +20,6 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
-import uk.gov.dluhc.printapi.messaging.models.CertificateLanguage
 import uk.gov.dluhc.printapi.service.IdFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroDto
@@ -124,7 +123,7 @@ class PrintRequestMapperTest {
                     )
                 },
                 eroEnglish = expectedEnglishEroContactDetails,
-                eroWelsh = if (certificateLanguageModel == CertificateLanguage.EN) null else expectedWelshEroContactDetails,
+                eroWelsh = expectedWelshEroContactDetails,
                 statusHistory = mutableListOf(
                     PrintRequestStatus(
                         status = Status.PENDING_ASSIGNMENT_TO_BATCH,


### PR DESCRIPTION
Welsh ERO was not being saved for local authority W06000001 as the certificate language was English.  Removed constraint in alignment with the JIRA ACs.