### PR TITLE
EIP1-2471: EIP1-2782: Map supporting information format to db entity

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,7 @@ tasks.withType<KotlinCompile> {
 tasks.withType<Test> {
     dependsOn(tasks.withType<GenerateTask>())
     useJUnitPlatform()
+    jvmArgs("--add-opens", "java.base/java.time=ALL-UNNAMED")
 }
 
 tasks.withType<GenerateTask> {

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
@@ -12,7 +12,7 @@ import uk.gov.dluhc.printapi.service.IdFactory
 import java.time.Clock
 import java.time.Instant
 
-@Mapper(uses = [InstantMapper::class])
+@Mapper(uses = [InstantMapper::class, SupportingInformationFormatMapper::class])
 abstract class PrintRequestMapper {
 
     @Autowired
@@ -23,7 +23,6 @@ abstract class PrintRequestMapper {
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "vacVersion", constant = "A")
-    @Mapping(target = "supportingInformationFormat", constant = "STANDARD")
     @Mapping(target = "requestId", expression = "java( idFactory.requestId() )")
     @Mapping(source = "message.photoLocation", target = "photoLocationArn")
     @Mapping(target = "statusHistory", expression = "java( initialStatus() )")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
@@ -1,8 +1,10 @@
 package uk.gov.dluhc.printapi.mapper
 
 import org.mapstruct.Mapper
-import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
+import org.mapstruct.ValueMapping
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat as SupportingInformationFormatEntityEnum
+import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat as SupportingInformationFormatModelEnum
 
 @Mapper
 interface SupportingInformationFormatMapper {
@@ -16,5 +18,9 @@ interface SupportingInformationFormatMapper {
      * but this can only be done with agreement and coordination with the Print Provider as they will need to refactor
      * their code at the same time.
      */
-    fun toPrintRequestApiEnum(supportingInformationFormat: SupportingInformationFormat): PrintRequest.CertificateFormat
+    fun toPrintRequestApiEnum(supportingInformationFormat: SupportingInformationFormatEntityEnum): PrintRequest.CertificateFormat
+
+    @ValueMapping(source = "LARGE_MINUS_PRINT", target = "LARGE_PRINT")
+    @ValueMapping(source = "EASY_MINUS_READ", target = "EASY_READ")
+    fun toPrintRequestEntityEnum(supportingInformationFormat: SupportingInformationFormatModelEnum): SupportingInformationFormatEntityEnum
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapperTest.kt
@@ -14,7 +14,6 @@ import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.Delivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
 import uk.gov.dluhc.printapi.database.entity.DeliveryMethod
-import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
@@ -22,6 +21,7 @@ import uk.gov.dluhc.printapi.service.IdFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroDto
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.toElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildSendApplicationToPrintMessage
 import java.time.Instant
 import java.time.LocalDate
@@ -63,19 +63,7 @@ class CertificateMapperTest {
         given(idFactory.vacNumber()).willReturn(vacNumber)
         given(instantMapper.toInstant(any())).willReturn(message.applicationReceivedDateTime.toInstant())
 
-        val englishEro = ElectoralRegistrationOffice(
-            name = "Gwynedd Council Elections",
-            phoneNumber = "01766 771000",
-            website = "https://www.gwynedd.llyw.cymru/en/Council/Contact-us/Contact-us.aspx",
-            emailAddress = "TrethCyngor@gwynedd.llyw.cymru",
-            address = Address(
-                property = "Gwynedd Council Headquarters",
-                street = "Shirehall Street",
-                town = "Caernarfon",
-                area = "Gwynedd",
-                postcode = "LL55 1SH",
-            )
-        )
+        val englishEro = ero.englishContactDetails.toElectoralRegistrationOffice()
 
         val printRequest = with(message) {
             PrintRequest(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
@@ -15,16 +15,15 @@ import uk.gov.dluhc.printapi.database.entity.Address
 import uk.gov.dluhc.printapi.database.entity.Delivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
 import uk.gov.dluhc.printapi.database.entity.DeliveryMethod
-import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat.EASY_READ
-import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat.EASY_MINUS_READ
 import uk.gov.dluhc.printapi.service.IdFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroDto
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.toElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildSendApplicationToPrintMessage
 import java.time.Clock
 import java.time.Instant
@@ -73,8 +72,8 @@ class PrintRequestMapperTest {
         given(idFactory.requestId()).willReturn(requestId)
         given(supportingInformationFormatMapper.toPrintRequestEntityEnum(any()))
             .willReturn(supportingInformationFormatEntityEnum)
-        val expectedEnglishEroContactDetails = toEroContactDetails(ero.englishContactDetails)
-        val expectedWelshEroContactDetails = toEroContactDetails(ero.welshContactDetails!!)
+        val expectedEnglishEroContactDetails = ero.englishContactDetails.toElectoralRegistrationOffice()
+        val expectedWelshEroContactDetails = ero.welshContactDetails!!.toElectoralRegistrationOffice()
         val expectedRequestDateTime = message.requestDateTime.toInstant()
         given(instantMapper.toInstant(any())).willReturn(expectedRequestDateTime)
         val expected = with(message) {
@@ -127,23 +126,4 @@ class PrintRequestMapperTest {
         verify(idFactory).requestId()
         verify(supportingInformationFormatMapper).toPrintRequestEntityEnum(supportingInformationFormatModelEnum)
     }
-
-    private fun toEroContactDetails(eroContactDetails: EroContactDetailsDto): ElectoralRegistrationOffice =
-        with(eroContactDetails) {
-            ElectoralRegistrationOffice(
-                name = name,
-                phoneNumber = phoneNumber,
-                website = website,
-                emailAddress = emailAddress,
-                address = with(address) {
-                    Address(
-                        property = property,
-                        street = street,
-                        town = town,
-                        area = area,
-                        postcode = postcode,
-                    )
-                }
-            )
-        }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
@@ -1,16 +1,16 @@
 package uk.gov.dluhc.printapi.mapper
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import org.mockito.InjectMocks
 import org.mockito.Mock
+import org.mockito.Spy
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
-import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.dluhc.printapi.database.entity.Address
 import uk.gov.dluhc.printapi.database.entity.Delivery
 import uk.gov.dluhc.printapi.database.entity.DeliveryClass
@@ -19,7 +19,9 @@ import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.Status
-import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat.EASY_READ
+import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
+import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat.EASY_MINUS_READ
 import uk.gov.dluhc.printapi.service.IdFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroDto
@@ -38,6 +40,7 @@ class PrintRequestMapperTest {
         private val FIXED_CLOCK = Clock.fixed(FIXED_TIME, ZoneOffset.UTC)
     }
 
+    @InjectMocks
     private lateinit var mapper: PrintRequestMapperImpl
 
     @Mock
@@ -46,51 +49,32 @@ class PrintRequestMapperTest {
     @Mock
     private lateinit var instantMapper: InstantMapper
 
-    @BeforeEach
-    fun setup() {
-        mapper = PrintRequestMapperImpl()
-        ReflectionTestUtils.setField(mapper, "idFactory", idFactory)
-        ReflectionTestUtils.setField(mapper, "clock", FIXED_CLOCK)
-        ReflectionTestUtils.setField(mapper, "instantMapper", instantMapper)
-    }
+    @Mock
+    private lateinit var supportingInformationFormatMapper: SupportingInformationFormatMapper
+
+    @Spy
+    private val clock: Clock = FIXED_CLOCK
 
     @ParameterizedTest
     @CsvSource(value = ["EN, EN", "CY, CY"])
-    fun `should map send application to print message to print details`(
+    fun `should map send application to print message to print request`(
         certificateLanguageModel: CertificateLanguageModel,
         certificateLanguageEntity: CertificateLanguageEntity
     ) {
         // Given
         val ero = buildEroDto()
-        val message = buildSendApplicationToPrintMessage(certificateLanguage = certificateLanguageModel)
+        val supportingInformationFormatModelEnum = EASY_MINUS_READ
+        val supportingInformationFormatEntityEnum = EASY_READ
+        val message = buildSendApplicationToPrintMessage(
+            certificateLanguage = certificateLanguageModel,
+            supportingInformationFormat = supportingInformationFormatModelEnum
+        )
         val requestId = aValidRequestId()
         given(idFactory.requestId()).willReturn(requestId)
-        val expectedEnglishEroContactDetails = ElectoralRegistrationOffice(
-            name = "Gwynedd Council Elections",
-            phoneNumber = "01766 771000",
-            website = "https://www.gwynedd.llyw.cymru/en/Council/Contact-us/Contact-us.aspx",
-            emailAddress = "TrethCyngor@gwynedd.llyw.cymru",
-            address = Address(
-                property = "Gwynedd Council Headquarters",
-                street = "Shirehall Street",
-                town = "Caernarfon",
-                area = "Gwynedd",
-                postcode = "LL55 1SH",
-            )
-        )
-        val expectedWelshEroContactDetails = ElectoralRegistrationOffice(
-            name = "Etholiadau Cyngor Gwynedd",
-            phoneNumber = "01766 771000",
-            website = "https://www.gwynedd.llyw.cymru/cy/Cyngor/Cysylltu-%c3%a2-ni/Cysylltu-%c3%a2-ni.aspx",
-            emailAddress = "TrethCyngor@gwynedd.llyw.cymru",
-            address = Address(
-                property = "Pencadlys Cyngor Gwynedd",
-                street = "Stryd y Jêl",
-                town = "Caernarfon",
-                area = "Gwynedd",
-                postcode = "LL55 1SH",
-            )
-        )
+        given(supportingInformationFormatMapper.toPrintRequestEntityEnum(any()))
+            .willReturn(supportingInformationFormatEntityEnum)
+        val expectedEnglishEroContactDetails = toEroContactDetails(ero.englishContactDetails)
+        val expectedWelshEroContactDetails = toEroContactDetails(ero.welshContactDetails!!)
         val expectedRequestDateTime = message.requestDateTime.toInstant()
         given(instantMapper.toInstant(any())).willReturn(expectedRequestDateTime)
         val expected = with(message) {
@@ -102,7 +86,7 @@ class PrintRequestMapperTest {
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = certificateLanguageEntity,
-                supportingInformationFormat = SupportingInformationFormat.STANDARD,
+                supportingInformationFormat = supportingInformationFormatEntityEnum,
                 photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
@@ -141,5 +125,25 @@ class PrintRequestMapperTest {
         // Then
         assertThat(actual).usingRecursiveComparison().ignoringFields("id").isEqualTo(expected)
         verify(idFactory).requestId()
+        verify(supportingInformationFormatMapper).toPrintRequestEntityEnum(supportingInformationFormatModelEnum)
     }
+
+    private fun toEroContactDetails(eroContactDetails: EroContactDetailsDto): ElectoralRegistrationOffice =
+        with(eroContactDetails) {
+            ElectoralRegistrationOffice(
+                name = name,
+                phoneNumber = phoneNumber,
+                website = website,
+                emailAddress = emailAddress,
+                address = with(address) {
+                    Address(
+                        property = property,
+                        street = street,
+                        town = town,
+                        area = area,
+                        postcode = postcode,
+                    )
+                }
+            )
+        }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
@@ -1,34 +1,63 @@
 package uk.gov.dluhc.printapi.mapper
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
+import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat as SupportingInformationFormatEntityEnum
+import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat as SupportingInformationFormatModelEnum
 
 class SupportingInformationFormatMapperTest {
 
     private val mapper = SupportingInformationFormatMapperImpl()
 
-    @ParameterizedTest
-    @CsvSource(
-        value = [
-            "STANDARD, STANDARD",
-            "BRAILLE, BRAILLE",
-            "EASY_READ, EASY_READ",
-            "LARGE_PRINT, LARGE_PRINT",
-        ]
-    )
-    fun `should map SupportingInformationFormat to print request api enum`(
-        source: SupportingInformationFormat,
-        expected: PrintRequest.CertificateFormat
-    ) {
-        // Given
+    @Nested
+    inner class ToPrintRequestApiEnum {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "STANDARD, STANDARD",
+                "BRAILLE, BRAILLE",
+                "EASY_READ, EASY_READ",
+                "LARGE_PRINT, LARGE_PRINT",
+            ]
+        )
+        fun `should map SupportingInformationFormat to print request api enum`(
+            source: SupportingInformationFormatEntityEnum,
+            expected: PrintRequest.CertificateFormat
+        ) {
+            // Given
 
-        // When
-        val actual = mapper.toPrintRequestApiEnum(source)
+            // When
+            val actual = mapper.toPrintRequestApiEnum(source)
 
-        // Then
-        assertThat(actual).isEqualTo(expected)
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+
+    @Nested
+    inner class ToPrintRequestEntityEnum {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "STANDARD, STANDARD",
+                "BRAILLE, BRAILLE",
+                "LARGE_MINUS_PRINT, LARGE_PRINT",
+                "EASY_MINUS_READ, EASY_READ",
+            ]
+        )
+        fun `should map SupportingInformationFormat model enum to entity enum`(
+            supportingInformationFormatModelEnum: SupportingInformationFormatModelEnum,
+            expected: SupportingInformationFormatEntityEnum
+        ) {
+            // Given
+            // When
+            val actual = mapper.toPrintRequestEntityEnum(supportingInformationFormatModelEnum)
+
+            // Then
+            assertThat(actual).isEqualTo(expected)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat
+import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat.EASY_MINUS_READ
 import uk.gov.dluhc.printapi.testsupport.TestLogAppender.Companion.hasLog
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
@@ -43,7 +44,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
         )
         val localAuthority = ero.localAuthorities[1]
         val gssCode = localAuthority.gssCode
-        val payload = buildSendApplicationToPrintMessage(gssCode = gssCode)
+        val payload = buildSendApplicationToPrintMessage(gssCode = gssCode, supportingInformationFormat = EASY_MINUS_READ)
         wireMockService.stubEroManagementGetEroByGssCode(ero, gssCode)
 
         val expected = with(payload) {
@@ -66,7 +67,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = CertificateLanguage.EN,
-                supportingInformationFormat = SupportingInformationFormat.STANDARD,
+                supportingInformationFormat = SupportingInformationFormat.EASY_READ,
                 photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroContactDetailsExtensions.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroContactDetailsExtensions.kt
@@ -1,0 +1,22 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.dto
+
+import uk.gov.dluhc.printapi.database.entity.Address
+import uk.gov.dluhc.printapi.database.entity.ElectoralRegistrationOffice
+import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
+
+fun EroContactDetailsDto.toElectoralRegistrationOffice() =
+    ElectoralRegistrationOffice(
+        name = name,
+        phoneNumber = phoneNumber,
+        website = website,
+        emailAddress = emailAddress,
+        address = with(address) {
+            Address(
+                property = property,
+                street = street,
+                town = town,
+                area = area,
+                postcode = postcode,
+            )
+        }
+    )


### PR DESCRIPTION
This PR is to map the supporting information format in the `SendApplicationToPrintMessage` model to db entity to persist that value.