### PR TITLE
EIP1-511 - Implemented controller through to service and repository

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/TemporaryCertificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/TemporaryCertificate.kt
@@ -128,6 +128,11 @@ class TemporaryCertificate(
     val status: TemporaryCertificateStatus.Status?
         get() = statusHistory.sortedByDescending { it.dateCreated }.first().status
 
+    val dateTimeGenerated: Instant?
+        get() = statusHistory
+            .sortedBy { it.dateCreated }
+            .first { it.status == TemporaryCertificateStatus.Status.GENERATED }.dateCreated
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/TemporaryCertificateStatusDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/TemporaryCertificateStatusDto.kt
@@ -1,0 +1,5 @@
+package uk.gov.dluhc.printapi.dto
+
+enum class TemporaryCertificateStatusDto {
+    GENERATED
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/TemporaryCertificateSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/TemporaryCertificateSummaryDto.kt
@@ -1,0 +1,13 @@
+package uk.gov.dluhc.printapi.dto
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+data class TemporaryCertificateSummaryDto(
+    val certificateNumber: String,
+    val status: TemporaryCertificateStatusDto,
+    val userId: String,
+    val dateTimeGenerated: OffsetDateTime,
+    val issueDate: LocalDate,
+    val validOnDate: LocalDate,
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/TemporaryCertificateSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/TemporaryCertificateSummaryMapper.kt
@@ -1,0 +1,14 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.dluhc.printapi.database.entity.TemporaryCertificate
+import uk.gov.dluhc.printapi.dto.TemporaryCertificateSummaryDto
+import uk.gov.dluhc.printapi.models.TemporaryCertificateSummary
+
+@Mapper(uses = [InstantMapper::class])
+interface TemporaryCertificateSummaryMapper {
+
+    fun toApiTemporaryCertificateSummary(dto: TemporaryCertificateSummaryDto): TemporaryCertificateSummary
+
+    fun toDtoTemporaryCertificateSummary(entity: TemporaryCertificate): TemporaryCertificateSummaryDto
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderService.kt
@@ -1,0 +1,19 @@
+package uk.gov.dluhc.printapi.service.temporarycertificate
+
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.database.entity.TemporaryCertificate
+import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
+import uk.gov.dluhc.printapi.service.EroService
+
+@Service
+class TemporaryCertificateFinderService(
+    private val eroService: EroService,
+    private val temporaryCertificateRepository: TemporaryCertificateRepository
+) {
+
+    fun getTemporaryCertificates(eroId: String, sourceType: SourceType, sourceReference: String): List<TemporaryCertificate> =
+        eroService.lookupGssCodesForEro(eroId).let { gssCodes ->
+            temporaryCertificateRepository.findByGssCodeInAndSourceTypeAndSourceReference(gssCodes, sourceType, sourceReference)
+        }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateSummaryService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateSummaryService.kt
@@ -1,0 +1,25 @@
+package uk.gov.dluhc.printapi.service.temporarycertificate
+
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.dto.TemporaryCertificateSummaryDto
+import uk.gov.dluhc.printapi.mapper.TemporaryCertificateSummaryMapper
+
+@Service
+class TemporaryCertificateSummaryService(
+    private val temporaryCertificateFinderService: TemporaryCertificateFinderService,
+    private val mapper: TemporaryCertificateSummaryMapper
+) {
+
+    fun getTemporaryCertificateSummaries(eroId: String, sourceType: SourceType, sourceReference: String):
+        List<TemporaryCertificateSummaryDto> {
+        val temporaryCertificates = temporaryCertificateFinderService.getTemporaryCertificates(
+            eroId,
+            sourceType,
+            sourceReference
+        )
+        return temporaryCertificates.map {
+            mapper.toDtoTemporaryCertificateSummary(it)
+        }
+    }
+}

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.4.0'
+  version: '1.4.1'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -175,7 +175,7 @@ paths:
           method.response.header.Access-Control-Allow-Origin: '''*'''
         connectionType: VPC_LINK
         connectionId: '${vpc_connection_id}'
-        httpMethod: POST
+        httpMethod: GET
 
   #
   # Temporary Certificate

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/TemporaryCertificateSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/TemporaryCertificateSummaryMapperTest.kt
@@ -1,0 +1,111 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.dluhc.printapi.database.entity.TemporaryCertificateStatus
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidGeneratedDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidOnDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildTemporaryCertificateSummaryDto
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildTemporaryCertificate
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildTemporaryCertificateStatus
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildTemporaryCertificateSummary
+import java.time.Instant
+import uk.gov.dluhc.printapi.dto.TemporaryCertificateStatusDto as TemporaryCertificateStatusDto
+import uk.gov.dluhc.printapi.models.TemporaryCertificateStatus as TemporaryCertificateStatusApi
+
+@ExtendWith(MockitoExtension::class)
+class TemporaryCertificateSummaryMapperTest {
+
+    @Mock
+    private lateinit var instantMapper: InstantMapper
+
+    @InjectMocks
+    private lateinit var mapper: TemporaryCertificateSummaryMapperImpl
+
+    @Test
+    fun `should map DTO to api model`() {
+        // Given
+        val certificateNumber = aValidCertificateNumber()
+        val userId = aValidUserId()
+        val dateTimeGenerated = aValidGeneratedDateTime()
+        val issueDate = aValidIssueDate()
+        val validOnDate = aValidOnDate()
+
+        val dto = buildTemporaryCertificateSummaryDto(
+            certificateNumber = certificateNumber,
+            userId = userId,
+            dateTimeGenerated = dateTimeGenerated,
+            issueDate = issueDate,
+            validOnDate = validOnDate,
+            status = TemporaryCertificateStatusDto.GENERATED
+        )
+        val expected = buildTemporaryCertificateSummary(
+            certificateNumber = certificateNumber,
+            userId = userId,
+            dateTimeGenerated = dateTimeGenerated,
+            issueDate = issueDate,
+            validOnDate = validOnDate,
+            status = TemporaryCertificateStatusApi.GENERATED
+        )
+
+        // When
+        val actual = mapper.toApiTemporaryCertificateSummary(dto)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+        verifyNoInteractions(instantMapper)
+    }
+
+    @Test
+    fun `should map entity to DTO`() {
+        // Given
+        val certificateNumber = aValidCertificateNumber()
+        val userId = aValidUserId()
+        val issueDate = aValidIssueDate()
+        val validOnDate = aValidOnDate()
+
+        val dateTimeGenerated = Instant.now()
+        val statusHistory = listOf(
+            buildTemporaryCertificateStatus(
+                status = TemporaryCertificateStatus.Status.GENERATED,
+                dateCreated = dateTimeGenerated
+            )
+        )
+        val entity = buildTemporaryCertificate(
+            certificateNumber = certificateNumber,
+            userId = userId,
+            issueDate = issueDate,
+            validOnDate = validOnDate,
+            statusHistory = statusHistory
+        )
+
+        val expectedDateTimeGenerated = aValidGeneratedDateTime()
+        given(instantMapper.toOffsetDateTime(any())).willReturn(expectedDateTimeGenerated)
+        val expected = buildTemporaryCertificateSummaryDto(
+            certificateNumber = certificateNumber,
+            userId = userId,
+            issueDate = issueDate,
+            validOnDate = validOnDate,
+            status = TemporaryCertificateStatusDto.GENERATED,
+            dateTimeGenerated = expectedDateTimeGenerated
+        )
+
+        // When
+        val actual = mapper.toDtoTemporaryCertificateSummary(entity)
+
+        // Then
+        verify(instantMapper).toOffsetDateTime(dateTimeGenerated)
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetTemporaryCertificateSummariesByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetTemporaryCertificateSummariesByApplicationIdIntegrationTest.kt
@@ -1,11 +1,20 @@
 package uk.gov.dluhc.printapi.rest
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.models.TemporaryCertificateStatus
+import uk.gov.dluhc.printapi.models.TemporaryCertificateSummariesResponse
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildTemporaryCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildTemporaryCertificateSummary
+import java.time.ZoneOffset.UTC
+import java.time.temporal.ChronoUnit.SECONDS
 
 internal class GetTemporaryCertificateSummariesByApplicationIdIntegrationTest : IntegrationTest() {
 
@@ -32,5 +41,77 @@ internal class GetTemporaryCertificateSummariesByApplicationIdIntegrationTest : 
             .exchange()
             .expectStatus()
             .isForbidden
+    }
+
+    @Test
+    fun `should return Temporary Certificate Summaries`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID)
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val temporaryCertificate1 = buildTemporaryCertificate(
+            sourceType = SourceType.VOTER_CARD,
+            sourceReference = APPLICATION_ID,
+            gssCode = eroResponse.localAuthorities[0].gssCode,
+        ).also {
+            temporaryCertificateRepository.save(it)
+        }
+
+        Thread.sleep(1000) // sleep for 1 second to ensure that the 2 temp certs are saved at different times and we can therefore predict and assert the order
+
+        val temporaryCertificate2 = buildTemporaryCertificate(
+            sourceType = SourceType.VOTER_CARD,
+            sourceReference = APPLICATION_ID,
+            gssCode = eroResponse.localAuthorities[0].gssCode,
+        ).also {
+            temporaryCertificateRepository.save(it)
+        }
+
+        val expectedTemporaryCertificateSummary1 = with(temporaryCertificate1) {
+            buildTemporaryCertificateSummary(
+                certificateNumber = certificateNumber!!,
+                status = TemporaryCertificateStatus.GENERATED,
+                userId = userId!!,
+                dateTimeGenerated = dateTimeGenerated!!.atOffset(UTC).truncatedTo(SECONDS),
+                issueDate = issueDate,
+                validOnDate = validOnDate!!,
+            )
+        }
+        val expectedTemporaryCertificateSummary2 = with(temporaryCertificate2) {
+            buildTemporaryCertificateSummary(
+                certificateNumber = certificateNumber!!,
+                status = TemporaryCertificateStatus.GENERATED,
+                userId = userId!!,
+                dateTimeGenerated = dateTimeGenerated!!.atOffset(UTC).truncatedTo(SECONDS),
+                issueDate = issueDate,
+                validOnDate = validOnDate!!,
+            )
+        }
+
+        // When
+        val response = webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-vc-admin-$ERO_ID")))
+            .contentType(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk
+
+        // Then
+        val actual = response.returnResult(TemporaryCertificateSummariesResponse::class.java).responseBody.blockFirst()
+        with(actual!!) {
+            assertThat(temporaryCertificates).hasSize(2)
+            // Assert that temp cert 2 is first in the list because it has a later dateTimeGenerated
+            // Ignore field comparison of dateTimeGenerated because millisecond rounding is hard to predict and control
+            assertThat(temporaryCertificates[0])
+                .usingRecursiveComparison()
+                .ignoringFields("dateTimeGenerated")
+                .isEqualTo(expectedTemporaryCertificateSummary2)
+            assertThat(temporaryCertificates[1])
+                .usingRecursiveComparison()
+                .ignoringFields("dateTimeGenerated")
+                .isEqualTo(expectedTemporaryCertificateSummary1)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderServiceTest.kt
@@ -1,0 +1,62 @@
+package uk.gov.dluhc.printapi.service.temporarycertificate
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
+import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
+import uk.gov.dluhc.printapi.service.EroService
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRandomEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildTemporaryCertificate
+import uk.gov.dluhc.printapi.testsupport.testdata.getRandomGssCodeList
+
+@ExtendWith(MockitoExtension::class)
+internal class TemporaryCertificateFinderServiceTest {
+
+    @Mock
+    private lateinit var eroService: EroService
+
+    @Mock
+    private lateinit var temporaryCertificateRepository: TemporaryCertificateRepository
+
+    @InjectMocks
+    private lateinit var temporaryCertificateFinderService: TemporaryCertificateFinderService
+
+    @Test
+    fun `should get TemporaryCertificates given one exists for the provided details`() {
+        // Given
+        val eroId = aValidRandomEroId()
+        val sourceType = VOTER_CARD
+        val sourceReference = aValidSourceReference()
+
+        val gssCodes = getRandomGssCodeList()
+        given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
+        val temporaryCertificates = listOf(buildTemporaryCertificate())
+        given(
+            temporaryCertificateRepository.findByGssCodeInAndSourceTypeAndSourceReference(
+                any(),
+                any(),
+                any()
+            )
+        ).willReturn(temporaryCertificates)
+
+        // When
+        val actual = temporaryCertificateFinderService.getTemporaryCertificates(eroId, sourceType, sourceReference)
+
+        // Then
+        verify(eroService).lookupGssCodesForEro(eroId)
+        verify(temporaryCertificateRepository).findByGssCodeInAndSourceTypeAndSourceReference(
+            gssCodes,
+            sourceType,
+            sourceReference
+        )
+        assertThat(actual).isSameAs(temporaryCertificates)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateFinderServiceTest.kt
@@ -30,7 +30,7 @@ internal class TemporaryCertificateFinderServiceTest {
     private lateinit var temporaryCertificateFinderService: TemporaryCertificateFinderService
 
     @Test
-    fun `should get TemporaryCertificates given one exists for the provided details`() {
+    fun `should get TemporaryCertificates given the provided details`() {
         // Given
         val eroId = aValidRandomEroId()
         val sourceType = VOTER_CARD

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateSummaryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/temporarycertificate/TemporaryCertificateSummaryServiceTest.kt
@@ -1,0 +1,80 @@
+package uk.gov.dluhc.printapi.service.temporarycertificate
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import uk.gov.dluhc.printapi.mapper.TemporaryCertificateSummaryMapper
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceType
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.buildTemporaryCertificateSummaryDto
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildTemporaryCertificate
+
+@ExtendWith(MockitoExtension::class)
+class TemporaryCertificateSummaryServiceTest {
+
+    @Mock
+    private lateinit var temporaryCertificateFinderService: TemporaryCertificateFinderService
+
+    @Mock
+    private lateinit var temporaryCertificateSummaryMapper: TemporaryCertificateSummaryMapper
+
+    @InjectMocks
+    private lateinit var temporaryCertificateSummaryService: TemporaryCertificateSummaryService
+
+    @Test
+    fun `should get Temporary Certificate Summaries given an application with some Temporary Certificates`() {
+        // Given
+        val eroId = aValidEroId()
+        val sourceType = aValidSourceType()
+        val sourceReference = aValidSourceReference()
+
+        val firstTemporaryCertificate = buildTemporaryCertificate()
+        val secondTemporaryCertificate = buildTemporaryCertificate()
+        val temporaryCertificates = listOf(firstTemporaryCertificate, secondTemporaryCertificate)
+        given(temporaryCertificateFinderService.getTemporaryCertificates(any(), any(), any())).willReturn(temporaryCertificates)
+
+        val firstTemporaryCertificateSummary = buildTemporaryCertificateSummaryDto()
+        val secondTemporaryCertificateSummary = buildTemporaryCertificateSummaryDto()
+        given(temporaryCertificateSummaryMapper.toDtoTemporaryCertificateSummary(any())).willReturn(
+            firstTemporaryCertificateSummary,
+            secondTemporaryCertificateSummary
+        )
+
+        val expected = listOf(firstTemporaryCertificateSummary, secondTemporaryCertificateSummary)
+
+        // When
+        val actual = temporaryCertificateSummaryService.getTemporaryCertificateSummaries(eroId, sourceType, sourceReference)
+
+        // Then
+        verify(temporaryCertificateFinderService).getTemporaryCertificates(eroId, sourceType, sourceReference)
+        verify(temporaryCertificateSummaryMapper).toDtoTemporaryCertificateSummary(firstTemporaryCertificate)
+        verify(temporaryCertificateSummaryMapper).toDtoTemporaryCertificateSummary(secondTemporaryCertificate)
+        assertThat(actual).usingRecursiveComparison().ignoringCollectionOrder().isEqualTo(expected)
+    }
+
+    @Test
+    fun `should get Temporary Certificate Summaries given an application with no Temporary Certificates`() {
+        // Given
+        val eroId = aValidEroId()
+        val sourceType = aValidSourceType()
+        val sourceReference = aValidSourceReference()
+
+        given(temporaryCertificateFinderService.getTemporaryCertificates(any(), any(), any())).willReturn(emptyList())
+
+        // When
+        val actual = temporaryCertificateSummaryService.getTemporaryCertificateSummaries(eroId, sourceType, sourceReference)
+
+        // Then
+        verify(temporaryCertificateFinderService).getTemporaryCertificates(eroId, sourceType, sourceReference)
+        verifyNoInteractions(temporaryCertificateSummaryMapper)
+        assertThat(actual).isEmpty()
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
@@ -8,6 +8,7 @@ import uk.gov.dluhc.printapi.testsupport.replaceSpacesWith
 import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
 import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
 import java.time.temporal.ChronoUnit.SECONDS
 
 fun aValidEroId() = "${faker.address().city().lowercase()}-city-council"
@@ -51,6 +52,10 @@ fun aValidApplicationReceivedDateTime(): Instant = Instant.now().truncatedTo(SEC
 fun aValidIssuingAuthority(): String = aValidLocalAuthorityName()
 
 fun aValidIssueDate(): LocalDate = LocalDate.now()
+
+fun aValidOnDate(): LocalDate = LocalDate.now()
+
+fun aValidGeneratedDateTime(): OffsetDateTime = OffsetDateTime.now()
 
 fun aValidSuggestedExpiryDate(): LocalDate = LocalDate.now().plusYears(10)
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/TemporaryCertificateSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/TemporaryCertificateSummaryBuilder.kt
@@ -1,0 +1,28 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.dto
+
+import uk.gov.dluhc.printapi.dto.TemporaryCertificateStatusDto
+import uk.gov.dluhc.printapi.dto.TemporaryCertificateSummaryDto
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidGeneratedDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidOnDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun buildTemporaryCertificateSummaryDto(
+    certificateNumber: String = aValidCertificateNumber(),
+    status: TemporaryCertificateStatusDto = TemporaryCertificateStatusDto.GENERATED,
+    userId: String = aValidUserId(),
+    dateTimeGenerated: OffsetDateTime = aValidGeneratedDateTime(),
+    issueDate: LocalDate = aValidIssueDate(),
+    validOnDate: LocalDate = aValidOnDate(),
+): TemporaryCertificateSummaryDto =
+    TemporaryCertificateSummaryDto(
+        certificateNumber = certificateNumber,
+        status = status,
+        userId = userId,
+        dateTimeGenerated = dateTimeGenerated,
+        issueDate = issueDate,
+        validOnDate = validOnDate,
+    )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/TemporaryCertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/TemporaryCertificateBuilder.kt
@@ -18,6 +18,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidTemporaryCertificateTemp
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+import java.time.Instant
 import java.time.LocalDate
 import java.util.UUID
 
@@ -69,9 +70,11 @@ fun buildTemporaryCertificate(
 fun buildTemporaryCertificateStatus(
     status: TemporaryCertificateStatus.Status = aValidTemporaryCertificateStatus(),
     userId: String = aValidUserId(),
+    dateCreated: Instant? = null
 ): TemporaryCertificateStatus {
     return TemporaryCertificateStatus(
         status = status,
-        userId = userId
+        userId = userId,
+        dateCreated = dateCreated,
     )
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/TemporaryCertificateSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/TemporaryCertificateSummaryBuilder.kt
@@ -1,0 +1,28 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.model
+
+import uk.gov.dluhc.printapi.models.TemporaryCertificateStatus
+import uk.gov.dluhc.printapi.models.TemporaryCertificateSummary
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidGeneratedDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidOnDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun buildTemporaryCertificateSummary(
+    certificateNumber: String = aValidCertificateNumber(),
+    status: TemporaryCertificateStatus = TemporaryCertificateStatus.GENERATED,
+    userId: String = aValidUserId(),
+    dateTimeGenerated: OffsetDateTime = aValidGeneratedDateTime(),
+    issueDate: LocalDate = aValidIssueDate(),
+    validOnDate: LocalDate = aValidOnDate(),
+): TemporaryCertificateSummary =
+    TemporaryCertificateSummary(
+        certificateNumber = certificateNumber,
+        status = status,
+        userId = userId,
+        dateTimeGenerated = dateTimeGenerated,
+        issueDate = issueDate,
+        validOnDate = validOnDate,
+    )


### PR DESCRIPTION
This PR implements the main controller method, through service, through repository; to implement the happy path for the REST API to get Temporary Certificate Summaries for a given application