### PR TITLE
EIP1-3802 - Calculate certificate delivery info removal date

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataClient.kt
@@ -1,0 +1,70 @@
+package uk.gov.dluhc.printapi.client
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import mu.KotlinLogging
+import java.time.LocalDate
+
+private val logger = KotlinLogging.logger {}
+
+interface BankHolidayDataClient {
+
+    /**
+     * Retrieves bank holiday dates for the requested [BankHolidayDivision] (e.g. England and Wales), starting from the
+     * provided [LocalDate].
+     *
+     * @param division The UK nation (e.g. Scotland) that the bank holidays are required for.
+     * @param fromDate The [LocalDate] from which the bank holidays start (defaults to today).
+     * @param toDate The [LocalDate] when the bank holidays end (defaults to an arbitrary 100 days in the future).
+     * @return a [List] of [LocalDate] values representing upcoming bank holidays.
+     */
+    fun getBankHolidayDates(
+        division: BankHolidayDivision,
+        fromDate: LocalDate = LocalDate.now(),
+        toDate: LocalDate = LocalDate.now().plusDays(100)
+    ): List<LocalDate>
+}
+
+/**
+ * The bank holiday data we retrieve from gov.uk is structured according to the UK nation (or "division" in the JSON).
+ */
+enum class BankHolidayDivision(val value: String) {
+    ENGLAND_AND_WALES("england-and-wales"),
+    SCOTLAND("scotland"),
+    NORTHERN_IRELAND("northern-ireland");
+
+    companion object {
+        @JvmStatic
+        fun fromGssCode(gssCode: String): BankHolidayDivision {
+            return when (gssCode.substring(0, 1)) {
+                "E", "W" -> ENGLAND_AND_WALES
+                "S" -> SCOTLAND
+                "N" -> NORTHERN_IRELAND
+                else -> {
+                    logger.warn("Unknown country prefix for gssCode: [$gssCode], defaulting to $ENGLAND_AND_WALES")
+                    ENGLAND_AND_WALES
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Data class to deserialize the JSON from gov.uk's Bank Holidays API (https://www.api.gov.uk/gds/bank-holidays).
+ */
+data class BankHolidayData(
+    @JsonProperty("division")
+    val division: String?,
+    @JsonProperty("events")
+    val events: List<BankHoliday>?
+)
+
+data class BankHoliday(
+    @JsonProperty("name")
+    val name: String?,
+    @JsonProperty("date")
+    val date: LocalDate?,
+    @JsonProperty("notes")
+    val notes: String?,
+    @JsonProperty("bunting")
+    val bunting: Boolean?
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataClient.kt
@@ -35,10 +35,10 @@ enum class BankHolidayDivision(val value: String) {
     companion object {
         @JvmStatic
         fun fromGssCode(gssCode: String): BankHolidayDivision {
-            return when (gssCode.substring(0, 1)) {
-                "E", "W" -> ENGLAND_AND_WALES
-                "S" -> SCOTLAND
-                "N" -> NORTHERN_IRELAND
+            return when (gssCode.first()) {
+                'E', 'W' -> ENGLAND_AND_WALES
+                'S' -> SCOTLAND
+                'N' -> NORTHERN_IRELAND
                 else -> {
                     logger.warn("Unknown country prefix for gssCode: [$gssCode], defaulting to $ENGLAND_AND_WALES")
                     ENGLAND_AND_WALES

--- a/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataFileClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataFileClient.kt
@@ -1,0 +1,49 @@
+package uk.gov.dluhc.printapi.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.type.MapType
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.core.io.Resource
+import org.springframework.stereotype.Component
+import java.time.LocalDate
+import javax.annotation.PostConstruct
+
+@Component
+class BankHolidayDataFileClient(
+    @Value("classpath:bank-holidays.json") private val resource: Resource,
+    private val mapper: ObjectMapper
+) : BankHolidayDataClient {
+
+    private var bankHolidayData: Map<String, BankHolidayData> = emptyMap()
+
+    @PostConstruct
+    fun loadBankHolidayData() {
+        val mapType: MapType = mapType()
+        bankHolidayData = mapper.readValue(resource.inputStream, mapType)
+    }
+
+    override fun getBankHolidayDates(
+        division: BankHolidayDivision,
+        fromDate: LocalDate,
+        toDate: LocalDate
+    ): List<LocalDate> {
+        val bankHolidays = bankHolidayData[division.value]?.events ?: emptyList()
+        return bankHolidays
+            .filter { upcomingEvents(it, fromDate, toDate) }
+            .map { e -> e.date!! }
+    }
+
+    private fun mapType(): MapType {
+        return mapper.typeFactory.constructMapType(
+            HashMap::class.java,
+            String::class.java,
+            BankHolidayData::class.java
+        )
+    }
+
+    private fun upcomingEvents(
+        bankHoliday: BankHoliday,
+        fromDate: LocalDate,
+        toDate: LocalDate
+    ) = bankHoliday.date!!.isAfter(fromDate) && bankHoliday.date.isBefore(toDate)
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/DataRetentionConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/DataRetentionConfiguration.kt
@@ -1,0 +1,11 @@
+package uk.gov.dluhc.printapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "api.print-api.retention.period")
+@ConstructorBinding
+data class DataRetentionConfiguration(
+    val certificateDeliveryInfo: Duration
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
@@ -1,0 +1,58 @@
+package uk.gov.dluhc.printapi.service
+
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.client.BankHolidayDataClient
+import uk.gov.dluhc.printapi.client.BankHolidayDivision
+import uk.gov.dluhc.printapi.config.DataRetentionConfiguration
+import java.time.DayOfWeek.SATURDAY
+import java.time.DayOfWeek.SUNDAY
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * Responsible for determining the removal date for a Certificate's data. The removal date varies, depending on the
+ * category of data and the type of Certificate concerned.
+ */
+@Component
+class CertificateRemovalDateResolver(
+    private val dataRetentionConfig: DataRetentionConfiguration,
+    private val bankHolidayDataClient: BankHolidayDataClient
+) {
+
+    /**
+     * Calculates the date that the delivery info for a Certificate's print requests should be removed. The retention
+     * period is currently 28 (configurable) working days from the certificate's "issue" date, which means weekends and
+     * bank holidays should be excluded when making this calculation. If the issue date was more than 28 working days
+     * ago, the removal date will be in the past.
+     *
+     * @param issueDate The date the Certificate was issued.
+     * @param gssCode The Certificate's GSS code which is used to determine if there are any upcoming bank holidays for
+     * the UK nation concerned.
+     * @return A [LocalDate] representing when a Certificate's delivery info should be removed
+     */
+    fun getCertificateDeliveryInfoRemovalDate(issueDate: LocalDate, gssCode: String): LocalDate =
+        with(getTotalDaysForWorkingDays(issueDate, dataRetentionConfig.certificateDeliveryInfo.toDays(), gssCode)) {
+            issueDate.plusDays(this.toLong())
+        }
+
+    private fun getTotalDaysForWorkingDays(issueDate: LocalDate, requiredWorkingDays: Long, gssCode: String): Int {
+        val upcomingBankHolidays = bankHolidayDataClient.getBankHolidayDates(BankHolidayDivision.fromGssCode(gssCode))
+        var date = issueDate
+        var workingDays = 0
+        while (workingDays < requiredWorkingDays) {
+            date = date.plusDays(1)
+            if (isWorkingDay(date, upcomingBankHolidays)) {
+                workingDays++
+            }
+        }
+        return ChronoUnit.DAYS.between(issueDate, date).toInt()
+    }
+
+    private fun isWorkingDay(date: LocalDate, upcomingBankHolidays: List<LocalDate>) =
+        !isWeekend(date) && !isBankHoliday(upcomingBankHolidays, date)
+
+    private fun isWeekend(date: LocalDate) = date.dayOfWeek == SATURDAY || date.dayOfWeek == SUNDAY
+
+    private fun isBankHoliday(upcomingBankHolidays: List<LocalDate>, date: LocalDate) =
+        upcomingBankHolidays.contains(date)
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,8 @@ api:
     generate-temporary-certificate:
       valid-on-date:
         max-calendar-days-in-future: 30
+    retention.period:
+      certificate-delivery-info: "P28D" # 28 working days
   ero-management:
     url: ${API_ERO_MANAGEMENT_URL}
 

--- a/src/main/resources/bank-holidays.json
+++ b/src/main/resources/bank-holidays.json
@@ -1,0 +1,1367 @@
+{
+  "england-and-wales": {
+    "division": "england-and-wales",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      }
+    ]
+  },
+  "scotland": {
+    "division": "scotland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2018-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2018-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2019-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2019-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2020-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2020-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2021-01-04",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2021-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2022-01-04",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2022-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2023-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2023-11-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2024-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2024-12-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "2nd January",
+        "date": "2025-01-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-04",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Andrew’s Day",
+        "date": "2025-12-01",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      }
+    ]
+  },
+  "northern-ireland": {
+    "division": "northern-ireland",
+    "events": [
+      {
+        "title": "New Year’s Day",
+        "date": "2018-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2018-03-19",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2018-03-30",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2018-04-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2018-05-07",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2018-05-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2018-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2018-08-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2018-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2018-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2019-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2019-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2019-04-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2019-04-22",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2019-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2019-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2019-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2019-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2019-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2019-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2020-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2020-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2020-04-10",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2020-04-13",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Early May bank holiday (VE day)",
+        "date": "2020-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2020-05-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2020-07-13",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2020-08-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2020-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2020-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2021-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2021-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2021-04-02",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2021-04-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2021-05-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2021-05-31",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2021-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2021-08-30",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2021-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2021-12-28",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2022-01-03",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2022-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2022-04-15",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2022-04-18",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2022-05-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2022-06-02",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Platinum Jubilee bank holiday",
+        "date": "2022-06-03",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2022-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2022-08-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank Holiday for the State Funeral of Queen Elizabeth II",
+        "date": "2022-09-19",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2022-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2022-12-27",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2023-01-02",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2023-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2023-04-07",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2023-04-10",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2023-05-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Bank holiday for the coronation of King Charles III",
+        "date": "2023-05-08",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2023-05-29",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2023-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2023-08-28",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2023-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2023-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2024-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2024-03-18",
+        "notes": "Substitute day",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2024-03-29",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2024-04-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2024-05-06",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2024-05-27",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2024-07-12",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2024-08-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2024-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2024-12-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "New Year’s Day",
+        "date": "2025-01-01",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "St Patrick’s Day",
+        "date": "2025-03-17",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Good Friday",
+        "date": "2025-04-18",
+        "notes": "",
+        "bunting": false
+      },
+      {
+        "title": "Easter Monday",
+        "date": "2025-04-21",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Early May bank holiday",
+        "date": "2025-05-05",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Spring bank holiday",
+        "date": "2025-05-26",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Battle of the Boyne (Orangemen’s Day)",
+        "date": "2025-07-14",
+        "notes": "Substitute day",
+        "bunting": false
+      },
+      {
+        "title": "Summer bank holiday",
+        "date": "2025-08-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Christmas Day",
+        "date": "2025-12-25",
+        "notes": "",
+        "bunting": true
+      },
+      {
+        "title": "Boxing Day",
+        "date": "2025-12-26",
+        "notes": "",
+        "bunting": true
+      }
+    ]
+  }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataFileClientTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/client/BankHolidayDataFileClientTest.kt
@@ -1,0 +1,30 @@
+package uk.gov.dluhc.printapi.client
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.dluhc.printapi.client.BankHolidayDivision.ENGLAND_AND_WALES
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import java.time.LocalDate
+
+internal class BankHolidayDataFileClientTest : IntegrationTest() {
+
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "2023-01-01,2023-12-31,9",
+            "2023-01-01,2023-01-31,1",
+            "2023-01-03,2023-01-31,0",
+            "2023-04-03,2023-04-11,2"
+        ]
+    )
+    fun `should get bank holiday dates`(fromDate: LocalDate, toDate: LocalDate, count: Int) {
+        // Given
+
+        // When
+        val bankHolidayDates = bankHolidayDataClient.getBankHolidayDates(ENGLAND_AND_WALES, fromDate, toDate)
+
+        // Then
+        assertThat(bankHolidayDates).hasSize(count)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -27,6 +27,7 @@ import org.springframework.integration.support.MessageBuilder
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.s3.S3Client
+import uk.gov.dluhc.printapi.client.BankHolidayDataClient
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_REQUEST_UPLOAD_PATH
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_RESPONSE_DOWNLOAD_PATH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
@@ -83,6 +84,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var s3Client: S3Client
+
+    @Autowired
+    protected lateinit var bankHolidayDataClient: BankHolidayDataClient
 
     @Autowired
     protected lateinit var clock: Clock

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
@@ -1,0 +1,65 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.client.BankHolidayDataClient
+import uk.gov.dluhc.printapi.client.BankHolidayDivision.ENGLAND_AND_WALES
+import uk.gov.dluhc.printapi.config.DataRetentionConfiguration
+import java.time.Duration
+import java.time.LocalDate
+
+@ExtendWith(MockitoExtension::class)
+internal class CertificateRemovalDateResolverTest {
+    @Mock
+    private lateinit var dataRetentionConfig: DataRetentionConfiguration
+
+    @Mock
+    private lateinit var bankHolidayDataClient: BankHolidayDataClient
+
+    @InjectMocks
+    private lateinit var certificateRemovalDateResolver: CertificateRemovalDateResolver
+
+    @Test
+    fun `should get removal date for delivery info given upcoming bank holiday`() {
+        // Given
+        val gssCode = "E09000007"
+        val issueDate = LocalDate.of(2023, 1, 1)
+        val upcomingBankHoliday = LocalDate.of(2023, 2, 1)
+        val expectedRemovalDate = LocalDate.of(2023, 2, 9)
+        given(dataRetentionConfig.certificateDeliveryInfo).willReturn(Duration.ofDays(28))
+        given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(listOf(upcomingBankHoliday))
+
+        // When
+        val actual = certificateRemovalDateResolver.getCertificateDeliveryInfoRemovalDate(issueDate, gssCode)
+
+        // Then
+        assertThat(actual).isEqualTo(expectedRemovalDate)
+        verify(dataRetentionConfig).certificateDeliveryInfo
+        verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+    }
+
+    @Test
+    fun `should get removal date for delivery info given no upcoming bank holidays`() {
+        // Given
+        val gssCode = "E09000007"
+        val issueDate = LocalDate.of(2023, 1, 1)
+        val expectedRemovalDate = LocalDate.of(2023, 2, 8)
+        given(dataRetentionConfig.certificateDeliveryInfo).willReturn(Duration.ofDays(28))
+        given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(emptyList())
+
+        // When
+        val actual = certificateRemovalDateResolver.getCertificateDeliveryInfoRemovalDate(issueDate, gssCode)
+
+        // Then
+        assertThat(actual).isEqualTo(expectedRemovalDate)
+        verify(dataRetentionConfig).certificateDeliveryInfo
+        verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+    }
+}


### PR DESCRIPTION
We've recently discovered we need to remove the address and addressee fields that are stored against each certificate's print requests much sooner than anticipated. Since this data is not on the printed certificate itself, we need to remove it 28 working days after a certificate is "issued" (as opposed to 28 working days following approval for the application's data in VCA).

There is currently some debate re what the "issue" date is exactly, but that is outside the focus of this PR.