### PR TITLE
EIP1-1878 - Turn down SFTP logging on int

### DIFF
--- a/src/main/resources/application-int.yml
+++ b/src/main/resources/application-int.yml
@@ -1,11 +1,3 @@
-logging:
-  level:
-    org:
-      springframework:
-        integration: DEBUG
-    com:
-      jcraft:
-        jsch: DEBUG
 jobs:
   batch-print-requests:
     daily-limit: 1000


### PR DESCRIPTION
This PR removes the additional logging for the SFTP components that we put into `int` recently.