### PR TITLE
EIP1-511 - openAPI doc for endpoint to get Temporary Certificates for an application

### DIFF
--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -488,11 +488,23 @@ components:
           format: date-time
           description: The timestamp in ISO-8601 UTC that the Temporary Certificate was generated
           example: '2022-11-17T10:53:25Z'
+        issueDate:
+          type: string
+          format: date
+          description: The date that the Temporary Certificate was issued
+          example: '2022-11-17'
+        validOnDate:
+          type: string
+          format: date
+          description: The date on which the Temporary Certificate is/was valid
+          example: '2022-11-19'
       required:
         - certificateNumber
         - status
         - userId
         - dateTime
+        - issueDate
+        - validOnDate
     TemporaryCertificateStatus:
       title: TemporaryCertificateStatus
       type: string

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.3.0'
+  version: '1.4.0'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -97,6 +97,85 @@ paths:
         connectionId: '${vpc_connection_id}'
         httpMethod: GET
 
+
+  #
+  # Temporary Certificates for a Voter Card Application
+  # --------------------------------------------------------------------------------
+  '/eros/{eroId}/temporary-certificates/applications/{applicationId}':
+    parameters:
+      - name: eroId
+        description: The ID of the Electoral Registration Office responsible for the application.
+        schema:
+          type: string
+        in: path
+        required: true
+      - name: applicationId
+        description: The identifier of the Voter Card Application.
+        schema:
+          type: string
+        in: path
+        required: true
+    options:
+      summary: CORS support
+      description: |
+        Enable CORS by returning correct headers
+      tags:
+        - Temporary Certificate Summaries
+      responses:
+        200:
+          description: Default response for CORS method
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content: { }
+      x-amazon-apigateway-integration:
+        type: mock
+        requestTemplates:
+          application/json: |
+            {
+              "statusCode" : 200
+            }
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+              method.response.header.Access-Control-Allow-Methods: '''*'''
+              method.response.header.Access-Control-Allow-Origin: '''*'''
+            responseTemplates:
+              application/json: |
+                {}
+    get:
+      summary: Returns the Temporary Certificate summaries for an application
+      description: Returns the Temporary Certificate summaries for an application
+      tags:
+        - Temporary Certificate Summaries
+      responses:
+        200:
+          $ref: '#/components/responses/TemporaryCertificateSummaries'
+      operationId: get-temporary-certificate-summaries-by-application-id
+      security:
+        - eroUserCognitoUserPoolAuthorizer: [ ]
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/eros/{eroId}/temporary-certificates/applications/{applicationId}'
+        requestParameters:
+          integration.request.path.eroId: method.request.path.eroId
+          integration.request.path.applicationId: method.request.path.applicationId
+        responseParameters:
+          method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+          method.response.header.Access-Control-Allow-Methods: '''*'''
+          method.response.header.Access-Control-Allow-Origin: '''*'''
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: POST
 
   #
   # Temporary Certificate
@@ -375,6 +454,51 @@ components:
         - en
       default: en
 
+    TemporaryCertificateSummariesResponse:
+      title: TemporaryCertificateSummariesResponse
+      type: object
+      description: A response containing a collection of Temporary Certificate summaries
+      properties:
+        temporaryCertificates:
+          type: array
+          description: List of Temporary Certificate summaries for the application.
+          items:
+            $ref: '#/components/schemas/TemporaryCertificateSummary'
+      required:
+        - temporaryCertificates
+    TemporaryCertificateSummary:
+      title: TemporaryCertificateSummary
+      type: object
+      description: An object containing Temporary Certificate summary
+      properties:
+        certificateNumber:
+          type: string
+          pattern: '^[0-9AC-HJ-NP-RT-Z]{20}$'
+          description: The unique identifier of the Certificate. A 20 character alphanumeric string.
+          example: DEV1W0XDH1368LWE1J40
+        status:
+          $ref: '#/components/schemas/TemporaryCertificateStatus'
+        userId:
+          type: string
+          format: email
+          example: fred.blogs@some-domain.co.uk
+          description: UserId of the user who generated the Temporary Certificate
+        dateTime:
+          type: string
+          format: date-time
+          description: The timestamp in ISO-8601 UTC that the Temporary Certificate was generated
+          example: '2022-11-17T10:53:25Z'
+      required:
+        - certificateNumber
+        - status
+        - userId
+        - dateTime
+    TemporaryCertificateStatus:
+      title: TemporaryCertificateStatus
+      type: string
+      enum:
+        - generated
+
     GenerateTemporaryCertificateRequest:
       title: GenerateTemporaryCertificateRequest
       description: Request body to generate a Temporary Certificate
@@ -456,6 +580,22 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/CertificateSummaryResponse'
+    TemporaryCertificateSummaries:
+      description: Response containing a collection of Temporary Certificate summaries
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/TemporaryCertificateSummariesResponse'
   #
   # Request Body Definitions
   # --------------------------------------------------------------------------------

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -483,7 +483,7 @@ components:
           format: email
           example: fred.blogs@some-domain.co.uk
           description: UserId of the user who generated the Temporary Certificate
-        dateTime:
+        dateTimeGenerated:
           type: string
           format: date-time
           description: The timestamp in ISO-8601 UTC that the Temporary Certificate was generated
@@ -502,7 +502,7 @@ components:
         - certificateNumber
         - status
         - userId
-        - dateTime
+        - dateTimeGenerated
         - issueDate
         - validOnDate
     TemporaryCertificateStatus:


### PR DESCRIPTION
This PR adds the new API spec for the REST API to get the Temporary Certificate summaries for an application

![Screenshot 2023-02-10 at 14 06 46](https://user-images.githubusercontent.com/78348259/218111903-f914f131-187f-4ab2-b7c9-2003a85b2af9.png)
