### PR TITLE
EIP1-2885 - Improve efficiency of assigning batch ids to certificates

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -26,7 +26,7 @@ class CertificateBatchingService(
         val batches = batchCertificates(batchSize)
         batches.forEach { (batchId, batchOfCertificates) ->
             certificateRepository.saveAll(batchOfCertificates)
-            logger.info { "Certificates with id ${batchOfCertificates.map { it.id }} assigned to batch [$batchId]" }
+            logger.info { "Certificate ids ${batchOfCertificates.map { it.id }} assigned to batch [$batchId]" }
         }
         return batches.keys
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -25,10 +25,8 @@ class CertificateBatchingService(
     fun batchPendingCertificates(batchSize: Int): Set<String> {
         val batches = batchCertificates(batchSize)
         batches.forEach { (batchId, batchOfCertificates) ->
-            batchOfCertificates.forEach { certificate ->
-                certificateRepository.save(certificate)
-                logger.info { "Certificate with id [${certificate.id}] assigned to batch [$batchId]" }
-            }
+            certificateRepository.saveAll(batchOfCertificates)
+            logger.info { "Certificates with id ${batchOfCertificates.map { it.id }} assigned to batch [$batchId]" }
         }
         return batches.keys
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,13 @@ spring:
     change-log: classpath:db/changelog/db.changelog-master.xml
     contexts: ${LIQUIBASE_CONTEXTS}
 
+  jpa:
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 50
+        order_inserts: true
+
 sqs:
   send-application-to-print-queue-name: ${SQS_SEND_APPLICATION_TO_PRINT_QUEUE_NAME}
   process-print-request-batch-queue-name: ${SQS_PROCESS_PRINT_REQUEST_BATCH_QUEUE_NAME}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
@@ -140,7 +140,7 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
 
                 assertThat(
                     TestLogAppender.getLogEventMatchingRegex(
-                        "Certificate with id \\[$certificateId\\] assigned to batch \\[.{32}\\]",
+                        "Certificates with id \\[$certificateId\\] assigned to batch \\[.{32}\\]",
                         Level.INFO
                     )
                 ).hasCorrelationId(expectedCorrelationId)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
@@ -140,7 +140,7 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
 
                 assertThat(
                     TestLogAppender.getLogEventMatchingRegex(
-                        "Certificates with id \\[$certificateId\\] assigned to batch \\[.{32}\\]",
+                        "Certificate ids \\[$certificateId\\] assigned to batch \\[.{32}\\]",
                         Level.INFO
                     )
                 ).hasCorrelationId(expectedCorrelationId)


### PR DESCRIPTION
This PR implements a suggestion from @adacayi to improve the efficiency of assigning batch IDs to Print Requests
Previously we looped through the batch (up to 50 records in a batch) and called `.save` on the repository for each record.
Now we call `saveAll` on the collection, therefore saving up to 50 records at a time.

IE. previously, if there were 190 Print Requests that we had grouped into 4 batches (50, 50, 50, 40); we would call `.save` 190 times.
Now with this change the same 190 Print Requests groups into the same 4 batches will results in 4 calls to `.saveAll` (50, 50, 50, 40)

This should be a massive improvement when dealing with very large numbers of un-batched Print Requests, as per the problem described in EIP1-2885