### PR TITLE
EIP1-2885 - Set batch job limit

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.printapi.database.repository
 
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
@@ -16,10 +17,17 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
 
     fun findByStatusAndPrintRequestsBatchId(certificateStatus: Status, batchId: String): List<Certificate>
 
-    fun findByStatus(certificateStatus: Status): List<Certificate>
+    fun findByStatusOrderByApplicationReceivedDateTimeAsc(certificateStatus: Status, pageable: Pageable): List<Certificate>
 
     fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): Certificate?
 
-    @Query("SELECT COUNT(*) FROM PrintRequestStatus s WHERE s.eventDateTime >= :startInstant AND s.eventDateTime <= :endInstant AND s.status = :status")
+    @Query(
+        value = """
+            SELECT COUNT(s) FROM PrintRequestStatus s
+            WHERE s.eventDateTime >= :startInstant 
+            AND s.eventDateTime <= :endInstant 
+            AND s.status = :status
+        """
+    )
     fun getPrintRequestStatusCount(startInstant: Instant, endInstant: Instant, status: Status): Int
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/BatchPrintRequestsJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/BatchPrintRequestsJob.kt
@@ -2,7 +2,6 @@ package uk.gov.dluhc.printapi.jobs
 
 import mu.KotlinLogging
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.service.PrintRequestsService
@@ -12,13 +11,11 @@ private val logger = KotlinLogging.logger {}
 @Component
 class BatchPrintRequestsJob(
     private val printRequestsService: PrintRequestsService,
-    @Value("\${jobs.batch-print-requests.batch-size}")
-    private val batchSize: Int
 ) {
 
     @Scheduled(cron = "\${jobs.batch-print-requests.cron}")
     @SchedulerLock(name = "\${jobs.batch-print-requests.name}")
     fun run() {
-        printRequestsService.processPrintRequests(batchSize)
+        printRequestsService.processPrintRequests()
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -13,11 +13,11 @@ class PrintRequestsService(
     private val certificateBatchingService: CertificateBatchingService
 ) {
 
-    fun processPrintRequests(batchSize: Int) {
+    fun processPrintRequests() {
         logger.info { "Looking for certificate Print Requests to assign to a new batch" }
 
         // split into batches and save to database before sending messages to SQS
-        certificateBatchingService.batchPendingCertificates(batchSize)
+        certificateBatchingService.batchPendingCertificates()
             .onEach { batchId ->
                 processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
                 logger.info { "Batch [$batchId] submitted to queue" }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ jobs:
     name: "BatchPrintRequests"
     cron: "0 0/15 * * * *" # every 15 minutes, starting on the hour - see analysis and recommendations in EIP1-2515
     batch-size: 50
-    max-un-batched-records: 5000
+    max-un-batched-records: 5000 # see analysis and recommendations in EIP1-2885
     daily-limit: 150_000
   process-print-responses:
     name: "ProcessPrintResponses"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ jobs:
     name: "BatchPrintRequests"
     cron: "0 0/15 * * * *" # every 15 minutes, starting on the hour - see analysis and recommendations in EIP1-2515
     batch-size: 50
+    max-un-batched-records: 5000
     daily-limit: 150_000
   process-print-responses:
     name: "ProcessPrintResponses"

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
@@ -5,10 +5,9 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
 import org.mockito.kotlin.given
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintRequestBatchMessage
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
@@ -28,21 +27,20 @@ class PrintRequestsServiceTest {
     @Test
     fun `should process print requests and submit to queue`() {
         // Given
-        val batchSize = 5
         val batchId1 = aValidBatchId()
         val batchId2 = aValidBatchId()
         val batchId3 = aValidBatchId()
         val batchIds = setOf(batchId1, batchId2, batchId3)
-        given(certificateBatchingService.batchPendingCertificates(any())).willReturn(batchIds)
+        given(certificateBatchingService.batchPendingCertificates()).willReturn(batchIds)
 
         // When
-        printRequestsService.processPrintRequests(batchSize)
+        printRequestsService.processPrintRequests()
 
         // Then
-        verify(certificateBatchingService).batchPendingCertificates(batchSize)
-        verify(processPrintRequestQueue, times(3)).submit(any())
+        verify(certificateBatchingService).batchPendingCertificates()
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId1))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId2))
         verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId3))
+        verifyNoMoreInteractions(processPrintRequestQueue)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -50,14 +50,16 @@ fun buildCertificate(
     gssCode: String = aGssCode(),
     sourceType: SourceType = aValidSourceType(),
     sourceReference: String = aValidSourceReference(),
+    applicationReceivedDateTime: Instant = aValidApplicationReceivedDateTime(),
+    applicationReference: String = aValidApplicationReference()
 ): Certificate {
     val certificate = Certificate(
         id = id,
         vacNumber = vacNumber,
         sourceType = sourceType,
         sourceReference = sourceReference,
-        applicationReference = aValidApplicationReference(),
-        applicationReceivedDateTime = aValidApplicationReceivedDateTime(),
+        applicationReference = applicationReference,
+        applicationReceivedDateTime = applicationReceivedDateTime,
         issuingAuthority = aValidIssuingAuthority(),
         issueDate = aValidIssueDate(),
         suggestedExpiryDate = aValidSuggestedExpiryDate(),


### PR DESCRIPTION
This PR sets a limit to the number of un-batched Print Requests that the batch job will pull from the database at a time (to prevent very very long running processes that span several cron invocations as described in EIP1-2885)

The limit is set at 5,000 in `application.yml` as proposed in EIP1-2885

