### PR TITLE
EIP1-511 - Basic controller with 401/403 scenarios

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/TemporaryCertificateController.kt
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.printapi.dto.PdfFile
 import uk.gov.dluhc.printapi.mapper.GenerateTemporaryCertificateMapper
 import uk.gov.dluhc.printapi.models.GenerateTemporaryCertificateRequest
+import uk.gov.dluhc.printapi.models.TemporaryCertificateSummariesResponse
 import uk.gov.dluhc.printapi.service.temporarycertificate.ExplainerPdfService
 import uk.gov.dluhc.printapi.service.temporarycertificate.TemporaryCertificateService
 import java.io.ByteArrayInputStream
@@ -27,6 +29,15 @@ class TemporaryCertificateController(
     private val temporaryCertificateService: TemporaryCertificateService,
     private val generateTemporaryCertificateMapper: GenerateTemporaryCertificateMapper,
 ) {
+
+    @GetMapping("/eros/{eroId}/temporary-certificates/applications/{applicationId}")
+    @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)
+    fun getTemporaryCertificateSummariesByApplicationId(
+        @PathVariable eroId: String,
+        @PathVariable applicationId: String,
+    ): TemporaryCertificateSummariesResponse {
+        TODO("not yet implemented")
+    }
 
     @PostMapping("/eros/{eroId}/temporary-certificate")
     @PreAuthorize(HAS_ERO_VC_ADMIN_AUTHORITY)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/ControllerSpringSecurityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/ControllerSpringSecurityIntegrationTest.kt
@@ -17,7 +17,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
  * Security is a cross-cutting concern across all REST APIs so does not need to be repeated for every REST API endpoint. We
  * only need to test this once.
  */
-internal class SpringSecurityIntegrationTest : IntegrationTest() {
+internal class ControllerSpringSecurityIntegrationTest : IntegrationTest() {
 
     companion object {
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/certificates/applications/{APPLICATION_ID}"

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.http.MediaType
 import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.testsupport.bearerToken
-import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
@@ -23,40 +22,6 @@ internal class GenerateTemporaryCertificateExplainerDocumentIntegrationTest : In
         private const val OTHER_ERO_ID = "other-city-council"
         private const val GSS_CODE = "E99999999"
         private const val MAX_SIZE_1_MB = 1024 * 1024
-    }
-
-    @Test
-    fun `should return unauthorized given no bearer token`() {
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID, GSS_CODE)
-            .exchange()
-            .expectStatus()
-            .isForbidden
-    }
-
-    @Test
-    fun `should return unauthorized given user with invalid bearer token`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID, GSS_CODE)
-            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus()
-            .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID, GSS_CODE)
-            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-admin-$ERO_ID")))
-            .contentType(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus()
-            .isForbidden
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateIntegrationTest.kt
@@ -15,7 +15,6 @@ import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
 import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.testsupport.assertj.assertions.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
-import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
@@ -38,43 +37,6 @@ internal class GenerateTemporaryCertificateIntegrationTest : IntegrationTest() {
         private const val CERTIFICATE_SAMPLE_PHOTO =
             "classpath:temporary-certificate-template/sample-certificate-photo.png"
         private const val MAX_SIZE_1_MB = 1024 * 1024
-    }
-
-    @Test
-    fun `should return forbidden given no bearer token`() {
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID)
-            .withBody(buildGenerateTemporaryCertificateRequest())
-            .exchange()
-            .expectStatus()
-            .isForbidden
-    }
-
-    @Test
-    fun `should return unauthorized given user with invalid bearer token`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID)
-            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON)
-            .withBody(buildGenerateTemporaryCertificateRequest())
-            .exchange()
-            .expectStatus()
-            .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-
-        webTestClient.post()
-            .uri(URI_TEMPLATE, ERO_ID)
-            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-admin-$ERO_ID")))
-            .contentType(MediaType.APPLICATION_JSON)
-            .withBody(buildGenerateTemporaryCertificateRequest())
-            .exchange()
-            .expectStatus()
-            .isForbidden
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
@@ -10,8 +10,6 @@ import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
 import uk.gov.dluhc.printapi.models.PrintRequestStatus
 import uk.gov.dluhc.printapi.models.PrintRequestSummary
 import uk.gov.dluhc.printapi.testsupport.bearerToken
