### PR TITLE
EIP1-3722 - Basic controller with 401/403 scenarios

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/CertificateSummaryController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/CertificateSummaryController.kt
@@ -16,18 +16,8 @@ class CertificateSummaryController(
     private val certificateSummaryService: CertificateSummaryService,
     private val certificateSummaryResponseMapper: CertificateSummaryResponseMapper
 ) {
-    companion object {
-        const val ERO_VC_ADMIN_GROUP_PREFIX = "ero-vc-admin-"
-    }
-
     @GetMapping("/eros/{eroId}/certificates/applications/{applicationId}")
-    @PreAuthorize(
-        """
-        hasAnyAuthority(
-            T(uk.gov.dluhc.printapi.rest.CertificateSummaryController).ERO_VC_ADMIN_GROUP_PREFIX.concat(#eroId)
-        )
-        """
-    )
+    @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)
     fun getCertificateSummaryByApplicationId(
         @PathVariable eroId: String,
         @PathVariable applicationId: String,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/ControllerSecurityConstants.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/ControllerSecurityConstants.kt
@@ -1,0 +1,5 @@
+package uk.gov.dluhc.printapi.rest
+
+const val HAS_ERO_VC_ADMIN_AUTHORITY = """
+    hasAnyAuthority("ero-vc-admin-".concat(#eroId))
+"""

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -1,0 +1,18 @@
+package uk.gov.dluhc.printapi.rest
+
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@CrossOrigin
+class TemporaryCertificateController {
+
+    @PostMapping("/eros/{eroId}/temporary-certificate")
+    @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)
+    fun generateTemporaryCertificate(@PathVariable eroId: String) {
+        TODO("not yet implemented")
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.dluhc.printapi.rest
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+
+internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/temporary-certificate"
+        private const val ERO_ID = "some-city-council"
+    }
+
+    @Test
+    fun `should return forbidden given no bearer token`() {
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return unauthorized given user with invalid bearer token`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(
+                getBearerToken(
+                    eroId = userGroupEroId,
+                    groups = listOf("ero-$userGroupEroId", "ero-vc-admin-$userGroupEroId")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+}


### PR DESCRIPTION
This PR introduces the basic skeleton controller for Temporary Certificates with the standard 401/403 scenarios