### PR TITLE
Bugfix EIP1-3454 - use new ero management API

### DIFF
--- a/.github/workflows/build-image-and-deploy-to-dev.yml
+++ b/.github/workflows/build-image-and-deploy-to-dev.yml
@@ -3,13 +3,13 @@ name: Build image and deploy to dev
 on:
   push:
     branches:
-      - bugfix/EIP1-3454-fix-welsh-local-authority-name-build
+      - main
 
 jobs:
   build-and-tag:
     runs-on: ubuntu-latest
     outputs:
-      version: v1.0.117.1
+      version: ${{ steps.bump-semver.outputs.new_version }}
     steps:
       - uses: actions/checkout@v3
 
@@ -31,12 +31,33 @@ jobs:
           java-version: 17
           cache: gradle
 
+      - name: Get latest version tag
+        uses: actions-ecosystem/action-get-latest-tag@v1
+        id: get-latest-tag
+        with:
+          semver_only: true
+          with_initial_version: true
+          initial_version: v1.0.0
+
+      - name: Bump version tag
+        uses: cabinetoffice/action-bump-semver@v1
+        id: bump-semver
+        with:
+          current_version: ${{ steps.get-latest-tag.outputs.tag }}
+          level: patch
+
+      - name: Push version tag
+        uses: actions-ecosystem/action-push-tag@v1
+        with:
+          tag: ${{ steps.bump-semver.outputs.new_version }}
+          message: "${{ github.event.head_commit.message }}"
+
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: print-api-repo
-          IMAGE_TAG: v1.0.117.1
+          IMAGE_TAG: ${{ steps.bump-semver.outputs.new_version }}
         run: |
           ./gradlew bootBuildImage
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -60,7 +81,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-live.outputs.registry }}
           ECR_REPOSITORY: print-api-repo
-          IMAGE_TAG: v1.0.117.1
+          IMAGE_TAG: ${{ steps.bump-semver.outputs.new_version }}
         run: |
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker tag eip-ero-print-api:latest $IMAGE
@@ -71,6 +92,6 @@ jobs:
     needs: build-and-tag
     uses: ./.github/workflows/deploy.yml
     with:
-      deploy_environment: test
+      deploy_environment: dev
       version: ${{ needs.build-and-tag.outputs.version }}
     secrets: inherit

--- a/.github/workflows/build-image-and-deploy-to-dev.yml
+++ b/.github/workflows/build-image-and-deploy-to-dev.yml
@@ -3,13 +3,13 @@ name: Build image and deploy to dev
 on:
   push:
     branches:
-      - main
+      - bugfix/EIP1-3454-fix-welsh-local-authority-name-build
 
 jobs:
   build-and-tag:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.bump-semver.outputs.new_version }}
+      version: v1.0.117.1
     steps:
       - uses: actions/checkout@v3
 
@@ -31,33 +31,12 @@ jobs:
           java-version: 17
           cache: gradle
 
-      - name: Get latest version tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        id: get-latest-tag
-        with:
-          semver_only: true
-          with_initial_version: true
-          initial_version: v1.0.0
-
-      - name: Bump version tag
-        uses: cabinetoffice/action-bump-semver@v1
-        id: bump-semver
-        with:
-          current_version: ${{ steps.get-latest-tag.outputs.tag }}
-          level: patch
-
-      - name: Push version tag
-        uses: actions-ecosystem/action-push-tag@v1
-        with:
-          tag: ${{ steps.bump-semver.outputs.new_version }}
-          message: "${{ github.event.head_commit.message }}"
-
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: print-api-repo
-          IMAGE_TAG: ${{ steps.bump-semver.outputs.new_version }}
+          IMAGE_TAG: v1.0.117.1
         run: |
           ./gradlew bootBuildImage
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
@@ -81,7 +60,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-live.outputs.registry }}
           ECR_REPOSITORY: print-api-repo
-          IMAGE_TAG: ${{ steps.bump-semver.outputs.new_version }}
+          IMAGE_TAG: v1.0.117.1
         run: |
           IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker tag eip-ero-print-api:latest $IMAGE
@@ -92,6 +71,6 @@ jobs:
     needs: build-and-tag
     uses: ./.github/workflows/deploy.yml
     with:
