### PR TITLE
EIP1-3946 Refactor the temporary certificate placeholder properties

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/TemporaryCertificateExplainerPdfTemplateProperties.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/TemporaryCertificateExplainerPdfTemplateProperties.kt
@@ -9,29 +9,6 @@ class TemporaryCertificateExplainerPdfTemplateProperties(
     val english: English,
     val welsh: Welsh
 ) {
-    //  explainer-pdf:
-    //     english:
-    //       path: "classpath:temporary-certificate-template/Explainer Document (English).pdf"
-    //       placeholder:
-    //         ero-name: "ero-recipient"
-    //         ero-address-line1: "ero-address-1-en"
-    //         ero-address-line2: "ero-address-2-en"
-    //         ero-address-line3: "ero-address-3-en"
-    //         ero-address-line4: "ero-address-4-en"
-    //         ero-address-postcode: "ero-postcode-en"
-    //         ero-email: "ero-email-en"
-    //         ero-phone: "ero-phonenumber-en"
-    //     welsh:
-    //       path: "classpath:temporary-certificate-template/Explainer Document (Dual Language).pdf"
-    //       placeholder:
-    //         ero-name: "ero-recipient"
-    //         ero-address-line1: "ero-address-1-cy"
-    //         ero-address-line2: "ero-address-2-cy"
-    //         ero-address-line3: "ero-address-3-cy"
-    //         ero-address-line4: "ero-address-4-cy"
-    //         ero-address-postcode: "ero-postcode-cy"
-    //         ero-email: "ero-email-cy"
-    //         ero-phone: "ero-phonenumber-cy"
     data class English(
         val path: String,
         val placeholder: Placeholder,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/TemporaryCertificateExplainerPdfTemplateProperties.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/TemporaryCertificateExplainerPdfTemplateProperties.kt
@@ -1,0 +1,55 @@
+package uk.gov.dluhc.printapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConfigurationProperties(prefix = "temporary-certificate.explainer-pdf")
+@ConstructorBinding
+class TemporaryCertificateExplainerPdfTemplateProperties(
+    val english: English,
+    val welsh: Welsh
+) {
+    //  explainer-pdf:
+    //     english:
+    //       path: "classpath:temporary-certificate-template/Explainer Document (English).pdf"
+    //       placeholder:
+    //         ero-name: "ero-recipient"
+    //         ero-address-line1: "ero-address-1-en"
+    //         ero-address-line2: "ero-address-2-en"
+    //         ero-address-line3: "ero-address-3-en"
+    //         ero-address-line4: "ero-address-4-en"
+    //         ero-address-postcode: "ero-postcode-en"
+    //         ero-email: "ero-email-en"
+    //         ero-phone: "ero-phonenumber-en"
+    //     welsh:
+    //       path: "classpath:temporary-certificate-template/Explainer Document (Dual Language).pdf"
+    //       placeholder:
+    //         ero-name: "ero-recipient"
+    //         ero-address-line1: "ero-address-1-cy"
+    //         ero-address-line2: "ero-address-2-cy"
+    //         ero-address-line3: "ero-address-3-cy"
+    //         ero-address-line4: "ero-address-4-cy"
+    //         ero-address-postcode: "ero-postcode-cy"
+    //         ero-email: "ero-email-cy"
+    //         ero-phone: "ero-phonenumber-cy"
+    data class English(
+        val path: String,
+        val placeholder: Placeholder,
+    )
+
+    data class Welsh(
+        val path: String,
+        val placeholder: Placeholder,
+    )
+
+    data class Placeholder(
+        val contactDetails1: String,
+        val contactDetails2: String,
+        val contactDetails3: String,
+        val contactDetails4: String,
+        val contactDetails5: String,
+        val contactDetails6: String,
+        val contactDetails7: String,
+        val contactDetails8: String,
+    )
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -91,25 +91,25 @@ temporary-certificate:
     english:
       path: "classpath:temporary-certificate-template/Explainer Document (English).pdf"
       placeholder:
-        ero-name: "ero-recipient"
-        ero-address-line1: "ero-address-1-en"
-        ero-address-line2: "ero-address-2-en"
-        ero-address-line3: "ero-address-3-en"
-        ero-address-line4: "ero-address-4-en"
-        ero-address-postcode: "ero-postcode-en"
-        ero-email: "ero-email-en"
-        ero-phone: "ero-phonenumber-en"
+        contact-details1: "ero-recipient"
+        contact-details2: "ero-address-1-en"
+        contact-details3: "ero-address-2-en"
+        contact-details4: "ero-address-3-en"
+        contact-details5: "ero-address-4-en"
+        contact-details6: "ero-postcode-en"
+        contact-details7: "ero-email-en"
+        contact-details8: "ero-phonenumber-en"
     welsh:
       path: "classpath:temporary-certificate-template/Explainer Document (Dual Language).pdf"
       placeholder:
-        ero-name: "ero-recipient"
-        ero-address-line1: "ero-address-1-cy"
-        ero-address-line2: "ero-address-2-cy"
-        ero-address-line3: "ero-address-3-cy"
-        ero-address-line4: "ero-address-4-cy"
-        ero-address-postcode: "ero-postcode-cy"
-        ero-email: "ero-email-cy"
-        ero-phone: "ero-phonenumber-cy"
+        contact-details1: "ero-recipient"
+        contact-details2: "ero-address-1-cy"
+        contact-details3: "ero-address-2-cy"
+        contact-details4: "ero-address-3-cy"
+        contact-details5: "ero-address-4-cy"
+        contact-details6: "ero-postcode-cy"
+        contact-details7: "ero-email-cy"
+        contact-details8: "ero-phonenumber-cy"
 
 thread-pool:
   zip:

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/ExplainerPdfTemplateDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/ExplainerPdfTemplateDetailsFactoryTest.kt
@@ -4,10 +4,17 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.dluhc.printapi.config.TemporaryCertificateExplainerPdfTemplateProperties
+import uk.gov.dluhc.printapi.config.TemporaryCertificateExplainerPdfTemplateProperties.English
+import uk.gov.dluhc.printapi.config.TemporaryCertificateExplainerPdfTemplateProperties.Placeholder
+import uk.gov.dluhc.printapi.config.TemporaryCertificateExplainerPdfTemplateProperties.Welsh
+import uk.gov.dluhc.printapi.dto.AddressDto
 import uk.gov.dluhc.printapi.service.GssCodeInterpreterKtTest.Companion.GSS_CODE_ENGLAND
 import uk.gov.dluhc.printapi.service.GssCodeInterpreterKtTest.Companion.GSS_CODE_NORTHERN_IRELAND
 import uk.gov.dluhc.printapi.service.GssCodeInterpreterKtTest.Companion.GSS_CODE_SCOTLAND
 import uk.gov.dluhc.printapi.service.GssCodeInterpreterKtTest.Companion.GSS_CODE_WALES
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.aWelshEroContactDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.anEnglishEroContactDetails
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildEroDto
 
 internal class ExplainerPdfTemplateDetailsFactoryTest {
@@ -18,62 +25,82 @@ internal class ExplainerPdfTemplateDetailsFactoryTest {
         private const val WELSH_TEMPLATE_PATH = "/path/to/welsh-template.pdf"
 
         // English placeholders
-        private const val ENGLISH_PLACEHOLDER_ERO_NAME = "eroNameEnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_LINE1 = "eroAddressLine1EnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_LINE2 = "eroAddressLine2EnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_LINE3 = "eroAddressLine3EnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_LINE4 = "eroAddressLine4EnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_POSTCODE = "eroAddressPostcodeEnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_EMAIL = "eroEmailAddressEnPlaceholder"
-        private const val ENGLISH_PLACEHOLDER_ERO_PHONE = "eroPhoneNumberEnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_1 = "eroNameEnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_2 = "eroAddressLine1EnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_3 = "eroAddressLine2EnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_4 = "eroAddressLine3EnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_5 = "eroAddressLine4EnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_6 = "eroAddressPostcodeEnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_7 = "eroEmailAddressEnPlaceholder"
+        private const val ENGLISH_CONTACT_DETAIL_8 = "eroPhoneNumberEnPlaceholder"
 
         // Welsh placeholders
-        private const val WELSH_PLACEHOLDER_ERO_NAME = "eroNameCyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_LINE1 = "eroAddressLine1CyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_LINE2 = "eroAddressLine2CyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_LINE3 = "eroAddressLine3CyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_LINE4 = "eroAddressLine4CyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_POSTCODE = "eroAddressPostcodeCyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_EMAIL = "eroEmailAddressCyPlaceholder"
-        private const val WELSH_PLACEHOLDER_ERO_PHONE = "eroPhoneNumberCyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_1 = "eroNameCyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_2 = "eroAddressLine1CyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_3 = "eroAddressLine2CyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_4 = "eroAddressLine3CyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_5 = "eroAddressLine4CyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_6 = "eroAddressPostcodeCyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_7 = "eroEmailAddressCyPlaceholder"
+        private const val WELSH_CONTACT_DETAIL_8 = "eroPhoneNumberCyPlaceholder"
     }
 
     private val templateSelector = ExplainerPdfTemplateDetailsFactory(
-        ENGLISH_TEMPLATE_PATH,
-        ENGLISH_PLACEHOLDER_ERO_NAME,
-        ENGLISH_PLACEHOLDER_ERO_LINE1,
-        ENGLISH_PLACEHOLDER_ERO_LINE2,
-        ENGLISH_PLACEHOLDER_ERO_LINE3,
-        ENGLISH_PLACEHOLDER_ERO_LINE4,
-        ENGLISH_PLACEHOLDER_ERO_POSTCODE,
-        ENGLISH_PLACEHOLDER_ERO_EMAIL,
-        ENGLISH_PLACEHOLDER_ERO_PHONE,
-        WELSH_TEMPLATE_PATH,
-        WELSH_PLACEHOLDER_ERO_NAME,
-        WELSH_PLACEHOLDER_ERO_LINE1,
-        WELSH_PLACEHOLDER_ERO_LINE2,
-        WELSH_PLACEHOLDER_ERO_LINE3,
-        WELSH_PLACEHOLDER_ERO_LINE4,
-        WELSH_PLACEHOLDER_ERO_POSTCODE,
-        WELSH_PLACEHOLDER_ERO_EMAIL,
-        WELSH_PLACEHOLDER_ERO_PHONE,
+        TemporaryCertificateExplainerPdfTemplateProperties(
+            English(
+                ENGLISH_TEMPLATE_PATH,
+                Placeholder(
+                    ENGLISH_CONTACT_DETAIL_1,
+                    ENGLISH_CONTACT_DETAIL_2,
+                    ENGLISH_CONTACT_DETAIL_3,
+                    ENGLISH_CONTACT_DETAIL_4,
+                    ENGLISH_CONTACT_DETAIL_5,
+                    ENGLISH_CONTACT_DETAIL_6,
+                    ENGLISH_CONTACT_DETAIL_7,
+                    ENGLISH_CONTACT_DETAIL_8
+                )
+            ),
+            Welsh(
+                WELSH_TEMPLATE_PATH,
+                Placeholder(
+                    WELSH_CONTACT_DETAIL_1,
+                    WELSH_CONTACT_DETAIL_2,
+                    WELSH_CONTACT_DETAIL_3,
+                    WELSH_CONTACT_DETAIL_4,
+                    WELSH_CONTACT_DETAIL_5,
+                    WELSH_CONTACT_DETAIL_6,
+                    WELSH_CONTACT_DETAIL_7,
+                    WELSH_CONTACT_DETAIL_8
+                )
+            )
+        )
     )
 
     @ParameterizedTest
     @CsvSource(value = [GSS_CODE_ENGLAND, GSS_CODE_SCOTLAND, GSS_CODE_NORTHERN_IRELAND])
     fun `should get template details when English template selected`(gssCode: String) {
         // Given
-        val eroDto = buildEroDto()
+        val eroDto = buildEroDto(
+            englishContactDetails = anEnglishEroContactDetails(
+                address = AddressDto(
+                    property = "Gwynedd Council Headquarters",
+                    street = "Shirehall Street",
+                    town = "Caernarfon",
+                    area = "Gwynedd",
+                    postcode = "LL55 1SH",
+                )
+            )
+        )
         val expectedPlaceholders = with(eroDto.englishContactDetails) {
             mapOf(
-                ENGLISH_PLACEHOLDER_ERO_NAME to name,
-                ENGLISH_PLACEHOLDER_ERO_LINE1 to address.property.orEmpty(),
-                ENGLISH_PLACEHOLDER_ERO_LINE2 to address.street,
-                ENGLISH_PLACEHOLDER_ERO_LINE3 to address.town.orEmpty(),
-                ENGLISH_PLACEHOLDER_ERO_LINE4 to address.area.orEmpty(),
-                ENGLISH_PLACEHOLDER_ERO_POSTCODE to address.postcode,
-                ENGLISH_PLACEHOLDER_ERO_EMAIL to emailAddress,
-                ENGLISH_PLACEHOLDER_ERO_PHONE to phoneNumber,
+                ENGLISH_CONTACT_DETAIL_1 to name,
+                ENGLISH_CONTACT_DETAIL_2 to address.property,
+                ENGLISH_CONTACT_DETAIL_3 to address.street,
+                ENGLISH_CONTACT_DETAIL_4 to address.town,
+                ENGLISH_CONTACT_DETAIL_5 to address.area,
+                ENGLISH_CONTACT_DETAIL_6 to address.postcode,
+                ENGLISH_CONTACT_DETAIL_7 to emailAddress,
+                ENGLISH_CONTACT_DETAIL_8 to phoneNumber,
             )
         }
 
@@ -89,17 +116,63 @@ internal class ExplainerPdfTemplateDetailsFactoryTest {
     fun `should get template details when Welsh template selected`() {
         // Given
         val gssCode = GSS_CODE_WALES
-        val eroDto = buildEroDto()
+        val eroDto = buildEroDto(
+            welshContactDetails = aWelshEroContactDetails(
+                address = AddressDto(
+                    property = "Pencadlys Cyngor Gwynedd",
+                    street = "Stryd y Jêl",
+                    town = "Caernarfon",
+                    area = "Gwynedd",
+                    postcode = "LL55 1SH",
+                )
+            )
+        )
         val expectedPlaceholders = with(eroDto.welshContactDetails!!) {
             mapOf(
-                WELSH_PLACEHOLDER_ERO_NAME to name,
-                WELSH_PLACEHOLDER_ERO_LINE1 to address.property.orEmpty(),
-                WELSH_PLACEHOLDER_ERO_LINE2 to address.street,
-                WELSH_PLACEHOLDER_ERO_LINE3 to address.town.orEmpty(),
-                WELSH_PLACEHOLDER_ERO_LINE4 to address.area.orEmpty(),
-                WELSH_PLACEHOLDER_ERO_POSTCODE to address.postcode,
-                WELSH_PLACEHOLDER_ERO_EMAIL to emailAddress,
-                WELSH_PLACEHOLDER_ERO_PHONE to phoneNumber,
+                WELSH_CONTACT_DETAIL_1 to name,
+                WELSH_CONTACT_DETAIL_2 to address.property,
+                WELSH_CONTACT_DETAIL_3 to address.street,
+                WELSH_CONTACT_DETAIL_4 to address.town,
+                WELSH_CONTACT_DETAIL_5 to address.area,
+                WELSH_CONTACT_DETAIL_6 to address.postcode,
+                WELSH_CONTACT_DETAIL_7 to emailAddress,
+                WELSH_CONTACT_DETAIL_8 to phoneNumber,
+            )
+        }
+
+        // When
+        val actual = templateSelector.getTemplateDetails(gssCode, eroDto)
+
+        // Then
+        assertThat(actual.path).isEqualTo(WELSH_TEMPLATE_PATH)
+        assertThat(actual.placeholders).isEqualTo(expectedPlaceholders)
+    }
+
+    @Test
+    fun `should get template details when optional properties are not available`() {
+        // Given
+        val gssCode = GSS_CODE_WALES
+        val eroDto = buildEroDto(
+            welshContactDetails = aWelshEroContactDetails(
+                address = AddressDto(
+                    property = null,
+                    street = "Stryd y Jêl",
+                    town = null,
+                    area = null,
+                    postcode = "LL55 1SH",
+                )
+            )
+        )
+        val expectedPlaceholders = with(eroDto.welshContactDetails!!) {
+            mapOf(
+                WELSH_CONTACT_DETAIL_1 to name,
+                WELSH_CONTACT_DETAIL_2 to address.street,
+                WELSH_CONTACT_DETAIL_3 to address.postcode,
+                WELSH_CONTACT_DETAIL_4 to emailAddress,
+                WELSH_CONTACT_DETAIL_5 to phoneNumber,
+                WELSH_CONTACT_DETAIL_6 to "",
+                WELSH_CONTACT_DETAIL_7 to "",
+                WELSH_CONTACT_DETAIL_8 to "",
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/ExplainerPdfTemplateDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/ExplainerPdfTemplateDetailsFactoryTest.kt
@@ -183,4 +183,39 @@ internal class ExplainerPdfTemplateDetailsFactoryTest {
         assertThat(actual.path).isEqualTo(WELSH_TEMPLATE_PATH)
         assertThat(actual.placeholders).isEqualTo(expectedPlaceholders)
     }
+    @Test
+    fun `should get template details when optional properties are blank`() {
+        // Given
+        val gssCode = GSS_CODE_WALES
+        val eroDto = buildEroDto(
+            welshContactDetails = aWelshEroContactDetails(
+                address = AddressDto(
+                    property = "",
+                    street = "Stryd y Jêl",
+                    town = "",
+                    area = "",
+                    postcode = "LL55 1SH",
+                )
+            )
+        )
+        val expectedPlaceholders = with(eroDto.welshContactDetails!!) {
+            mapOf(
+                WELSH_CONTACT_DETAIL_1 to name,
+                WELSH_CONTACT_DETAIL_2 to address.street,
+                WELSH_CONTACT_DETAIL_3 to address.postcode,
+                WELSH_CONTACT_DETAIL_4 to emailAddress,
+                WELSH_CONTACT_DETAIL_5 to phoneNumber,
+                WELSH_CONTACT_DETAIL_6 to "",
+                WELSH_CONTACT_DETAIL_7 to "",
+                WELSH_CONTACT_DETAIL_8 to "",
+            )
+        }
+
+        // When
+        val actual = templateSelector.getTemplateDetails(gssCode, eroDto)
+
+        // Then
+        assertThat(actual.path).isEqualTo(WELSH_TEMPLATE_PATH)
+        assertThat(actual.placeholders).isEqualTo(expectedPlaceholders)
+    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroContactDetailsDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/EroContactDetailsDtoBuilder.kt
@@ -3,32 +3,40 @@ package uk.gov.dluhc.printapi.testsupport.testdata.dto
 import uk.gov.dluhc.printapi.dto.AddressDto
 import uk.gov.dluhc.printapi.dto.EroContactDetailsDto
 
-fun anEnglishEroContactDetails(): EroContactDetailsDto =
+fun anEnglishEroContactDetails(
+    address: AddressDto = anEnglishEroAddress(),
+): EroContactDetailsDto =
     EroContactDetailsDto(
         name = "Gwynedd Council Elections",
         phoneNumber = "01766 771000",
         website = "https://www.gwynedd.llyw.cymru/en/Council/Contact-us/Contact-us.aspx",
         emailAddress = "TrethCyngor@gwynedd.llyw.cymru",
-        address = AddressDto(
-            property = "Gwynedd Council Headquarters",
-            street = "Shirehall Street",
-            town = "Caernarfon",
-            area = "Gwynedd",
-            postcode = "LL55 1SH",
-        )
+        address = address
     )
 
-fun aWelshEroContactDetails(): EroContactDetailsDto =
+fun anEnglishEroAddress(): AddressDto = AddressDto(
+    property = "Gwynedd Council Headquarters",
+    street = "Shirehall Street",
+    town = "Caernarfon",
+    area = "Gwynedd",
+    postcode = "LL55 1SH",
+)
+
+fun aWelshEroContactDetails(
+    address: AddressDto = aWelshEroAddress(),
+): EroContactDetailsDto =
     EroContactDetailsDto(
         name = "Etholiadau Cyngor Gwynedd",
         phoneNumber = "01766 771000",
         website = "https://www.gwynedd.llyw.cymru/cy/Cyngor/Cysylltu-%c3%a2-ni/Cysylltu-%c3%a2-ni.aspx",
         emailAddress = "TrethCyngor@gwynedd.llyw.cymru",
-        address = AddressDto(
-            property = "Pencadlys Cyngor Gwynedd",
-            street = "Stryd y Jêl",
-            town = "Caernarfon",
-            area = "Gwynedd",
-            postcode = "LL55 1SH",
-        )
+        address = address
     )
+
+fun aWelshEroAddress(): AddressDto = AddressDto(
+    property = "Pencadlys Cyngor Gwynedd",
+    street = "Stryd y Jêl",
+    town = "Caernarfon",
+    area = "Gwynedd",
+    postcode = "LL55 1SH",
+)


### PR DESCRIPTION
Refactor the temporary certificate placeholder properties to dynamically assign values to appropriate placeholder to avoid leaving blank fields for optional data.

