### PR TITLE
EIP1-2467 Refactor to support certificates with several print requests

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -104,30 +104,32 @@ class Certificate(
         printRequests.filter { it.getCurrentStatus().status == printRequestStatus }
 
     fun addPrintRequestToBatch(batchId: String) {
-        getPrintRequestsByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH).forEach {
-            it.addPrintRequestStatus(
-                PrintRequestStatus(
-                    status = Status.ASSIGNED_TO_BATCH,
-                    eventDateTime = Instant.now(),
-                    message = null
+        processPrintRequestUpdate {
+            getPrintRequestsByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH).forEach {
+                it.addPrintRequestStatus(
+                    PrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now(),
+                        message = null
+                    )
                 )
-            )
-            it.batchId = batchId
+                it.batchId = batchId
+            }
         }
-        assignStatus()
     }
 
     fun addSentToPrintProviderEventForBatch(batchId: String) {
-        getPrintRequestsByBatchId(batchId).forEach {
-            it.addPrintRequestStatus(
-                PrintRequestStatus(
-                    status = Status.SENT_TO_PRINT_PROVIDER,
-                    eventDateTime = Instant.now(),
-                    message = null
+        processPrintRequestUpdate {
+            getPrintRequestsByBatchId(batchId).forEach {
+                it.addPrintRequestStatus(
+                    PrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now(),
+                        message = null
+                    )
                 )
-            )
+            }
         }
-        assignStatus()
     }
 
     fun addReceivedByPrintProviderEventForBatch(
@@ -135,16 +137,17 @@ class Certificate(
         eventDateTime: Instant,
         message: String?
     ) {
-        getPrintRequestsByBatchId(batchId).forEach {
-            it.addPrintRequestStatus(
-                PrintRequestStatus(
-                    status = Status.RECEIVED_BY_PRINT_PROVIDER,
-                    eventDateTime = eventDateTime,
-                    message = message
+        processPrintRequestUpdate {
+            getPrintRequestsByBatchId(batchId).forEach {
+                it.addPrintRequestStatus(
+                    PrintRequestStatus(
+                        status = Status.RECEIVED_BY_PRINT_PROVIDER,
+                        eventDateTime = eventDateTime,
+                        message = message
+                    )
                 )
-            )
+            }
         }
-        assignStatus()
     }
 
     fun requeuePrintRequestForBatch(
@@ -153,18 +156,19 @@ class Certificate(
         message: String?,
         newRequestId: String
     ) {
-        getPrintRequestsByBatchId(batchId).forEach {
-            it.addPrintRequestStatus(
-                PrintRequestStatus(
-                    status = Status.PENDING_ASSIGNMENT_TO_BATCH,
-                    eventDateTime = eventDateTime,
-                    message = message
+        processPrintRequestUpdate {
+            getPrintRequestsByBatchId(batchId).forEach {
+                it.addPrintRequestStatus(
+                    PrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = eventDateTime,
+                        message = message
+                    )
                 )
-            )
-            it.batchId = null
-            it.requestId = newRequestId
+                it.batchId = null
+                it.requestId = newRequestId
+            }
         }
-        assignStatus()
     }
 
     fun addPrintRequestEvent(
@@ -173,15 +177,21 @@ class Certificate(
         eventDateTime: Instant,
         message: String?
     ) {
-        getPrintRequestsByRequestId(requestId).forEach {
-            it.addPrintRequestStatus(
-                PrintRequestStatus(
-                    status = status,
-                    eventDateTime = eventDateTime,
-                    message = message
+        processPrintRequestUpdate {
+            getPrintRequestsByRequestId(requestId).forEach {
+                it.addPrintRequestStatus(
+                    PrintRequestStatus(
+                        status = status,
+                        eventDateTime = eventDateTime,
+                        message = message
+                    )
                 )
-            )
+            }
         }
+    }
+
+    private fun processPrintRequestUpdate(update: () -> Unit) {
+        update.invoke()
         assignStatus()
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -103,18 +103,16 @@ class Certificate(
     fun getPrintRequestsByStatus(printRequestStatus: Status) =
         printRequests.filter { it.getCurrentStatus().status == printRequestStatus }
 
-    fun addPrintRequestToBatch(batchId: String) {
+    fun addPrintRequestToBatch(printRequest: PrintRequest, batchId: String) {
         processPrintRequestUpdate {
-            getPrintRequestsByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH).forEach {
-                it.addPrintRequestStatus(
-                    PrintRequestStatus(
-                        status = Status.ASSIGNED_TO_BATCH,
-                        eventDateTime = Instant.now(),
-                        message = null
-                    )
+            printRequest.addPrintRequestStatus(
+                PrintRequestStatus(
+                    status = Status.ASSIGNED_TO_BATCH,
+                    eventDateTime = Instant.now(),
+                    message = null
                 )
-                it.batchId = batchId
-            }
+            )
+            printRequest.batchId = batchId
         }
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -126,7 +126,6 @@ class Certificate(
                     message = null
                 )
             )
-            it.batchId = batchId
         }
         assignStatus()
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -100,12 +100,8 @@ class Certificate(
         return this
     }
 
-    fun getCurrentPrintRequest(): PrintRequest {
-        printRequests.sortByDescending { it.requestDateTime }
-        return printRequests.first()
-    }
     fun getPrintRequestsByStatus(printRequestStatus: Status) =
-        printRequests.filter { status == printRequestStatus }
+        printRequests.filter { it.getCurrentStatus().status == printRequestStatus }
 
     fun addPrintRequestToBatch(batchId: String) {
         getPrintRequestsByStatus(Status.PENDING_ASSIGNMENT_TO_BATCH).forEach {
@@ -189,6 +185,8 @@ class Certificate(
         }
         assignStatus()
     }
+
+    private fun getCurrentPrintRequest(): PrintRequest = printRequests.sortedByDescending { it.requestDateTime }.first()
 
     private fun getPrintRequestsByRequestId(requestId: String) = printRequests.filter { it.requestId == requestId }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
@@ -35,6 +35,6 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
 object CertificateRepositoryExtensions {
     fun CertificateRepository.findByPrintRequestStatusAndBatchId(status: Status, batchId: String): List<Certificate> {
         return findByPrintRequestsBatchId(batchId)
-            .filter { it.printRequests.stream().anyMatch { printRequest -> printRequest.getCurrentStatus().status == status } }
+            .filter { it.printRequests.any { printRequest -> printRequest.getCurrentStatus().status == status } }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
@@ -15,7 +15,7 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
 
     fun getByPrintRequestsRequestId(requestId: String): Certificate?
 
-    fun findByStatusAndPrintRequestsBatchId(certificateStatus: Status, batchId: String): List<Certificate>
+    fun findByPrintRequestsBatchId(batchId: String): List<Certificate>
 
     fun findByStatusOrderByApplicationReceivedDateTimeAsc(certificateStatus: Status, pageable: Pageable): List<Certificate>
 
@@ -30,4 +30,11 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
         """
     )
     fun getPrintRequestStatusCount(startInstant: Instant, endInstant: Instant, status: Status): Int
+}
+
+object CertificateRepositoryExtensions {
+    fun CertificateRepository.findByPrintRequestStatusAndBatchId(status: Status, batchId: String): List<Certificate> {
+        return findByPrintRequestsBatchId(batchId)
+            .filter { it.printRequests.stream().anyMatch { printRequest -> printRequest.getCurrentStatus().status == status } }
+    }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -42,10 +42,7 @@ class CertificateBatchingService(
 
         return limitCertificates(certificatesPendingAssignment).chunked(batchSize).associate { batchOfCertificates ->
             val batchId = idFactory.batchId()
-            batchId to batchOfCertificates.onEach {
-                it.getCurrentPrintRequest().batchId = batchId
-                it.addStatus(ASSIGNED_TO_BATCH)
-            }
+            batchId to batchOfCertificates.onEach { it.addPrintRequestToBatch(batchId) }
         }
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.printapi.database.entity.Certificate
+import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
 import uk.gov.dluhc.printapi.database.entity.Status.PENDING_ASSIGNMENT_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
@@ -40,38 +41,45 @@ class CertificateBatchingService(
             Pageable.ofSize(maxUnBatchedRecords)
         )
 
-        return limitCertificates(certificatesPendingAssignment).chunked(batchSize).associate { batchOfCertificates ->
+        val printRequestsPendingAssignment = certificatesPendingAssignment.flatMap { it.printRequests }
+            .filter { it.getCurrentStatus().status == PENDING_ASSIGNMENT_TO_BATCH }
+
+        return limitPrintRequests(printRequestsPendingAssignment).chunked(batchSize).associate { batchOfPrintRequests ->
             val batchId = idFactory.batchId()
-            batchId to batchOfCertificates.onEach { it.addPrintRequestToBatch(batchId) }
+            batchId to batchOfPrintRequests.map { printRequest ->
+                val certificate = certificatesPendingAssignment.first { it.printRequests.contains(printRequest) }
+                certificate.addPrintRequestToBatch(printRequest, batchId)
+                certificate
+            }
         }
     }
 
-    private fun limitCertificates(certificatesPendingAssignment: List<Certificate>): List<Certificate> {
+    private fun limitPrintRequests(printRequestsPendingAssignmentToBatch: List<PrintRequest>): List<PrintRequest> {
         val startOfDay = Instant.now(clock).truncatedTo(DAYS)
         val endOfDay = startOfDay.plus(1, DAYS).minusSeconds(1)
         val countOfRequestsSentToPrintProvider =
             certificateRepository.getPrintRequestStatusCount(startOfDay, endOfDay, ASSIGNED_TO_BATCH)
 
-        if ((certificatesPendingAssignment.size + countOfRequestsSentToPrintProvider) > dailyLimit) {
-            logDailyLimit(certificatesPendingAssignment, countOfRequestsSentToPrintProvider, endOfDay)
-            return certificatesPendingAssignment.subList(0, dailyLimit - countOfRequestsSentToPrintProvider)
+        if ((printRequestsPendingAssignmentToBatch.size + countOfRequestsSentToPrintProvider) > dailyLimit) {
+            logDailyLimit(printRequestsPendingAssignmentToBatch, countOfRequestsSentToPrintProvider, endOfDay)
+            return printRequestsPendingAssignmentToBatch.subList(0, dailyLimit - countOfRequestsSentToPrintProvider)
         }
 
-        return certificatesPendingAssignment
+        return printRequestsPendingAssignmentToBatch
     }
 
     private fun logDailyLimit(
-        certificatesPendingAssignment: List<Certificate>,
+        printRequestsPendingAssignmentToBatch: List<PrintRequest>,
         countOfRequestsSentToPrintProvider: Int,
         endOfDay: Instant
     ) {
         val nextDay = endOfDay.plusSeconds(1)
         logger.warn {
-            """Identified ${certificatesPendingAssignment.size} certificates to assign to a batch. 
+            """Identified ${printRequestsPendingAssignmentToBatch.size} print requests to assign to a batch. 
             Daily print limit is $dailyLimit. 
-            $countOfRequestsSentToPrintProvider certificates already sent to print provider today.
+            $countOfRequestsSentToPrintProvider print requests already sent to print provider today.
             Remaining capacity is ${dailyLimit - countOfRequestsSentToPrintProvider}.
-            ${certificatesPendingAssignment.size + countOfRequestsSentToPrintProvider - dailyLimit} certificates won't be assigned to a batch until $nextDay at the earliest."""
+            ${printRequestsPendingAssignmentToBatch.size + countOfRequestsSentToPrintProvider - dailyLimit} print requests won't be assigned to a batch until $nextDay at the earliest."""
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
@@ -1,6 +1,8 @@
 package uk.gov.dluhc.printapi.service
 
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.database.entity.Certificate
+import uk.gov.dluhc.printapi.database.entity.Status
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -10,9 +12,19 @@ import java.time.format.DateTimeFormatter
 @Component
 class FilenameFactory(private val clock: Clock) {
 
-    fun createZipFilename(batchId: String, count: Int): String = createFilename(batchId, count, "zip")
+    fun createZipFilename(batchId: String, certificates: List<Certificate>): String {
+        return createFilename(batchId, printRequestCount(batchId, certificates), "zip")
+    }
 
-    fun createPrintRequestsFilename(batchId: String, count: Int): String = createFilename(batchId, count, "psv")
+    fun createPrintRequestsFilename(batchId: String, certificates: List<Certificate>): String {
+        return createFilename(batchId, printRequestCount(batchId, certificates), "psv")
+    }
+
+    private fun printRequestCount(batchId: String, certificates: List<Certificate>): Int {
+        return certificates
+            .flatMap { it.printRequests }
+            .count { it.getCurrentStatus().status == Status.ASSIGNED_TO_BATCH && it.batchId == batchId }
+    }
 
     private fun createFilename(batchId: String, count: Int, ext: String): String {
         val timestamp = LocalDateTime.now(clock).toInstant(ZoneOffset.UTC)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
@@ -17,7 +17,7 @@ class PrintFileDetailsFactory(
     fun createFileDetailsFromCertificates(batchId: String, certificates: List<Certificate>): FileDetails {
         val fileContents = createFromCertificates(certificates)
         return FileDetails(
-            printRequestsFilename = filenameFactory.createPrintRequestsFilename(batchId, certificates.size),
+            printRequestsFilename = filenameFactory.createPrintRequestsFilename(batchId, certificates),
             printRequests = fileContents.printRequests,
             photoLocations = fileContents.photoLocations
         )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingService.kt
@@ -6,6 +6,7 @@ import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.Status.SENT_TO_PRINT_PROVIDER
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
+import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findByPrintRequestStatusAndBatchId
 import uk.gov.dluhc.printapi.mapper.ProcessPrintResponseMessageMapper
 import uk.gov.dluhc.printapi.mapper.StatusMapper
 import uk.gov.dluhc.printapi.messaging.MessageQueue
@@ -47,7 +48,7 @@ class PrintResponseProcessingService(
     fun processBatchResponses(batchResponses: List<BatchResponse>) {
         batchResponses.forEach { batchResponse ->
             val certificates =
-                certificateRepository.findByStatusAndPrintRequestsBatchId(
+                certificateRepository.findByPrintRequestStatusAndBatchId(
                     SENT_TO_PRINT_PROVIDER,
                     batchResponse.batchId
                 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service
 import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
+import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findByPrintRequestStatusAndBatchId
 import uk.gov.dluhc.printapi.exception.EmptyBatchException
 import javax.transaction.Transactional
 
@@ -38,7 +39,7 @@ class ProcessPrintBatchService(
      */
     @Transactional
     fun processBatch(batchId: String) {
-        val certificates = certificateRepository.findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
+        val certificates = certificateRepository.findByPrintRequestStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
         if (certificates.isEmpty()) {
             throw EmptyBatchException(batchId, ASSIGNED_TO_BATCH)
         }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -2,7 +2,6 @@ package uk.gov.dluhc.printapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.exception.EmptyBatchException
@@ -47,12 +46,10 @@ class ProcessPrintBatchService(
         val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
         val sftpFilename = filenameFactory.createZipFilename(batchId, certificates.size)
         sftpService.sendFile(sftpInputStream, sftpFilename)
-        updateCertificates(certificates)
+        updateCertificates(batchId, certificates)
     }
 
-    private fun updateCertificates(certificates: List<Certificate>) {
-        certificates.forEach { certificate ->
-            certificate.addStatus(Status.SENT_TO_PRINT_PROVIDER)
-        }
+    private fun updateCertificates(batchId: String, certificates: List<Certificate>) {
+        certificates.forEach { certificate -> certificate.addSentToPrintProviderEventForBatch(batchId) }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchService.kt
@@ -45,7 +45,7 @@ class ProcessPrintBatchService(
         }
         val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
         val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
-        val sftpFilename = filenameFactory.createZipFilename(batchId, certificates.size)
+        val sftpFilename = filenameFactory.createZipFilename(batchId, certificates)
         sftpService.sendFile(sftpInputStream, sftpFilename)
         updateCertificates(batchId, certificates)
     }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/entity/CertificateTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/entity/CertificateTest.kt
@@ -2,9 +2,10 @@ package uk.gov.dluhc.printapi.database.entity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchException
-import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
@@ -57,23 +58,334 @@ internal class CertificateTest {
     }
 
     @Nested
-    inner class AddStatus {
-
+    inner class AddPrintRequestToBatch {
         @Test
-        fun `should fail to add status for Certificate with no existing Print Requests`() {
+        fun `should addPrintRequestToBatch for Certificate with one Print Request PENDING_ASSIGNMENT_TO_BATCH`() {
             // Given
-            val certificate = buildCertificate(printRequests = emptyList())
-            val status = Status.VALIDATED_BY_PRINT_PROVIDER
+            val batchId = aValidBatchId()
+            val pendingAssignmentPrintRequest = buildPrintRequest(
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minusSeconds(1)
+                    )
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(pendingAssignmentPrintRequest))
+            val expectedStatus = Status.ASSIGNED_TO_BATCH
 
             // When
-            val actual = catchException { certificate.addStatus(status) }
+            certificate.addPrintRequestToBatch(batchId)
 
             // Then
-            assertThat(actual).isInstanceOf(NoSuchElementException::class.java)
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(pendingAssignmentPrintRequest.getCurrentStatus().status).isEqualTo(expectedStatus)
+            assertThat(pendingAssignmentPrintRequest.batchId).isEqualTo(batchId)
         }
 
         @Test
-        fun `should add status for Certificate with one Print Request with one status`() {
+        fun `should addPrintRequestToBatch for Certificate with multiple Print Requests including one PENDING_ASSIGNMENT_TO_BATCH`() {
+            // Given
+            val batchId = aValidBatchId()
+            val failedPrintRequest = buildPrintRequest(
+                requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(30, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(29, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.PRINT_PROVIDER_DISPATCH_FAILED,
+                        eventDateTime = Instant.now().minus(20, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val printRequestToIncludeInBatch = buildPrintRequest(
+                requestDateTime = Instant.now().minus(1, ChronoUnit.DAYS),
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(1, ChronoUnit.DAYS)
+                    )
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(failedPrintRequest, printRequestToIncludeInBatch))
+            val expectedStatus = Status.ASSIGNED_TO_BATCH
+
+            // When
+            certificate.addPrintRequestToBatch(batchId)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(printRequestToIncludeInBatch.getCurrentStatus().status).isEqualTo(expectedStatus)
+            assertThat(printRequestToIncludeInBatch.batchId).isEqualTo(batchId)
+        }
+    }
+
+    @Nested
+    inner class AddSentToPrintProviderEventForBatch {
+        @Test
+        fun `should addSentToPrintProviderEventForBatch for Certificate with one Print Request assigned to batch`() {
+            // Given
+            val batchId = aValidBatchId()
+            val assignedToBatchPrintRequest = buildPrintRequest(
+                batchId = batchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minusSeconds(1)
+                    )
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(assignedToBatchPrintRequest))
+            val expectedStatus = Status.SENT_TO_PRINT_PROVIDER
+
+            // When
+            certificate.addSentToPrintProviderEventForBatch(batchId)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(assignedToBatchPrintRequest.getCurrentStatus().status).isEqualTo(expectedStatus)
+            assertThat(assignedToBatchPrintRequest.batchId).isEqualTo(batchId)
+        }
+
+        @Test
+        fun `should addSentToPrintProviderEventForBatch for Certificate with multiple Print Requests including one assigned to batch`() {
+            // Given
+            val oldBatchId = aValidBatchId()
+            val batchIdBeingProcessed = aValidBatchId()
+            val oldPrintRequest = buildPrintRequest(
+                requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
+                batchId = oldBatchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(30, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(29, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.PRINT_PROVIDER_DISPATCH_FAILED,
+                        eventDateTime = Instant.now().minus(20, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val printRequestAssignedToBatch = buildPrintRequest(
+                requestDateTime = Instant.now().minus(1, ChronoUnit.DAYS),
+                batchId = batchIdBeingProcessed,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(10, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(9, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(oldPrintRequest, printRequestAssignedToBatch))
+            val expectedStatus = Status.SENT_TO_PRINT_PROVIDER
+
+            // When
+            certificate.addSentToPrintProviderEventForBatch(batchIdBeingProcessed)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(printRequestAssignedToBatch.getCurrentStatus().status).isEqualTo(expectedStatus)
+            assertThat(printRequestAssignedToBatch.batchId).isEqualTo(batchIdBeingProcessed)
+        }
+    }
+
+    @Nested
+    inner class AddReceivedByPrintProviderEventForBatch {
+        @Test
+        fun `should add RECEIVED_BY_PRINT_PROVIDER for Batch for Certificate with one Print Request SENT_TO_PRINT_PROVIDER`() {
+            // Given
+            val batchId = aValidBatchId()
+            val pendingAssignmentPrintRequest = buildPrintRequest(
+                batchId = batchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minusSeconds(1)
+                    )
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(pendingAssignmentPrintRequest))
+            val expectedStatus = Status.RECEIVED_BY_PRINT_PROVIDER
+            val expectedEvent = buildPrintRequestStatus(status = expectedStatus)
+
+            // When
+            certificate.addReceivedByPrintProviderEventForBatch(batchId, expectedEvent.eventDateTime!!, expectedEvent.message)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(pendingAssignmentPrintRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
+            assertThat(pendingAssignmentPrintRequest.batchId).isEqualTo(batchId)
+        }
+
+        @Test
+        fun `should add RECEIVED_BY_PRINT_PROVIDER for Batch for Certificate with multiple Print Requests including one SENT_TO_PRINT_PROVIDER`() {
+            // Given
+            val failedBatchId = aValidBatchId()
+            val resendBatchId = aValidBatchId()
+            val failedPrintRequest = buildPrintRequest(
+                requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
+                batchId = failedBatchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(30, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(29, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.PRINT_PROVIDER_DISPATCH_FAILED,
+                        eventDateTime = Instant.now().minus(20, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val resendPrintRequest = buildPrintRequest(
+                requestDateTime = Instant.now().minus(1, ChronoUnit.DAYS),
+                batchId = resendBatchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(1, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(failedPrintRequest, resendPrintRequest))
+            val expectedStatus = Status.RECEIVED_BY_PRINT_PROVIDER
+            val expectedEvent = buildPrintRequestStatus(status = expectedStatus)
+
+            // When
+            certificate.addReceivedByPrintProviderEventForBatch(resendBatchId, expectedEvent.eventDateTime!!, expectedEvent.message)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(resendPrintRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
+            assertThat(resendPrintRequest.batchId).isEqualTo(resendBatchId)
+        }
+    }
+
+    @Nested
+    inner class RequeuePrintRequestForBatch {
+        @Test
+        fun `should requeuePrintRequestForBatch for Certificate with one Print Request SENT_TO_PRINT_PROVIDER`() {
+            // Given
+            val batchId = aValidBatchId()
+            val newRequestId = aValidRequestId()
+            val pendingAssignmentPrintRequest = buildPrintRequest(
+                batchId = batchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minusSeconds(1)
+                    )
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(pendingAssignmentPrintRequest))
+            val expectedStatus = Status.PENDING_ASSIGNMENT_TO_BATCH
+            val expectedEvent = buildPrintRequestStatus(status = expectedStatus)
+
+            // When
+            certificate.requeuePrintRequestForBatch(batchId, expectedEvent.eventDateTime!!, expectedEvent.message, newRequestId)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(pendingAssignmentPrintRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
+            assertThat(pendingAssignmentPrintRequest.batchId).isNull()
+            assertThat(pendingAssignmentPrintRequest.requestId).isEqualTo(newRequestId)
+        }
+
+        @Test
+        fun `should requeuePrintRequestForBatch for Certificate with multiple Print Requests including one SENT_TO_PRINT_PROVIDER`() {
+            // Given
+            val oldBatchId = aValidBatchId()
+            val batchIdBeingProcessed = aValidBatchId()
+            val newRequestId = aValidRequestId()
+            val oldPrintRequest = buildPrintRequest(
+                requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
+                batchId = oldBatchId,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(30, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.ASSIGNED_TO_BATCH,
+                        eventDateTime = Instant.now().minus(29, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.PRINT_PROVIDER_DISPATCH_FAILED,
+                        eventDateTime = Instant.now().minus(20, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val printRequestBeingProcessed = buildPrintRequest(
+                requestDateTime = Instant.now().minus(1, ChronoUnit.DAYS),
+                batchId = batchIdBeingProcessed,
+                printRequestStatuses = listOf(
+                    buildPrintRequestStatus(
+                        status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                        eventDateTime = Instant.now().minus(1, ChronoUnit.DAYS)
+                    ),
+                    buildPrintRequestStatus(
+                        status = Status.SENT_TO_PRINT_PROVIDER,
+                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
+                    ),
+                )
+            )
+            val certificate = buildCertificate(printRequests = listOf(oldPrintRequest, printRequestBeingProcessed))
+            val expectedStatus = Status.PENDING_ASSIGNMENT_TO_BATCH
+            val expectedEvent = buildPrintRequestStatus(status = expectedStatus)
+
+            // When
+            certificate.requeuePrintRequestForBatch(batchIdBeingProcessed, expectedEvent.eventDateTime!!, expectedEvent.message, newRequestId)
+
+            // Then
+            assertThat(certificate.status).isEqualTo(expectedStatus)
+            assertThat(printRequestBeingProcessed.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
+            assertThat(printRequestBeingProcessed.batchId).isNull()
+            assertThat(printRequestBeingProcessed.requestId).isEqualTo(newRequestId)
+        }
+    }
+
+    @Nested
+    inner class UpdatePrintRequestStatusByRequestId {
+
+        @Test
+        fun `should update status for Certificate with one Print Request with one status`() {
             // Given
             val printRequest = buildPrintRequest(
                 printRequestStatuses = listOf(
@@ -85,17 +397,18 @@ internal class CertificateTest {
             )
             val certificate = buildCertificate(printRequests = listOf(printRequest))
             val status = Status.VALIDATED_BY_PRINT_PROVIDER
+            val expectedEvent = buildPrintRequestStatus(status = status)
 
             // When
-            certificate.addStatus(status)
+            certificate.addPrintRequestEvent(printRequest.requestId!!, status, expectedEvent.eventDateTime!!, expectedEvent.message)
 
             // Then
             assertThat(certificate.status).isEqualTo(status)
-            assertThat(printRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
+            assertThat(printRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
         }
 
         @Test
-        fun `should add status for Certificate with one Print Request with multiple statuses`() {
+        fun `should update status for Certificate with one Print Request with multiple statuses`() {
             // Given
             val printRequest = buildPrintRequest(
                 printRequestStatuses = listOf(
@@ -115,17 +428,18 @@ internal class CertificateTest {
             )
             val certificate = buildCertificate(printRequests = listOf(printRequest))
             val status = Status.VALIDATED_BY_PRINT_PROVIDER
+            val expectedEvent = buildPrintRequestStatus(status = status)
 
             // When
-            certificate.addStatus(status)
+            certificate.addPrintRequestEvent(printRequest.requestId!!, status, expectedEvent.eventDateTime!!, expectedEvent.message)
 
             // Then
             assertThat(certificate.status).isEqualTo(status)
-            assertThat(printRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
+            assertThat(printRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
         }
 
         @Test
-        fun `should add status for Certificate with multiple Print Requests with multiple statuses`() {
+        fun `should update status for Certificate with multiple Print Requests with multiple statuses`() {
             // Given
             val firstPrintRequest = buildPrintRequest(
                 requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
@@ -172,13 +486,14 @@ internal class CertificateTest {
             )
             val certificate = buildCertificate(printRequests = listOf(firstPrintRequest, secondPrintRequest))
             val status = Status.VALIDATED_BY_PRINT_PROVIDER
+            val expectedEvent = buildPrintRequestStatus(status = status)
 
             // When
-            certificate.addStatus(status)
+            certificate.addPrintRequestEvent(secondPrintRequest.requestId!!, status, expectedEvent.eventDateTime!!, expectedEvent.message)
 
             // Then
             assertThat(certificate.status).isEqualTo(status)
-            assertThat(secondPrintRequest.statusHistory).extracting(PrintRequestStatus::status).contains(Tuple(status))
+            assertThat(secondPrintRequest.getCurrentStatus()).usingRecursiveComparison().isEqualTo(expectedEvent)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/entity/CertificateTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/entity/CertificateTest.kt
@@ -99,58 +99,12 @@ internal class CertificateTest {
             val expectedStatus = Status.ASSIGNED_TO_BATCH
 
             // When
-            certificate.addPrintRequestToBatch(batchId)
+            certificate.addPrintRequestToBatch(pendingAssignmentPrintRequest, batchId)
 
             // Then
             assertThat(certificate.status).isEqualTo(expectedStatus)
             assertThat(pendingAssignmentPrintRequest.getCurrentStatus().status).isEqualTo(expectedStatus)
             assertThat(pendingAssignmentPrintRequest.batchId).isEqualTo(batchId)
-        }
-
-        @Test
-        fun `should addPrintRequestToBatch for Certificate with multiple Print Requests including one PENDING_ASSIGNMENT_TO_BATCH`() {
-            // Given
-            val batchId = aValidBatchId()
-            val failedPrintRequest = buildPrintRequest(
-                requestDateTime = Instant.now().minus(30, ChronoUnit.DAYS),
-                printRequestStatuses = listOf(
-                    buildPrintRequestStatus(
-                        status = PENDING_ASSIGNMENT_TO_BATCH,
-                        eventDateTime = Instant.now().minus(30, ChronoUnit.DAYS)
-                    ),
-                    buildPrintRequestStatus(
-                        status = Status.ASSIGNED_TO_BATCH,
-                        eventDateTime = Instant.now().minus(29, ChronoUnit.DAYS)
-                    ),
-                    buildPrintRequestStatus(
-                        status = SENT_TO_PRINT_PROVIDER,
-                        eventDateTime = Instant.now().minus(28, ChronoUnit.DAYS)
-                    ),
-                    buildPrintRequestStatus(
-                        status = Status.PRINT_PROVIDER_DISPATCH_FAILED,
-                        eventDateTime = Instant.now().minus(20, ChronoUnit.DAYS)
-                    ),
-                )
-            )
-            val printRequestToIncludeInBatch = buildPrintRequest(
-                requestDateTime = Instant.now().minus(1, ChronoUnit.DAYS),
-                printRequestStatuses = listOf(
-                    buildPrintRequestStatus(
-                        status = PENDING_ASSIGNMENT_TO_BATCH,
-                        eventDateTime = Instant.now().minus(1, ChronoUnit.DAYS)
-                    )
-                )
-            )
-            val certificate = buildCertificate(printRequests = listOf(failedPrintRequest, printRequestToIncludeInBatch))
-            val expectedStatus = Status.ASSIGNED_TO_BATCH
-
-            // When
-            certificate.addPrintRequestToBatch(batchId)
-
-            // Then
-            assertThat(certificate.status).isEqualTo(expectedStatus)
-            assertThat(printRequestToIncludeInBatch.getCurrentStatus().status).isEqualTo(expectedStatus)
-            assertThat(printRequestToIncludeInBatch.batchId).isEqualTo(batchId)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -164,7 +164,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 )
                 .isEqualTo(expected)
             assertThat(saved.status).isEqualTo(Status.PENDING_ASSIGNMENT_TO_BATCH)
-            assertThat(saved.getCurrentPrintRequest().requestId).containsPattern(Regex("^[a-f\\d]{24}$").pattern)
+            assertThat(saved.printRequests[0].requestId).containsPattern(Regex("^[a-f\\d]{24}$").pattern)
             assertThat(saved.vacNumber).containsPattern(Regex("^[A-Za-z\\d]{20}$").pattern)
         }
     }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/FilenameFactoryTest.kt
@@ -3,6 +3,8 @@ package uk.gov.dluhc.printapi.service
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.database.entity.Status
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneId
@@ -22,9 +24,11 @@ internal class FilenameFactoryTest {
         // Given
         val batchId = "05372cf5339447b39f98b248c2217b9f"
         val count = 10
+        val certificates = (1..count)
+            .map { buildCertificate(batchId = batchId, status = Status.ASSIGNED_TO_BATCH) }
 
         // When
-        val filename = filenameFactory.createZipFilename(batchId, count)
+        val filename = filenameFactory.createZipFilename(batchId, certificates)
 
         // Then
         assertThat(filename).isEqualTo("05372cf5339447b39f98b248c2217b9f-20221018112232123-10.zip")
@@ -35,9 +39,11 @@ internal class FilenameFactoryTest {
         // Given
         val batchId = "49825273c8e64dd885886b74883b8bb3"
         val count = 19
+        val certificates = (1..count)
+            .map { buildCertificate(batchId = batchId, status = Status.ASSIGNED_TO_BATCH) }
 
         // When
-        val filename = filenameFactory.createPrintRequestsFilename(batchId, count)
+        val filename = filenameFactory.createPrintRequestsFilename(batchId, certificates)
 
         // Then
         assertThat(filename).isEqualTo("49825273c8e64dd885886b74883b8bb3-20221018112232123-19.psv")

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
@@ -9,12 +9,14 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.mapper.CertificateToPrintRequestMapper
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidPrintRequestsFilename
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
 import uk.gov.dluhc.printapi.testsupport.testdata.model.aPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoZipPath
@@ -41,7 +43,12 @@ internal class PrintFileDetailsFactoryTest {
         val batchId = aValidBatchId()
         val requestId = aValidRequestId()
         val photoArn = aPhotoArn()
-        val currentPrintRequest = buildPrintRequest(batchId = batchId, requestId = requestId, photoLocationArn = photoArn)
+        val currentPrintRequest = buildPrintRequest(
+            batchId = batchId,
+            printRequestStatuses = listOf(buildPrintRequestStatus(status = Status.ASSIGNED_TO_BATCH)),
+            requestId = requestId,
+            photoLocationArn = photoArn
+        )
         val certificate = buildCertificate(
             printRequests = mutableListOf(currentPrintRequest)
         )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
@@ -65,7 +65,7 @@ internal class PrintFileDetailsFactoryTest {
         val fileDetails = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
 
         // Then
-        verify(filenameFactory).createPrintRequestsFilename(batchId, 1)
+        verify(filenameFactory).createPrintRequestsFilename(batchId, certificates)
         verify(photoLocationFactory).create(batchId, requestId, photoArn)
         verify(certificateToPrintRequestMapper).map(certificate, currentPrintRequest, zipPath)
         assertThat(fileDetails.printRequestsFilename).isEqualTo(psvFilename)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingServiceTest.kt
@@ -145,16 +145,20 @@ class PrintResponseProcessingServiceTest {
             service.processBatchResponses(listOf(batchResponse1, batchResponse2))
 
             // Then
-            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(SENT_TO_PRINT_PROVIDER, batchResponse1.batchId)
-            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(SENT_TO_PRINT_PROVIDER, batchResponse2.batchId)
+            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(
+                SENT_TO_PRINT_PROVIDER,
+                batchResponse1.batchId
+            )
+            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(
+                SENT_TO_PRINT_PROVIDER,
+                batchResponse2.batchId
+            )
             verify(certificateRepository).saveAll(listOf(certificate1))
             verify(certificateRepository).saveAll(listOf(certificate2))
-            assertThat(certificate1.getCurrentPrintRequest().requestId).isEqualTo(newRequestId)
-            assertThat(certificate1.getCurrentPrintRequest().batchId).isNull()
-            assertThat(
-                certificate1.getCurrentPrintRequest().statusHistory.sortedByDescending { it.eventDateTime }
-                    .first()
-            )
+            val printRequest1 = certificate1.printRequests[0]
+            assertThat(printRequest1.requestId).isEqualTo(newRequestId)
+            assertThat(printRequest1.batchId).isNull()
+            assertThat(printRequest1.statusHistory.sortedByDescending { it.eventDateTime }.first())
                 .usingRecursiveComparison().isEqualTo(
                     PrintRequestStatus(
                         status = PENDING_ASSIGNMENT_TO_BATCH,
@@ -162,10 +166,7 @@ class PrintResponseProcessingServiceTest {
                         message = batchResponse1.message
                     )
                 )
-            assertThat(
-                certificate2.getCurrentPrintRequest().statusHistory.sortedByDescending { it.eventDateTime }
-                    .first()
-            )
+            assertThat(certificate2.printRequests[0].statusHistory.sortedByDescending { it.eventDateTime }.first())
                 .usingRecursiveComparison().isEqualTo(
                     PrintRequestStatus(
                         status = RECEIVED_BY_PRINT_PROVIDER,
@@ -209,10 +210,7 @@ class PrintResponseProcessingServiceTest {
             verify(certificateRepository).getByPrintRequestsRequestId(requestId)
             verify(certificateRepository).save(certificate)
             assertThat(certificate.status).isEqualTo(expectedStatus)
-            assertThat(
-                certificate.getCurrentPrintRequest().statusHistory.sortedByDescending { it.eventDateTime }
-                    .first()
-            )
+            assertThat(certificate.printRequests[0].statusHistory.sortedByDescending { it.eventDateTime }.first())
                 .usingRecursiveComparison().isEqualTo(
                     PrintRequestStatus(
                         status = expectedStatus,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintResponseProcessingServiceTest.kt
@@ -137,7 +137,7 @@ class PrintResponseProcessingServiceTest {
             )
 
             val newRequestId = aValidRequestId()
-            given(certificateRepository.findByStatusAndPrintRequestsBatchId(any(), any()))
+            given(certificateRepository.findByPrintRequestsBatchId(any()))
                 .willReturn(listOf(certificate1), listOf(certificate2))
             given(idFactory.requestId()).willReturn(newRequestId)
 
@@ -145,14 +145,8 @@ class PrintResponseProcessingServiceTest {
             service.processBatchResponses(listOf(batchResponse1, batchResponse2))
 
             // Then
-            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(
-                SENT_TO_PRINT_PROVIDER,
-                batchResponse1.batchId
-            )
-            verify(certificateRepository).findByStatusAndPrintRequestsBatchId(
-                SENT_TO_PRINT_PROVIDER,
-                batchResponse2.batchId
-            )
+            verify(certificateRepository).findByPrintRequestsBatchId(batchResponse1.batchId)
+            verify(certificateRepository).findByPrintRequestsBatchId(batchResponse2.batchId)
             verify(certificateRepository).saveAll(listOf(certificate1))
             verify(certificateRepository).saveAll(listOf(certificate2))
             val printRequest1 = certificate1.printRequests[0]

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.given
 import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.database.entity.Status.ASSIGNED_TO_BATCH
+import uk.gov.dluhc.printapi.database.entity.Status
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidInputStream
@@ -44,12 +44,12 @@ internal class ProcessPrintBatchServiceTest {
     fun `should send file to SFTP`() {
         // Given
         val batchId = aValidBatchId()
-        val certificates = listOf(buildCertificate())
+        val certificates = listOf(buildCertificate(status = Status.ASSIGNED_TO_BATCH))
         val fileDetails = aFileDetails()
         val sftpInputStream = aValidInputStream()
         val zipFilename = aValidZipFilename()
         val sftpPath = aValidSftpPath()
-        given(certificateRepository.findByStatusAndPrintRequestsBatchId(any(), any())).willReturn(certificates)
+        given(certificateRepository.findByPrintRequestsBatchId(any())).willReturn(certificates)
         given(printFileDetailsFactory.createFileDetailsFromCertificates(any(), any())).willReturn(fileDetails)
         given(sftpZipInputStreamProvider.createSftpInputStream(any())).willReturn(sftpInputStream)
         given(filenameFactory.createZipFilename(any(), any())).willReturn(zipFilename)
@@ -59,7 +59,7 @@ internal class ProcessPrintBatchServiceTest {
         processPrintBatchService.processBatch(batchId)
 
         // Then
-        verify(certificateRepository).findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
+        verify(certificateRepository).findByPrintRequestsBatchId(batchId)
         verify(printFileDetailsFactory).createFileDetailsFromCertificates(batchId, certificates)
         verify(sftpZipInputStreamProvider).createSftpInputStream(fileDetails)
         verify(filenameFactory).createZipFilename(batchId, certificates.size)
@@ -71,13 +71,13 @@ internal class ProcessPrintBatchServiceTest {
         // Given
         val batchId = "4143d442a2424740afa3ce5eae630aad"
         val certificates = emptyList<Certificate>()
-        given(certificateRepository.findByStatusAndPrintRequestsBatchId(any(), any())).willReturn(certificates)
+        given(certificateRepository.findByPrintRequestsBatchId(any())).willReturn(certificates)
 
         // When
         val error = catchThrowable { processPrintBatchService.processBatch(batchId) }
 
         // Then
-        verify(certificateRepository).findByStatusAndPrintRequestsBatchId(ASSIGNED_TO_BATCH, batchId)
+        verify(certificateRepository).findByPrintRequestsBatchId(batchId)
         assertThat(error).hasMessage("No certificates found for batchId = 4143d442a2424740afa3ce5eae630aad and status = ASSIGNED_TO_BATCH")
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/ProcessPrintBatchServiceTest.kt
@@ -62,7 +62,7 @@ internal class ProcessPrintBatchServiceTest {
         verify(certificateRepository).findByPrintRequestsBatchId(batchId)
         verify(printFileDetailsFactory).createFileDetailsFromCertificates(batchId, certificates)
         verify(sftpZipInputStreamProvider).createSftpInputStream(fileDetails)
-        verify(filenameFactory).createZipFilename(batchId, certificates.size)
+        verify(filenameFactory).createZipFilename(batchId, certificates)
         verify(sftpService).sendFile(sftpInputStream, zipFilename)
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
@@ -73,3 +73,5 @@ fun aValidEmailAddress(): String = "contact@${aValidEroName().replaceSpacesWith(
 fun aValidWebsite(): String = "https://${aValidEroName().replaceSpacesWith("-")}.gov.uk"
 
 fun aValidPrintRequestStatusEventDateTime(): Instant = Instant.now().truncatedTo(SECONDS)
+
+fun aValidEventMessage(): String = faker.harryPotter().spell()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidAddressFormat
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReceivedDateTime
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidBatchId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateLanguage
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateStatus
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidDeliveryAddressType
@@ -48,14 +49,18 @@ fun buildCertificate(
     id: UUID? = UUID.randomUUID(),
     vacNumber: String = aValidVacNumber(),
     status: Status = aValidCertificateStatus(),
+    batchId: String = aValidBatchId(),
     printRequests: List<PrintRequest> = listOf(
-        buildPrintRequest(printRequestStatuses = listOf(buildPrintRequestStatus(status = status)))
+        buildPrintRequest(
+            batchId = batchId,
+            printRequestStatuses = listOf(buildPrintRequestStatus(status = status))
+        )
     ),
     gssCode: String = aGssCode(),
     sourceType: SourceType = aValidSourceType(),
     sourceReference: String = aValidSourceReference(),
     applicationReceivedDateTime: Instant = aValidApplicationReceivedDateTime(),
-    applicationReference: String = aValidApplicationReference()
+    applicationReference: String = aValidApplicationReference(),
 ): Certificate {
     val certificate = Certificate(
         id = id,


### PR DESCRIPTION
Original implementation had data structure to support multiple print requests per Certificate but the code was simplified to act against the current (only) print request in the various flows.  This PR updates the codebase to select the relevant Print Request based on one of its status, its assigned batch or its request id.  Refactored `getCurrentPrintRequest()` to be private in the Certificate.