### PR TITLE
EIP1-3800 - Liquibase/entity changes for the initial data retention period

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -66,8 +66,20 @@ class Certificate(
     @field:NotNull
     var issueDate: LocalDate = LocalDate.now(),
 
+    /**
+     * The certificate's expiry date. Not to be confused with removal dates related to data retention policies.
+     */
     @field:NotNull
     var suggestedExpiryDate: LocalDate = issueDate.plusYears(10),
+
+    /**
+     * The legislation stipulates there are two retention periods for certificate related data. The first (initial)
+     * period applies to PII data that is not on the printed certificate itself (e.g. the addressee/address on the
+     * envelope), which needs to be removed 28 (configurable) working days after the certificate is "issued".
+     * For standard (non-temporary) certificates, the retention period is considerably longer and is currently specified
+     * as the tenth 1st July.
+     */
+    var initialRetentionRemovalDate: LocalDate? = null,
 
     /**
      * Certificate status corresponds to the current status of the most recent

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -17,4 +17,5 @@
     <include relativeToChangelogFile="true" file="ddl/0009_EIP1-3454_alter_certificate.xml"/>
     <include relativeToChangelogFile="true" file="migration/0001_EIP1-3454_update_certificate.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0010_create_temporary_certificate_tables.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0011_initial_data_retention_period_changes.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0011_initial_data_retention_period_changes.xml
+++ b/src/main/resources/db/changelog/ddl/0011_initial_data_retention_period_changes.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="matt.wills@valtech.com" id="0011_EIP1-3800_alter_certificate - add initial_retention_removal_date column" context="ddl">
+
+        <addColumn tableName="certificate">
+            <column name="initial_retention_removal_date" type="date" remarks="The date that certain data should be removed after the first retention period">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <createIndex tableName="certificate" indexName="certificate_initial_retention_removal_date_idx">
+            <column name="source_type"/>
+            <column name="initial_retention_removal_date"/>
+        </createIndex>
+
+        <rollback>
+            <dropColumn
+                tableName="certificate"
+                columnName="initial_retention_removal_date"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="matt.wills@valtech.com" id="0011_EIP1-3800_alter_print_request - make delivery nullable" context="ddl">
+
+        <dropNotNullConstraint tableName="print_request" columnName="delivery_id" columnDataType="uuid"/>
+
+        <rollback>
+            <addNotNullConstraint tableName="print_request" columnName="delivery_id" columnDataType="uuid"/>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This PR is an enabler to allow us to store the date for removing PII data which is not on the printed certificate itself (currently just the addressee/address on the envelope).