-      deploy_environment: dev
+      deploy_environment: test
       version: ${{ needs.build-and-tag.outputs.version }}
     secrets: inherit

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapper.kt
@@ -10,19 +10,19 @@ import uk.gov.dluhc.printapi.dto.EroDto
 @Mapper
 abstract class EroDtoMapper {
 
-    @Mapping(target = "englishContactDetails", expression = "java(toEroContactDetailsDto( localAuthority.getName(), localAuthority.getContactDetailsEnglish() ))")
-    @Mapping(target = "welshContactDetails", expression = "java(toNullEroContactDetailsDto( localAuthority.getName(), localAuthority.getContactDetailsWelsh() ))")
+    @Mapping(target = "englishContactDetails", expression = "java(toEroContactDetailsDto( localAuthority.getContactDetailsEnglish() ))")
+    @Mapping(target = "welshContactDetails", expression = "java(toNullEroContactDetailsDto( localAuthority.getContactDetailsWelsh() ))")
     abstract fun toEroDto(localAuthority: LocalAuthorityResponse): EroDto
 
-    fun toNullEroContactDetailsDto(name: String, contactDetails: ContactDetails?): EroContactDetailsDto? {
+    fun toNullEroContactDetailsDto(contactDetails: ContactDetails?): EroContactDetailsDto? {
         return if (contactDetails == null) {
             null
         } else {
-            toEroContactDetailsDto(name, contactDetails)
+            toEroContactDetailsDto(contactDetails)
         }
     }
 
     @Mapping(target = "emailAddress", source = "contactDetails.email")
     @Mapping(target = "phoneNumber", source = "contactDetails.phone")
-    abstract fun toEroContactDetailsDto(name: String, contactDetails: ContactDetails): EroContactDetailsDto
+    abstract fun toEroContactDetailsDto(contactDetails: ContactDetails): EroContactDetailsDto
 }

--- a/src/main/resources/openapi/external/EROManagementAPIs.yaml
+++ b/src/main/resources/openapi/external/EROManagementAPIs.yaml
@@ -3,7 +3,7 @@ security:
   - bearerAuth: []
 info:
   title: EROManagementAPIs
-  version: '1.2.0'
+  version: '1.2.1'
   description: API for viewing and managing ERO Users and ERO Details.
   contact:
     name: Krister Bone
@@ -712,7 +712,7 @@ components:
           format: email
         phoneNumber:
           type: string
-          pattern: ^\+\d+$
+          pattern: ^(\+\d+|)$
         firstName:
           type: string
           minLength: 2
@@ -723,7 +723,6 @@ components:
           maxLength: 255
       required:
         - email
-        - phoneNumber
         - firstName
         - surname
     EroGroup:
@@ -749,6 +748,7 @@ components:
         name: 'Isle of Anglesey County Council'
         contactDetailsEnglish:
           {
+            name: "Isle of Anglesey County Council",
             phoneNumber: "01248 752548",
             website: "http://www.anglesey.gov.uk/council-and-democracy/councillors-democracy-and-elections/electoral-register-elections-and-voting-/",
             email: "shxcs@ynysmon.gov.uk",
@@ -762,6 +762,7 @@ components:
           }
         contactDetailsWelsh:
           {
+            name: "Cyngor Sir Ynys Môn",
             phoneNumber: "(01248) 750057",
             website: "https://www.ynysmon.llyw.cymru/cy/Cyngor/Pleidleisio-ac-etholiadau/Cofrestru-etholiadol/Cofrestru-i-bleidleisio.aspx",
             email: "shxcs@ynysmon.gov.uk",
@@ -791,6 +792,9 @@ components:
       type: object
       description: Contact details for an ERO
       properties:
+        name:
+          type: string
+          example: Isle of Anglesey County Council
         website:
           type: string
           example: "https://ero-address.com"
@@ -803,6 +807,7 @@ components:
         address:
           $ref: '#/components/schemas/Address'
       required:
+        - name
         - website
         - phone
         - email
@@ -862,6 +867,7 @@ components:
             name: 'Isle of Anglesey County Council',
             contactDetailsEnglish:
               {
+                name: 'Isle of Anglesey County Council',
                 phoneNumber: "01248 752548",
                 website: "http://www.anglesey.gov.uk/council-and-democracy/councillors-democracy-and-elections/electoral-register-elections-and-voting-/",
                 email: "shxcs@ynysmon.gov.uk",
@@ -875,6 +881,7 @@ components:
               },
             contactDetailsWelsh:
               {
+                name: 'Cyngor Sir Ynys Môn',
                 phoneNumber: "(01248) 750057",
                 website: "https://www.ynysmon.llyw.cymru/cy/Cyngor/Pleidleisio-ac-etholiadau/Cofrestru-etholiadol/Cofrestru-i-bleidleisio.aspx",
                 email: "shxcs@ynysmon.gov.uk",

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -61,8 +61,8 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
                 vacNumber = aValidVacNumber(),
                 applicationReceivedDateTime = applicationReceivedDateTime.toInstant(),
                 gssCode = gssCode,
-                issuingAuthority = localAuthority.name,
-                issuingAuthorityCy = localAuthority.name,
+                issuingAuthority = localAuthority.contactDetailsEnglish.name,
+                issuingAuthorityCy = localAuthority.contactDetailsWelsh?.name,
                 issueDate = LocalDate.now(),
             )
             val printRequest = PrintRequest(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/LocalAuthorityResponseBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/LocalAuthorityResponseBuilder.kt
@@ -23,12 +23,14 @@ fun buildLocalAuthorityResponse(
 )
 
 fun buildContactDetails(
+    name: String = aValidLocalAuthorityName(),
     websiteAddress: String = aValidWebsite(),
     phoneNumber: String = aValidPhoneNumber(),
     emailAddress: String = aValidEmailAddress(),
     address: Address = buildEroManagementAddress(),
 ): ContactDetails =
     ContactDetails(
+        name = name,
         website = websiteAddress,
         phone = phoneNumber,
         email = emailAddress,


### PR DESCRIPTION
This PR fixes bug EIP1-3454 by bringing in the latest ERO Management openApi spec (v1.2.1) which introduces a new `name` field on the `contactDetails` object in the REST API response from ERO Management. The new `name` field is then mapped to the `issuingAuthority` and `issuingAuthorityCy` fields in the `Certificate` entity.

The rest of the code required for this overall bugfix is already there and was committed in my last PR for this.