-import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
-import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
@@ -26,59 +24,6 @@ internal class GetCertificateSummaryByApplicationIdIntegrationTest : Integration
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/certificates/applications/{APPLICATION_ID}"
         private const val ERO_ID = "some-city-council"
         private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
-    }
-
-    @Test
-    fun `should return unauthorized given no bearer token`() {
-        webTestClient.get()
-            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
-            .exchange()
-            .expectStatus()
-            .isUnauthorized
-    }
-
-    @Test
-    fun `should return unauthorized given user with invalid bearer token`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-        webTestClient.get()
-            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
-            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
-            .contentType(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus()
-            .isUnauthorized
-    }
-
-    @Test
-    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-
-        webTestClient.get()
-            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
-            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-admin-$ERO_ID")))
-            .contentType(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus()
-            .isForbidden
-    }
-
-    @Test
-    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
-        wireMockService.stubCognitoJwtIssuerResponse()
-        val userGroupEroId = anotherValidEroId(ERO_ID)
-
-        webTestClient.get()
-            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
-            .bearerToken(
-                getBearerToken(
-                    eroId = userGroupEroId,
-                    groups = listOf("ero-$userGroupEroId", "ero-vc-admin-$userGroupEroId")
-                )
-            )
-            .contentType(MediaType.APPLICATION_JSON)
-            .exchange()
-            .expectStatus()
-            .isForbidden
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
 import uk.gov.dluhc.printapi.models.PrintRequestStatus
 import uk.gov.dluhc.printapi.models.PrintRequestSummary
 import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
@@ -24,6 +25,25 @@ internal class GetCertificateSummaryByApplicationIdIntegrationTest : Integration
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/certificates/applications/{APPLICATION_ID}"
         private const val ERO_ID = "some-city-council"
         private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(
+                getBearerToken(
+                    eroId = userGroupEroId,
+                    groups = listOf("ero-$userGroupEroId", "ero-vc-admin-$userGroupEroId")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetTemporaryCertificateSummariesByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetTemporaryCertificateSummariesByApplicationIdIntegrationTest.kt
@@ -1,0 +1,36 @@
+package uk.gov.dluhc.printapi.rest
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+
+internal class GetTemporaryCertificateSummariesByApplicationIdIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/temporary-certificates/applications/{APPLICATION_ID}"
+        private const val ERO_ID = "some-city-council"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(
+                getBearerToken(
+                    eroId = userGroupEroId,
+                    groups = listOf("ero-$userGroupEroId", "ero-vc-admin-$userGroupEroId")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/SpringSecurityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/SpringSecurityIntegrationTest.kt
@@ -1,0 +1,61 @@
+package uk.gov.dluhc.printapi.rest
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.UNAUTHORIZED_BEARER_TOKEN
+import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+
+/**
+ * Integration test that tests the basic spring security configuration concerns that are common across all API endpoints.
+ * Specifically:
+ * - A web request presented with no bearer token
+ * - A web request presented with an invalid/corrupt bearer token.
+ * - A web request presented with a bearer token that is not in the required group
+ *
+ * Security is a cross-cutting concern across all REST APIs so does not need to be repeated for every REST API endpoint. We
+ * only need to test this once.
+ */
+internal class SpringSecurityIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/certificates/applications/{APPLICATION_ID}"
+        private const val ERO_ID = "some-city-council"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
+    }
+
+    @Test
+    fun `should return unauthorized given no bearer token`() {
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return unauthorized given user with invalid bearer token`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(UNAUTHORIZED_BEARER_TOKEN)
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isUnauthorized
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different group`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+}


### PR DESCRIPTION
This PR adds the basic controller for the new endpoint to get the Temporary Certificate Summaries for the application; complete with our usual 401/403 scenarios.

