### PR TITLE
EIP1-3454 - Set Welsh Issuing Authority as the Welsh LA Name

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -60,6 +60,9 @@ class Certificate(
     @field:Size(max = 255)
     var issuingAuthority: String? = null,
 
+    @field:Size(max = 255)
+    var issuingAuthorityCy: String? = null,
+
     @field:NotNull
     var issueDate: LocalDate = LocalDate.now(),
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
@@ -6,9 +6,7 @@ import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 import uk.gov.dluhc.printapi.dto.EroDto
-import uk.gov.dluhc.printapi.messaging.models.CertificateLanguage
 import uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage
 import uk.gov.dluhc.printapi.service.IdFactory
 
@@ -23,7 +21,7 @@ abstract class CertificateMapper {
 
     @Mapping(target = "vacNumber", expression = "java( idFactory.vacNumber() )")
     @Mapping(source = "ero.englishContactDetails.name", target = "issuingAuthority")
-    @Mapping(expression = "java( welshIssuingAuthorityName(message, ero.getWelshContactDetails()) )", target = "issuingAuthorityCy")
+    @Mapping(source = "ero.welshContactDetails.name", target = "issuingAuthorityCy")
     abstract fun toCertificate(
         message: SendApplicationToPrintMessage,
         ero: EroDto
@@ -36,13 +34,5 @@ abstract class CertificateMapper {
         @MappingTarget certificate: Certificate
     ) {
         certificate.addPrintRequest(printRequestMapper.toPrintRequest(message, ero))
-    }
-
-    protected fun welshIssuingAuthorityName(message: SendApplicationToPrintMessage, welshContactDetails: EroContactDetailsDto?): String? {
-        return if (message.certificateLanguage == CertificateLanguage.CY && welshContactDetails != null) {
-            welshContactDetails.name
-        } else {
-            null
-        }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
@@ -6,7 +6,9 @@ import org.mapstruct.Mapping
 import org.mapstruct.MappingTarget
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.printapi.database.entity.Certificate
+import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 import uk.gov.dluhc.printapi.dto.EroDto
+import uk.gov.dluhc.printapi.messaging.models.CertificateLanguage
 import uk.gov.dluhc.printapi.messaging.models.SendApplicationToPrintMessage
 import uk.gov.dluhc.printapi.service.IdFactory
 
@@ -21,6 +23,7 @@ abstract class CertificateMapper {
 
     @Mapping(target = "vacNumber", expression = "java( idFactory.vacNumber() )")
     @Mapping(source = "ero.englishContactDetails.name", target = "issuingAuthority")
+    @Mapping(expression = "java( welshIssuingAuthorityName(message, ero.getWelshContactDetails()) )", target = "issuingAuthorityCy")
     abstract fun toCertificate(
         message: SendApplicationToPrintMessage,
         ero: EroDto
@@ -33,5 +36,13 @@ abstract class CertificateMapper {
         @MappingTarget certificate: Certificate
     ) {
         certificate.addPrintRequest(printRequestMapper.toPrintRequest(message, ero))
+    }
+
+    protected fun welshIssuingAuthorityName(message: SendApplicationToPrintMessage, welshContactDetails: EroContactDetailsDto?): String? {
+        return if (message.certificateLanguage == CertificateLanguage.CY && welshContactDetails != null) {
+            welshContactDetails.name
+        } else {
+            null
+        }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapper.kt
@@ -52,7 +52,7 @@ abstract class CertificateToPrintRequestMapper {
     @Mapping(source = "printRequest.eroWelsh.address.area", target = "eroDeliveryAreaCy")
     @Mapping(source = "printRequest.eroWelsh.address.postcode", target = "eroDeliveryPostcodeCy")
     @Mapping(source = "printRequest.eroWelsh.emailAddress", target = "eroEmailAddressCy")
-    @Mapping(source = "printRequest.eroWelsh.name", target = "issuingAuthorityCy")
+    @Mapping(source = "certificate.issuingAuthorityCy", target = "issuingAuthorityCy")
     @Mapping(source = "printRequest.requestDateTime", target = "requestDateTime")
     @Mapping(source = "photoZipPath", target = "photo")
     abstract fun map(certificate: Certificate, printRequest: uk.gov.dluhc.printapi.database.entity.PrintRequest, photoZipPath: String): PrintRequest

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -14,4 +14,6 @@
     <include relativeToChangelogFile="true" file="ddl/0006_add_index_event_date_time_status_to_print_request_status.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0007_EIP1-2781_alter_print_request.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0008_EIP1-2833_alter_delivery.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0009_EIP1-3454_alter_certificate.xml"/>
+    <include relativeToChangelogFile="true" file="migration/0001_EIP1-3454_update_certificate.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0009_EIP1-3454_alter_certificate.xml
+++ b/src/main/resources/db/changelog/ddl/0009_EIP1-3454_alter_certificate.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="nathan.russell@valtech.com" id="0009_EIP1-3454_alter_certificate - add issuing_authority_cy column" context="ddl">
+
+        <addColumn tableName="certificate">
+            <column name="issuing_authority_cy" type="varchar(255)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn
+                tableName="certificate"
+                columnName="issuing_authority_cy"
+            />
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/migration/0001_EIP1-3454_update_certificate.xml
+++ b/src/main/resources/db/changelog/migration/0001_EIP1-3454_update_certificate.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="nathan.russell@valtech.com" id="0001_EIP1-3454_update_certificate - populate issuing_authority_cy column">
+        <sql>
+            <comment>
+                Set issuing_authority_cy to the best value we can for existing Welsh language certificates.
+                Setting this field for existing certificates will prevent null pointer exceptions if these certificates are ever reprinted.
+                The 'best value' we can set is `Swyddog Cofrestru Etholiadol` which translates as `Electoral Registration Officer` rather than the actual Welsh Issuing Authority.
+                This is deemed acceptable as that is the value that would have been printed (incorrectly) on the original certificate when printed for the first time.
+                Over and above that we do not have the Welsh Local Authority name in the context of the execution of this running liquibase migration - the actual value is only
+                available at runtime when we call the ERO Management REST API to get the relevant ERO and local authorities.
+
+                This is not guaranteed to fix all Welsh certificates unfortunately. There are some certificates in the production database that are meant to be Welsh/Dual Language
+                but have their `certificate_language` field set to `EN`. This is because they were created before bugfix EIP1-3314 was deployed and their `certificate_language` field
+                was incorrectly set based on the language the applicant used when creating their initial application on the IER site. We have no way of easily identifying those records.
+                (We could possibly identify them via their gssCode starting with `W` but we won't have the rest of the Welsh LA data such as address etc to correct all of the data)
+            </comment>
+            UPDATE certificate c
+            INNER JOIN print_request pr on c.id = pr.certificate_id
+            SET c.issuing_authority_cy = 'Swyddog Cofrestru Etholiadol'
+            WHERE pr.certificate_language = 'CY'
+        </sql>
+
+        <rollback/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
@@ -1,10 +1,8 @@
 package uk.gov.dluhc.printapi.mapper
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -35,7 +33,6 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.OffsetDateTime
 import java.time.ZoneOffset.UTC
-import java.util.stream.Stream
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateFormat as PrintRequestCertificateFormat
 import uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateLanguage as PrintRequestCertificateLanguage
 
@@ -55,49 +52,45 @@ class CertificateToPrintRequestMapperTest {
     private lateinit var certificateLanguageMapper: CertificateLanguageMapper
 
     companion object {
-        @JvmStatic
-        private fun welshEro(): Stream<Arguments> {
-            return Stream.of(
-                Arguments.of(null),
-                Arguments.of(buildElectoralRegistrationOffice(name = aValidLocalAuthorityName())),
-            )
-        }
-    }
-
-    @ParameterizedTest
-    @MethodSource("welshEro")
-    fun `should map ERO response to dto with optional Welsh ERO translation`(eroWelsh: ElectoralRegistrationOffice?) {
-        // Given
-        given(supportingInformationFormatMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateFormat.STANDARD)
-        given(certificateLanguageMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateLanguage.EN)
-        given(instantMapper.toOffsetDateTime(any())).willReturn(OffsetDateTime.ofInstant(Instant.ofEpochMilli(0), UTC))
-
-        val requestId: String = aValidRequestId()
-        val sourceReference: String = aValidSourceReference()
-        val applicationReference: String = aValidApplicationReference()
-        val vacNumber: String = aValidVacNumber()
-        val vacVersion = "1"
-        val sourceType: SourceType = SourceType.VOTER_CARD
-        val requestDateTime: Instant = Instant.ofEpochMilli(0)
-        val firstName = "John"
-        val middleNames = "Anthony Barry"
-        val surname = "Doe"
-        val certificateLanguage = CertificateLanguage.EN
-        val supportingInformationFormat = SupportingInformationFormat.STANDARD
-        val delivery = buildDelivery()
-        val gssCode: String = getRandomGssCode()
-        val issuingAuthority: String = aValidLocalAuthorityName()
-        val issueDate = LocalDate.of(2022, 10, 21)
-        val suggestedExpiryDate = LocalDate.of(2032, 10, 21)
-        val eroEnglish: ElectoralRegistrationOffice = buildElectoralRegistrationOffice(name = issuingAuthority)
-        val photoLocation = aPhotoArn()
-        val statusHistory = mutableListOf(
+        private val requestId: String = aValidRequestId()
+        private val sourceReference: String = aValidSourceReference()
+        private val applicationReference: String = aValidApplicationReference()
+        private val vacNumber: String = aValidVacNumber()
+        private val vacVersion = "1"
+        private val sourceType: SourceType = SourceType.VOTER_CARD
+        private val requestDateTime: Instant = Instant.ofEpochMilli(0)
+        private val firstName = "John"
+        private val middleNames = "Anthony Barry"
+        private val surname = "Doe"
+        private val supportingInformationFormat = SupportingInformationFormat.STANDARD
+        private val delivery = buildDelivery()
+        private val gssCode: String = getRandomGssCode()
+        private val issuingAuthorityEn = aValidLocalAuthorityName()
+        private val issueDate = LocalDate.of(2022, 10, 21)
+        private val suggestedExpiryDate = LocalDate.of(2032, 10, 21)
+        private val photoLocation = aPhotoArn()
+        private val statusHistory = mutableListOf(
             PrintRequestStatus(
                 status = Status.PENDING_ASSIGNMENT_TO_BATCH,
                 eventDateTime = Instant.now()
             )
         )
-        val batchId = aValidBatchId()
+        private val batchId = aValidBatchId()
+        private val photoZipPath: String = aPhotoZipPath()
+    }
+
+    @Test
+    fun `should map to print request with English ERO`() {
+        // Given
+        given(certificateLanguageMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateLanguage.EN)
+
+        given(supportingInformationFormatMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateFormat.STANDARD)
+        given(instantMapper.toOffsetDateTime(any())).willReturn(OffsetDateTime.ofInstant(Instant.ofEpochMilli(0), UTC))
+
+        val certificateLanguage = CertificateLanguage.EN
+
+        val eroEnglish: ElectoralRegistrationOffice = buildElectoralRegistrationOffice(name = issuingAuthorityEn)
+
         val printRequest = PrintRequest(
             requestId = requestId,
             vacVersion = vacVersion,
@@ -110,7 +103,7 @@ class CertificateToPrintRequestMapperTest {
             photoLocationArn = photoLocation,
             delivery = delivery,
             eroEnglish = eroEnglish,
-            eroWelsh = eroWelsh,
+            eroWelsh = null,
             batchId = batchId,
             userId = aValidUserId(),
             statusHistory = statusHistory
@@ -121,14 +114,14 @@ class CertificateToPrintRequestMapperTest {
             sourceReference = sourceReference,
             applicationReference = applicationReference,
             applicationReceivedDateTime = Instant.now(),
-            issuingAuthority = issuingAuthority,
+            issuingAuthority = issuingAuthorityEn,
+            issuingAuthorityCy = null,
             issueDate = issueDate,
             suggestedExpiryDate = suggestedExpiryDate,
             status = Status.PENDING_ASSIGNMENT_TO_BATCH,
             gssCode = gssCode,
             printRequests = mutableListOf(printRequest)
         )
-        val photoZipPath: String = aPhotoZipPath()
 
         val expected = uk.gov.dluhc.printapi.printprovider.models.PrintRequest()
         expected.requestId = requestId
@@ -162,18 +155,119 @@ class CertificateToPrintRequestMapperTest {
         expected.eroDeliveryTownEn = eroEnglish.address?.town
         expected.eroDeliveryAreaEn = eroEnglish.address?.area
         expected.eroDeliveryPostcodeEn = eroEnglish.address?.postcode
-        // Optional Welsh translation expectations
-        expected.issuingAuthorityCy = eroWelsh?.name
-        expected.eroNameCy = eroWelsh?.name
-        expected.eroPhoneNumberCy = eroWelsh?.phoneNumber
-        expected.eroEmailAddressCy = eroWelsh?.emailAddress
-        expected.eroWebsiteCy = eroWelsh?.website
-        expected.eroDeliveryStreetCy = eroWelsh?.address?.street
-        expected.eroDeliveryPropertyCy = eroWelsh?.address?.property
-        expected.eroDeliveryLocalityCy = eroWelsh?.address?.locality
-        expected.eroDeliveryTownCy = eroWelsh?.address?.town
-        expected.eroDeliveryAreaCy = eroWelsh?.address?.area
-        expected.eroDeliveryPostcodeCy = eroWelsh?.address?.postcode
+        // Welsh fields
+        expected.issuingAuthorityCy = null
+        expected.eroNameCy = null
+        expected.eroPhoneNumberCy = null
+        expected.eroEmailAddressCy = null
+        expected.eroWebsiteCy = null
+        expected.eroDeliveryStreetCy = null
+        expected.eroDeliveryPropertyCy = null
+        expected.eroDeliveryLocalityCy = null
+        expected.eroDeliveryTownCy = null
+        expected.eroDeliveryAreaCy = null
+        expected.eroDeliveryPostcodeCy = null
+
+        // When
+        val actual = mapper.map(certificate, printRequest, photoZipPath)
+
+        // Then
+        assertThat(actual).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expected)
+        verify(supportingInformationFormatMapper).toPrintRequestApiEnum(supportingInformationFormat)
+        verify(certificateLanguageMapper).toPrintRequestApiEnum(certificateLanguage)
+    }
+
+    @Test
+    fun `should map to print request with Welsh ERO`() {
+        // Given
+        given(certificateLanguageMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateLanguage.CY)
+
+        given(supportingInformationFormatMapper.toPrintRequestApiEnum(any())).willReturn(PrintRequestCertificateFormat.STANDARD)
+        given(instantMapper.toOffsetDateTime(any())).willReturn(OffsetDateTime.ofInstant(Instant.ofEpochMilli(0), UTC))
+
+        val certificateLanguage = CertificateLanguage.CY
+
+        val issuingAuthorityCy = aValidLocalAuthorityName()
+
+        val eroWelsh = buildElectoralRegistrationOffice(name = issuingAuthorityCy)
+        val eroEnglish: ElectoralRegistrationOffice = buildElectoralRegistrationOffice(name = issuingAuthorityEn)
+
+        val printRequest = PrintRequest(
+            requestId = requestId,
+            vacVersion = vacVersion,
+            requestDateTime = requestDateTime,
+            firstName = firstName,
+            middleNames = middleNames,
+            surname = surname,
+            certificateLanguage = certificateLanguage,
+            supportingInformationFormat = supportingInformationFormat,
+            photoLocationArn = photoLocation,
+            delivery = delivery,
+            eroEnglish = eroEnglish,
+            eroWelsh = eroWelsh,
+            batchId = batchId,
+            userId = aValidUserId(),
+            statusHistory = statusHistory
+        )
+        val certificate = Certificate(
+            vacNumber = vacNumber,
+            sourceType = sourceType,
+            sourceReference = sourceReference,
+            applicationReference = applicationReference,
+            applicationReceivedDateTime = Instant.now(),
+            issuingAuthority = issuingAuthorityEn,
+            issuingAuthorityCy = issuingAuthorityCy,
+            issueDate = issueDate,
+            suggestedExpiryDate = suggestedExpiryDate,
+            status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+            gssCode = gssCode,
+            printRequests = mutableListOf(printRequest)
+        )
+
+        val expected = uk.gov.dluhc.printapi.printprovider.models.PrintRequest()
+        expected.requestId = requestId
+        expected.issuingAuthorityEn = eroEnglish.name
+        expected.issueDate = issueDate
+        expected.suggestedExpiryDate = suggestedExpiryDate
+        expected.requestDateTime = requestDateTime.atOffset(UTC)
+        expected.cardFirstname = firstName
+        expected.cardMiddleNames = middleNames
+        expected.cardSurname = surname
+        expected.cardVersion = vacVersion
+        expected.cardNumber = vacNumber
+        expected.certificateLanguage = uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateLanguage.CY
+        expected.certificateFormat = uk.gov.dluhc.printapi.printprovider.models.PrintRequest.CertificateFormat.STANDARD
+        expected.deliveryOption = uk.gov.dluhc.printapi.printprovider.models.PrintRequest.DeliveryOption.STANDARD
+        expected.photo = photoZipPath
+        expected.deliveryName = delivery.addressee
+        expected.deliveryStreet = delivery.address.street
+        expected.deliveryProperty = delivery.address.property
+        expected.deliveryLocality = delivery.address.locality
+        expected.deliveryTown = delivery.address.town
+        expected.deliveryArea = delivery.address.area
+        expected.deliveryPostcode = delivery.address.postcode
+        expected.eroNameEn = eroEnglish.name
+        expected.eroPhoneNumberEn = eroEnglish.phoneNumber
+        expected.eroEmailAddressEn = eroEnglish.emailAddress
+        expected.eroWebsiteEn = eroEnglish.website
+        expected.eroDeliveryStreetEn = eroEnglish.address?.street
+        expected.eroDeliveryPropertyEn = eroEnglish.address?.property
+        expected.eroDeliveryLocalityEn = eroEnglish.address?.locality
+        expected.eroDeliveryTownEn = eroEnglish.address?.town
+        expected.eroDeliveryAreaEn = eroEnglish.address?.area
+        expected.eroDeliveryPostcodeEn = eroEnglish.address?.postcode
+        // Welsh fields
+        expected.issuingAuthorityCy = eroWelsh.name
+        expected.eroNameCy = eroWelsh.name
+        expected.eroPhoneNumberCy = eroWelsh.phoneNumber
+        expected.eroEmailAddressCy = eroWelsh.emailAddress
+        expected.eroWebsiteCy = eroWelsh.website
+        expected.eroDeliveryStreetCy = eroWelsh.address?.street
+        expected.eroDeliveryPropertyCy = eroWelsh.address?.property
+        expected.eroDeliveryLocalityCy = eroWelsh.address?.locality
+        expected.eroDeliveryTownCy = eroWelsh.address?.town
+        expected.eroDeliveryAreaCy = eroWelsh.address?.area
+        expected.eroDeliveryPostcodeCy = eroWelsh.address?.postcode
 
         // When
         val actual = mapper.map(certificate, printRequest, photoZipPath)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -45,7 +45,11 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
         )
         val localAuthority = ero.localAuthorities[1]
         val gssCode = localAuthority.gssCode
-        val payload = buildSendApplicationToPrintMessage(gssCode = gssCode, supportingInformationFormat = EASY_MINUS_READ)
+        val payload = buildSendApplicationToPrintMessage(
+            gssCode = gssCode,
+            supportingInformationFormat = EASY_MINUS_READ,
+            certificateLanguage = uk.gov.dluhc.printapi.messaging.models.CertificateLanguage.CY
+        )
         wireMockService.stubEroManagementGetEroByGssCode(ero, gssCode)
 
         val expected = with(payload) {
@@ -58,6 +62,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 applicationReceivedDateTime = applicationReceivedDateTime.toInstant(),
                 gssCode = gssCode,
                 issuingAuthority = localAuthority.name,
+                issuingAuthorityCy = localAuthority.name,
                 issueDate = LocalDate.now(),
             )
             val printRequest = PrintRequest(
@@ -67,7 +72,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 firstName = firstName,
                 middleNames = middleNames,
                 surname = surname,
-                certificateLanguage = CertificateLanguage.EN,
+                certificateLanguage = CertificateLanguage.CY,
                 supportingInformationFormat = SupportingInformationFormat.EASY_READ,
                 photoLocationArn = photoLocation,
                 delivery = with(delivery) {


### PR DESCRIPTION
This PR fixes bug EIP1-3454 by setting the Welsh Local Authority name on the printed certificate to the Welsh LA Name from the Certificate's `issuingAuthorityCy` field (rather than the slightly confusing `name` field from the Print Request's `eroWelsh` field)

The Certificate's `issuingAuthorityCy` is set from the ERO's Welsh Contact Details when the Certificate is first persisted to the database (as we do with the English issuing authority)
