### PR TITLE
EIP1-3666 Validate the ERO found by GSS Code matches the ERO from the URL when generating temporary certificate explainer PDF

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClient.kt
@@ -63,7 +63,10 @@ class ElectoralRegistrationOfficeManagementApiClient(
             throw ElectoralRegistrationOfficeNotFoundException(mapOf("gssCode" to gssCode))
         }
 
-        return eroMapper.toEroDto(response.eros[0].localAuthorities.filter { it.gssCode == gssCode }[0])
+        return eroMapper.toEroDto(
+            response.eros[0].id,
+            response.eros[0].localAuthorities.filter { it.gssCode == gssCode }[0]
+        )
     }
 
     private fun <T> handleException(ex: Throwable, searchCriteria: Map<String, String>): Mono<T> =

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/EroDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/EroDto.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.printapi.dto
 
 data class EroDto(
+    val eroId: String,
     val englishContactDetails: EroContactDetailsDto,
     val welshContactDetails: EroContactDetailsDto? = null
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/TemporaryCertificateExplainerDocumentNotFoundException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/TemporaryCertificateExplainerDocumentNotFoundException.kt
@@ -1,4 +1,4 @@
 package uk.gov.dluhc.printapi.exception
 
-class TemporaryCertificateExplainerDocumentNotFoundException(gssCode: String) :
-    RuntimeException("Temporary certificate explainer document not found for gssCode $gssCode")
+class TemporaryCertificateExplainerDocumentNotFoundException(eroId: String, gssCode: String) :
+    RuntimeException("Temporary certificate explainer document not found for eroId $eroId and gssCode $gssCode")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapper.kt
@@ -12,7 +12,7 @@ abstract class EroDtoMapper {
 
     @Mapping(target = "englishContactDetails", expression = "java(toEroContactDetailsDto( localAuthority.getContactDetailsEnglish() ))")
     @Mapping(target = "welshContactDetails", expression = "java(toNullEroContactDetailsDto( localAuthority.getContactDetailsWelsh() ))")
-    abstract fun toEroDto(localAuthority: LocalAuthorityResponse): EroDto
+    abstract fun toEroDto(eroId: String, localAuthority: LocalAuthorityResponse): EroDto
 
     fun toNullEroContactDetailsDto(contactDetails: ContactDetails?): EroContactDetailsDto? {
         return if (contactDetails == null) {

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -44,7 +44,7 @@ class TemporaryCertificateController(
         @PathVariable eroId: String,
         @PathVariable gssCode: String,
     ): ResponseEntity<InputStreamResource> {
-        return explainerPdfService.generateExplainerPdf(gssCode).let { pdfFile ->
+        return explainerPdfService.generateExplainerPdf(eroId, gssCode).let { pdfFile ->
             ResponseEntity.status(HttpStatus.CREATED)
                 .headers(createPdfHttpHeaders(pdfFile))
                 .body(InputStreamResource(ByteArrayInputStream(pdfFile.contents)))

--- a/src/test/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClientTest.kt
@@ -170,7 +170,7 @@ internal class ElectoralRegistrationOfficeManagementApiClientTest {
                 Mono.just(erosResponse)
             )
             val expected = buildEroDto()
-            given(eroMapper.toEroDto(any())).willReturn(expected)
+            given(eroMapper.toEroDto(any(), any())).willReturn(expected)
 
             // When
             val ero = apiClient.getEro(gssCode)
@@ -178,7 +178,7 @@ internal class ElectoralRegistrationOfficeManagementApiClientTest {
             // Then
             assertThat(ero).isSameAs(expected)
             assertRequestUri(gssCode)
-            verify(eroMapper).toEroDto(eroResponse.localAuthorities[0])
+            verify(eroMapper).toEroDto(eroResponse.id, eroResponse.localAuthorities[0])
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/EroDtoMapperTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.dluhc.printapi.dto.AddressDto
 import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 import uk.gov.dluhc.printapi.dto.EroDto
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRandomEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildContactDetails
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
 
@@ -14,34 +15,34 @@ class EroDtoMapperTest {
     @Test
     fun `should map ERO response to ERO dto`() {
         // Given
+        val eroId = aValidRandomEroId()
         val localAuthority = buildLocalAuthorityResponse(contactDetailsWelsh = null)
-        val expected = with(localAuthority) {
-            EroDto(
-                englishContactDetails = with(localAuthority.contactDetailsEnglish) {
-                    EroContactDetailsDto(
-                        name = name,
-                        emailAddress = email,
-                        phoneNumber = phone,
-                        website = website,
-                        address = with(address) {
-                            AddressDto(
-                                street = street,
-                                postcode = postcode,
-                                property = property,
-                                locality = locality,
-                                town = town,
-                                area = area,
-                                uprn = uprn
-                            )
-                        }
-                    )
-                },
-                welshContactDetails = null
-            )
-        }
+        val expected = EroDto(
+            eroId = eroId,
+            englishContactDetails = with(localAuthority.contactDetailsEnglish) {
+                EroContactDetailsDto(
+                    name = name,
+                    emailAddress = email,
+                    phoneNumber = phone,
+                    website = website,
+                    address = with(address) {
+                        AddressDto(
+                            street = street,
+                            postcode = postcode,
+                            property = property,
+                            locality = locality,
+                            town = town,
+                            area = area,
+                            uprn = uprn
+                        )
+                    }
+                )
+            },
+            welshContactDetails = null
+        )
 
         // When
-        val actual = mapper.toEroDto(localAuthority)
+        val actual = mapper.toEroDto(eroId, localAuthority)
 
         // Then
         Assertions.assertThat(actual).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expected)
@@ -50,54 +51,54 @@ class EroDtoMapperTest {
     @Test
     fun `should map ERO response with Welsh to ERO dto`() {
         // Given
+        val eroId = aValidRandomEroId()
         val localAuthority = buildLocalAuthorityResponse(
             contactDetailsWelsh = buildContactDetails()
         )
-        val expected = with(localAuthority) {
-            EroDto(
-                englishContactDetails = with(localAuthority.contactDetailsEnglish) {
-                    EroContactDetailsDto(
-                        name = name,
-                        emailAddress = email,
-                        phoneNumber = phone,
-                        website = website,
-                        address = with(address) {
-                            AddressDto(
-                                street = street,
-                                postcode = postcode,
-                                property = property,
-                                locality = locality,
-                                town = town,
-                                area = area,
-                                uprn = uprn
-                            )
-                        }
-                    )
-                },
-                welshContactDetails = with(localAuthority.contactDetailsWelsh!!) {
-                    EroContactDetailsDto(
-                        name = name,
-                        emailAddress = email,
-                        phoneNumber = phone,
-                        website = website,
-                        address = with(address) {
-                            AddressDto(
-                                street = street,
-                                postcode = postcode,
-                                property = property,
-                                locality = locality,
-                                town = town,
-                                area = area,
-                                uprn = uprn
-                            )
-                        }
-                    )
-                }
-            )
-        }
+        val expected = EroDto(
+            eroId = eroId,
+            englishContactDetails = with(localAuthority.contactDetailsEnglish) {
+                EroContactDetailsDto(
+                    name = name,
+                    emailAddress = email,
+                    phoneNumber = phone,
+                    website = website,
+                    address = with(address) {
+                        AddressDto(
+                            street = street,
+                            postcode = postcode,
+                            property = property,
+                            locality = locality,
+                            town = town,
+                            area = area,
+                            uprn = uprn
+                        )
+                    }
+                )
+            },
+            welshContactDetails = with(localAuthority.contactDetailsWelsh!!) {
+                EroContactDetailsDto(
+                    name = name,
+                    emailAddress = email,
+                    phoneNumber = phone,
+                    website = website,
+                    address = with(address) {
+                        AddressDto(
+                            street = street,
+                            postcode = postcode,
+                            property = property,
+                            locality = locality,
+                            town = town,
+                            area = area,
+                            uprn = uprn
+                        )
+                    }
+                )
+            }
+        )
 
         // When
-        val actual = mapper.toEroDto(localAuthority)
+        val actual = mapper.toEroDto(eroId, localAuthority)
 
         // Then
         Assertions.assertThat(actual).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroDtoBuilder.kt
@@ -2,11 +2,14 @@ package uk.gov.dluhc.printapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 import uk.gov.dluhc.printapi.dto.EroDto
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRandomEroId
 
 fun buildEroDto(
+    eroId: String = aValidRandomEroId(),
     englishContactDetails: EroContactDetailsDto = anEnglishEroContactDetails(),
     welshContactDetails: EroContactDetailsDto? = aWelshEroContactDetails()
 ) = EroDto(
+    eroId = eroId,
     englishContactDetails = englishContactDetails,
     welshContactDetails = welshContactDetails,
 )


### PR DESCRIPTION
Reject requests to create an explainer document when the ERO identified by the provided GSS Code does not match the ERO ID included in the request.