### PR TITLE
EIP1-3439 Add to controller endpoint the functionality to create a temporary certificate PDF file

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -34,15 +34,17 @@ class TemporaryCertificateController(
         @PathVariable eroId: String,
         @RequestBody @Valid generateTemporaryCertificateRequest: GenerateTemporaryCertificateRequest,
         authentication: Authentication
-    ) {
+    ): ResponseEntity<InputStreamResource> {
         val userId = authentication.name
         val dto = generateTemporaryCertificateMapper.toGenerateTemporaryCertificateDto(
             generateTemporaryCertificateRequest,
             userId
         )
-        val pdfFile = temporaryCertificateService.generateTemporaryCertificate(dto)
-
-        TODO("not yet implemented")
+        return temporaryCertificateService.generateTemporaryCertificate(eroId, dto).let { pdfFile ->
+            ResponseEntity.status(HttpStatus.CREATED)
+                .headers(createPdfHttpHeaders(pdfFile))
+                .body(InputStreamResource(ByteArrayInputStream(pdfFile.contents)))
+        }
     }
 
     @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PhotoLocationFactory.kt
@@ -1,21 +1,13 @@
 package uk.gov.dluhc.printapi.service
 
 import org.springframework.stereotype.Component
-import software.amazon.awssdk.arns.Arn
 
 @Component
 class PhotoLocationFactory {
 
     fun create(batchId: String, requestId: String, photoArn: String): PhotoLocation {
-        val s3Photo = Arn.fromString(photoArn)
-        val bucket = s3Photo.resource().resourceType().get()
-        val path = createPath(s3Photo)
-        val zipPhotoPath = "$batchId-$requestId.${path.substringAfterLast('.')}"
-        return PhotoLocation(zipPhotoPath, bucket, path)
+        val s3Location = parseS3Arn(photoArn)
+        val zipPhotoPath = "$batchId-$requestId.${s3Location.path.substringAfterLast('.')}"
+        return PhotoLocation(zipPhotoPath, s3Location.bucket, s3Location.path)
     }
-
-    private fun createPath(s3Photo: Arn): String =
-        if (s3Photo.resource().qualifier().isPresent)
-            "${s3Photo.resource().resource()}/${s3Photo.resource().qualifier().get()}"
-        else s3Photo.resource().resource()
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/S3ArnParser.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/S3ArnParser.kt
@@ -1,0 +1,20 @@
+package uk.gov.dluhc.printapi.service
+
+import software.amazon.awssdk.arns.Arn
+
+fun parseS3Arn(s3Arn: String): S3Location {
+    val s3Photo = Arn.fromString(s3Arn)
+    val bucket = s3Photo.resource().resourceType().get()
+    val path = createPath(s3Photo)
+    return S3Location(bucket, path)
+}
+
+private fun createPath(s3Photo: Arn): String =
+    if (s3Photo.resource().qualifier().isPresent)
+        "${s3Photo.resource().resource()}/${s3Photo.resource().qualifier().get()}"
+    else s3Photo.resource().resource()
+
+data class S3Location(
+    val bucket: String,
+    val path: String
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/PdfFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/PdfFactory.kt
@@ -16,6 +16,7 @@ class PdfFactory {
         PdfReader(ResourceUtils.getFile(templateDetails.path).inputStream()).use { reader ->
             val stamper = PdfStamper(reader, outputStream)
             stamper.cleanMetadata()
+            stamper.setFormFlattening(true)
             try {
                 populateFormFields(stamper.acroFields, templateDetails.placeholders)
                 addImages(templateDetails.images, stamper)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.dao.TransientDataAccessException
+import org.springframework.data.repository.CrudRepository
 import org.springframework.integration.file.FileHeaders.FILENAME
 import org.springframework.integration.file.remote.session.CachingSessionFactory
 import org.springframework.integration.file.remote.session.SessionFactory
@@ -140,12 +141,17 @@ internal abstract class IntegrationTest {
 
     @BeforeEach
     @AfterEach
-    fun clearRdsDatabase() {
+    fun clearDatabase() {
+        clearRepository(certificateRepository, "certificateRepository")
+        clearRepository(temporaryCertificateRepository, "temporaryCertificateRepository")
+    }
+
+    private fun clearRepository(repository: CrudRepository<*, *>, repoName: String) {
         try {
-            certificateRepository.deleteAll()
+            repository.deleteAll()
         } catch (tdae: TransientDataAccessException) {
-            logger.warn("exception while cleaning up db with `certificateRepository.deleteAll()`", tdae)
-            certificateRepository.deleteAll()
+            logger.warn("exception while cleaning up db with `$repoName.deleteAll()`", tdae)
+            repository.deleteAll()
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -31,6 +31,7 @@ import uk.gov.dluhc.printapi.client.BankHolidayDataClient
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_REQUEST_UPLOAD_PATH
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_RESPONSE_DOWNLOAD_PATH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
+import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
 import uk.gov.dluhc.printapi.jobs.BatchPrintRequestsJob
 import uk.gov.dluhc.printapi.jobs.ProcessPrintResponsesBatchJob
 import uk.gov.dluhc.printapi.messaging.MessageQueue
@@ -111,6 +112,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var certificateRepository: CertificateRepository
+
+    @Autowired
+    protected lateinit var temporaryCertificateRepository: TemporaryCertificateRepository
 
     @BeforeEach
     fun clearLogAppender() {

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
@@ -120,7 +120,7 @@ internal class GenerateTemporaryCertificateExplainerDocumentIntegrationTest : In
     }
 
     @Test
-    fun `should return temporary certificate pdf document given valid request for authorised user`() {
+    fun `should return temporary certificate explainer document pdf given valid request for authorised user`() {
         // Given
         val eroName = aValidLocalAuthorityName()
         val localAuthorities: List<LocalAuthorityResponse> = listOf(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.printapi.rest
 
 import com.lowagie.text.pdf.PdfReader
+import com.lowagie.text.pdf.parser.PdfTextExtractor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
@@ -149,7 +150,8 @@ internal class GenerateTemporaryCertificateExplainerDocumentIntegrationTest : In
         val pdfContent = result.responseBody
         assertThat(pdfContent).isNotNull
         PdfReader(pdfContent).use { reader ->
-            assertThat(reader.acroFields.getField("eroName")).isEqualTo(eroName)
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(eroName)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.printapi.rest
 
 import com.lowagie.text.pdf.PdfReader
+import com.lowagie.text.pdf.parser.PdfTextExtractor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
@@ -254,7 +255,8 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
         val pdfContent = response.responseBody
         assertThat(pdfContent).isNotNull
         PdfReader(pdfContent).use { reader ->
-            assertThat(reader.acroFields.getField("localAuthorityEn")).isEqualTo(localAuthorityName)
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(localAuthorityName)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -1,23 +1,42 @@
 package uk.gov.dluhc.printapi.rest
 
+import com.lowagie.text.pdf.PdfReader
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
+import org.springframework.util.ResourceUtils
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration
+import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
 import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.testsupport.assertj.assertions.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildContactDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildGenerateTemporaryCertificateRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
 import uk.gov.dluhc.printapi.testsupport.withBody
+import java.io.ByteArrayInputStream
 import java.time.LocalDate
+import java.util.UUID
 
 internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
 
     companion object {
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/temporary-certificate"
         private const val ERO_ID = "some-city-council"
+        private const val OTHER_ERO_ID = "other-city-council"
+        private const val GSS_CODE = "W06000023"
+        private const val CERTIFICATE_SAMPLE_PHOTO =
+            "classpath:temporary-certificate-template/sample-certificate-photo.png"
+        private const val MAX_SIZE_1_MB = 1024 * 1024
     }
 
     @Test
@@ -132,5 +151,126 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
             .hasStatus(400)
             .hasError("Bad Request")
             .hasMessageContaining("Temporary Certificate validOnDate cannot be in the past")
+    }
+
+    @Test
+    fun `should return not found given no local authority found for the provided gss code`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCodeNoMatch(GSS_CODE)
+        val requestBody = buildGenerateTemporaryCertificateRequest(gssCode = GSS_CODE)
+
+        // When
+        val response = webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-vc-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Temporary Certificate gssCode '$GSS_CODE' does not exist")
+    }
+
+    @Test
+    fun `should return not found given no local authority found for the provided ero and gss code`() {
+        // Given
+        val eroResponseHasDifferentEroIdToBearerTokenAndUri = buildElectoralRegistrationOfficeResponse(
+            id = OTHER_ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE))
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(eroResponseHasDifferentEroIdToBearerTokenAndUri, GSS_CODE)
+        val requestBody = buildGenerateTemporaryCertificateRequest(gssCode = GSS_CODE)
+
+        // When
+        val response = webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-vc-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Temporary Certificate gssCode '$GSS_CODE' is not valid for eroId '$ERO_ID'")
+    }
+
+    @Test
+    fun `should return temporary certificate pdf given valid request for authorised user`() {
+        // Given
+        val photoLocationArn = addPhotoToS3()
+        val request = buildGenerateTemporaryCertificateRequest(photoLocation = photoLocationArn)
+        val localAuthorityName = aValidLocalAuthorityName()
+        val localAuthorities: List<LocalAuthorityResponse> = listOf(
+            buildLocalAuthorityResponse(
+                gssCode = request.gssCode,
+                contactDetailsEnglish = buildContactDetails(name = localAuthorityName)
+            )
+        )
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID, localAuthorities = localAuthorities)
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(eroResponse, request.gssCode)
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_1_MB) }
+            .build().post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-vc-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(request)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val temporaryCertificates = temporaryCertificateRepository.findByGssCodeInAndSourceTypeAndSourceReference(
+            listOf(request.gssCode),
+            VOTER_CARD,
+            request.sourceReference
+        )
+        assertThat(temporaryCertificates).hasSize(1)
+        val temporaryCertificate = temporaryCertificates[0]
+        val contentDisposition = response.responseHeaders.contentDisposition
+        assertThat(contentDisposition.filename)
+            .isEqualTo("temporary-certificate-${temporaryCertificate.certificateNumber}.pdf")
+
+        val pdfContent = response.responseBody
+        assertThat(pdfContent).isNotNull
+        PdfReader(pdfContent).use { reader ->
+            assertThat(reader.acroFields.getField("localAuthorityEn")).isEqualTo(localAuthorityName)
+        }
+    }
+
+    private fun addPhotoToS3(): String {
+        val s3Resource = ResourceUtils.getFile(CERTIFICATE_SAMPLE_PHOTO).readBytes()
+        val s3Bucket = LocalStackContainerConfiguration.S3_BUCKET_CONTAINING_PHOTOS
+        val s3Path = "E09000007/0013a30ac9bae2ebb9b1239b/${UUID.randomUUID()}/8a53a30ac9bae2ebb9b1239b-test-photo.png"
+
+        // add resource to S3
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(s3Bucket)
+                .key(s3Path)
+                .build(),
+            RequestBody.fromInputStream(ByteArrayInputStream(s3Resource), s3Resource.size.toLong())
+        )
+        return "arn:aws:s3:::$s3Bucket/$s3Path"
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/S3ArnParserKtTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/S3ArnParserKtTest.kt
@@ -1,0 +1,38 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class S3ArnParserKtTest {
+
+    @Test
+    fun `should parse S3 ARN with qualifier`() {
+        // Given
+        val photoArn =
+            "arn:aws:s3:::dev-vca-api-vca-target-bucket/E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+        val expectedS3Location = S3Location(
+            "dev-vca-api-vca-target-bucket",
+            "E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+        )
+
+        // When
+        val s3Location = parseS3Arn(photoArn)
+
+        // Then
+        assertThat(s3Location).isEqualTo(expectedS3Location)
+    }
+
+    @Test
+    fun `should parse S3 ARN without qualifier`() {
+        // Given
+        val photoArn = "arn:aws:s3:::dev-vca-api-vca-target-bucket/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+        val expectedS3Location =
+            S3Location("dev-vca-api-vca-target-bucket", "8a53a30ac9bae2ebb9b1239b-initial-photo-1.png")
+
+        // When
+        val s3Location = parseS3Arn(photoArn)
+
+        // Then
+        assertThat(s3Location).isEqualTo(expectedS3Location)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
@@ -12,7 +12,10 @@ fun aPhotoLocation(): PhotoLocation = buildPhotoLocation()
 
 fun aPhotoLocationList(): List<PhotoLocation> = listOf(aPhotoLocation())
 
-fun aPhotoArn() = "arn:aws:s3:::dev-vca-api-vca-target-bucket/E09000007/0013a30ac9bae2ebb9b1239b/0d77b2ad-64e7-4aa9-b4de-d58380392962/8a53a30ac9bae2ebb9b1239b-initial-photo-1.png"
+fun aPhotoArn(
+    bucket: String = aPhotoBucket(),
+    path: String = aPhotoBucketPath()
+) = "arn:aws:s3:::$bucket/$path"
 
 fun aPhotoBucket() = "dev-vca-api-vca-target-bucket"
 


### PR DESCRIPTION
Updates the Controller and Integration tests for generation of the PDF temporary certificate - includes additional request validation in the service that the GSS code included in the request finds an ERO that the user is allowed access.