### PR TITLE
EIP1-3803 - Job to remove initial retention period data for VCAs

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -203,6 +203,12 @@ class Certificate(
         }
     }
 
+    fun removeInitialRetentionPeriodData() =
+        printRequests.forEach {
+            it.delivery = null
+            it.supportingInformationFormat = null
+        }
+
     private fun processPrintRequestUpdate(update: () -> Unit) {
         update.invoke()
         assignStatus()

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
@@ -63,7 +63,6 @@ class PrintRequest(
     @Enumerated(EnumType.STRING)
     var certificateLanguage: CertificateLanguage? = null,
 
-    @field:NotNull
     @Enumerated(EnumType.STRING)
     var supportingInformationFormat: SupportingInformationFormat? = null,
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
@@ -8,6 +8,7 @@ import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import java.time.Instant
+import java.time.LocalDate
 import java.util.UUID
 
 @Repository
@@ -22,6 +23,8 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
     fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): Certificate?
 
     fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): Certificate?
+
+    fun findBySourceTypeAndInitialRetentionRemovalDateBefore(sourceType: SourceType, initialRetentionRemovalDate: LocalDate): List<Certificate>
 
     @Query(
         value = """
@@ -38,5 +41,9 @@ object CertificateRepositoryExtensions {
     fun CertificateRepository.findDistinctByPrintRequestStatusAndBatchId(status: Status, batchId: String): List<Certificate> {
         return findByPrintRequestsBatchId(batchId).toSet()
             .filter { it.printRequests.any { printRequest -> printRequest.getCurrentStatus().status == status } }
+    }
+
+    fun CertificateRepository.findPendingRemovalOfInitialRetentionData(sourceType: SourceType): List<Certificate> {
+        return findBySourceTypeAndInitialRetentionRemovalDateBefore(sourceType = sourceType, initialRetentionRemovalDate = LocalDate.now())
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/BatchPrintRequestsJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/BatchPrintRequestsJob.kt
@@ -1,12 +1,9 @@
 package uk.gov.dluhc.printapi.jobs
 
-import mu.KotlinLogging
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.service.PrintRequestsService
-
-private val logger = KotlinLogging.logger {}
 
 @Component
 class BatchPrintRequestsJob(

--- a/src/main/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJob.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJob.kt
@@ -1,0 +1,19 @@
+package uk.gov.dluhc.printapi.jobs
+
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
+import uk.gov.dluhc.printapi.service.CertificateDataRetentionService
+
+@Component
+class InitialRetentionPeriodDataRemovalJob(
+    private val certificateDataRetentionService: CertificateDataRetentionService
+) {
+
+    @Scheduled(cron = "\${jobs.remove-vca-initial-retention-period-data.cron}")
+    @SchedulerLock(name = "\${jobs.remove-vca-initial-retention-period-data.name}")
+    fun removeVoterCardInitialRetentionPeriodData() {
+        certificateDataRetentionService.removeInitialRetentionPeriodData(sourceType = VOTER_CARD)
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
@@ -2,7 +2,9 @@ package uk.gov.dluhc.printapi.service
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
+import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findPendingRemovalOfInitialRetentionData
 import uk.gov.dluhc.printapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.printapi.messaging.models.ApplicationRemovedMessage
 import javax.transaction.Transactional
@@ -35,6 +37,18 @@ class CertificateDataRetentionService(
                 certificateRepository.save(it)
             }
                 ?: logger.error { "Certificate with sourceType = $sourceType and sourceReference = $sourceReference not found" }
+        }
+    }
+
+    @Transactional
+    fun removeInitialRetentionPeriodData(sourceType: SourceType) {
+        logger.info { "Finding certificates to remove initial retention period data from" }
+        with(certificateRepository.findPendingRemovalOfInitialRetentionData(sourceType = sourceType)) {
+            forEach {
+                it.removeInitialRetentionPeriodData()
+                certificateRepository.save(it)
+                logger.info { "Removed initial retention period data from certificate with sourceReference ${it.sourceReference}" }
+            }
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
@@ -42,12 +42,14 @@ class CertificateDataRetentionService(
 
     @Transactional
     fun removeInitialRetentionPeriodData(sourceType: SourceType) {
-        logger.info { "Finding certificates to remove initial retention period data from" }
+        logger.info { "Finding certificates with sourceType $sourceType to remove initial retention period data from" }
         with(certificateRepository.findPendingRemovalOfInitialRetentionData(sourceType = sourceType)) {
             forEach {
                 it.removeInitialRetentionPeriodData()
                 certificateRepository.save(it)
-                logger.info { "Removed initial retention period data from certificate with sourceReference ${it.sourceReference}" }
+            }
+            if (isNotEmpty()) {
+                logger.info { "Removed initial retention period data from $size certificates" }
             }
         }
     }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,3 +6,7 @@ jobs:
     name: "BatchPrintRequests"
     cron: "0 */10 * ? * *" # every 10 minutes
     daily-limit: 1000
+  remove-vca-initial-retention-period-data:
+    enabled: true
+    name: "RemoveVcaInitialRetentionPeriodData"
+    cron: "0 */10 * ? * *" # every 10 minutes

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,11 +31,12 @@ api:
       valid-on-date:
         max-calendar-days-in-future: 30
     retention.period:
-      # The legislation defines the first (initial) retention period as 28 working days from the date of "issue", which now means the date the
-      # certificate was printed, not when it was sent to the print provider. Currently, we are not informed of when the certificate was printed - only
-      # when it was dispatched, which is not necessarily the same day. However in the vast majority of cases it is understood to be the next working day.
-      # Therefore, as a workaround, the following property is set to 29 (28+1) for the time being.
-      # A separate story will set this according to the actual printed date, which will require changes to the response files from the print provider.
+      # The legislation defines the first (initial) retention period as 28 working days from the date of "issue", which has been confirmed as the date the
+      # certificate was printed, not when it was sent to the print provider (and therefore not the "issue date" that is currently printed on the certificate
+      # itself). As it stands, we are not informed when the certificate was printed (only when it was dispatched, which may not be the same day).
+      # However, we have established that in the vast majority of cases the certificate will be printed the next working day after it was sent to the print
+      # provider. Therefore, as a workaround, the following property is set to 29 (28+1) for the time being.
+      # A separate story will set this according to the actual printed date, which will require changes to the specification with the print provider.
       certificate-initial-retention-period: "P29D"
   ero-management:
     url: ${API_ERO_MANAGEMENT_URL}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,7 +31,12 @@ api:
       valid-on-date:
         max-calendar-days-in-future: 30
     retention.period:
-      certificate-initial-retention-period: "P28D" # 28 working days
+      # The legislation defines the first (initial) retention period as 28 working days from the date of "issue", which now means the date the
+      # certificate was printed, not when it was sent to the print provider. Currently, we are not informed of when the certificate was printed - only
+      # when it was dispatched, which is not necessarily the same day. However in the vast majority of cases it is understood to be the next working day.
+      # Therefore, as a workaround, the following property is set to 29 (28+1) for the time being.
+      # A separate story will set this according to the actual printed date, which will require changes to the response files from the print provider.
+      certificate-initial-retention-period: "P29D"
   ero-management:
     url: ${API_ERO_MANAGEMENT_URL}
 
@@ -55,7 +60,12 @@ jobs:
   process-print-responses:
     name: "ProcessPrintResponses"
     cron: "0 15/30 * * * *" # every 30 minutes starting at 15 minutes past the hour - see analysis and recommendations in EIP1-2515
-
+  remove-vca-initial-retention-period-data:
+    enabled: false
+    name: "RemoveVcaInitialRetentionPeriodData"
+    # Runs at 21:35, 01:35 and 05:35.
+    # Running outside business hours to avoid delivery info suddenly disappearing.
+    cron: "0 35 1,5,21 * * *"
 temporary-certificate:
   certificate-pdf:
     english:

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -18,4 +18,5 @@
     <include relativeToChangelogFile="true" file="migration/0001_EIP1-3454_update_certificate.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0010_create_temporary_certificate_tables.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0011_initial_data_retention_period_changes.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0012_supporting_information_non_mandatory.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0012_supporting_information_non_mandatory.xml
+++ b/src/main/resources/db/changelog/ddl/0012_supporting_information_non_mandatory.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
 
-    <changeSet author="matt.wills@valtech.com" id="0011_EIP1-3803_alter_print_request - make supporting_information_format nullable" context="ddl">
+    <changeSet author="matt.wills@valtech.com" id="0012_EIP1-3803_alter_print_request - make supporting_information_format nullable" context="ddl">
 
         <dropNotNullConstraint tableName="print_request" columnName="supporting_information_format" columnDataType="varchar(20)"/>
 

--- a/src/main/resources/db/changelog/ddl/0012_supporting_information_non_mandatory.xml
+++ b/src/main/resources/db/changelog/ddl/0012_supporting_information_non_mandatory.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="matt.wills@valtech.com" id="0011_EIP1-3803_alter_print_request - make supporting_information_format nullable" context="ddl">
+
+        <dropNotNullConstraint tableName="print_request" columnName="supporting_information_format" columnDataType="varchar(20)"/>
+
+        <rollback>
+            <addNotNullConstraint tableName="print_request" columnName="supporting_information_format" columnDataType="varchar(20)"/>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -34,6 +34,7 @@ import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_R
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
 import uk.gov.dluhc.printapi.jobs.BatchPrintRequestsJob
+import uk.gov.dluhc.printapi.jobs.InitialRetentionPeriodDataRemovalJob
 import uk.gov.dluhc.printapi.jobs.ProcessPrintResponsesBatchJob
 import uk.gov.dluhc.printapi.messaging.MessageQueue
 import uk.gov.dluhc.printapi.messaging.models.ProcessPrintResponseFileMessage
@@ -80,6 +81,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var processPrintResponsesBatchJob: ProcessPrintResponsesBatchJob
+
+    @Autowired
+    protected lateinit var initialRetentionPeriodDataRemovalJob: InitialRetentionPeriodDataRemovalJob
 
     @Autowired
     protected lateinit var batchPrintRequestsJob: BatchPrintRequestsJob

--- a/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
@@ -1,0 +1,36 @@
+package uk.gov.dluhc.printapi.jobs
+
+import ch.qos.logback.classic.Level
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.testsupport.TestLogAppender
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.Assertions.assertThat
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
+import java.time.LocalDate
+
+internal class InitialRetentionPeriodDataRemovalJobIntegrationTest : IntegrationTest() {
+
+    @Test
+    fun `should remove voter card initial retention period data`() {
+        // Given
+        val certificate1 = buildCertificate(initialRetentionRemovalDate = LocalDate.now().minusDays(1))
+        val certificate2 = buildCertificate(initialRetentionRemovalDate = LocalDate.now().minusDays(1))
+        val certificate3 = buildCertificate(initialRetentionRemovalDate = LocalDate.now())
+        val certificate4 = buildCertificate(initialRetentionRemovalDate = LocalDate.now().plusDays(1))
+        certificateRepository.saveAll(listOf(certificate1, certificate2, certificate3, certificate4))
+        TestLogAppender.reset()
+
+        // When
+        initialRetentionPeriodDataRemovalJob.removeVoterCardInitialRetentionPeriodData()
+
+        // Then
+        assertThat(certificateRepository.findById(certificate1.id!!).get()).doesNotHaveInitialRetentionPeriodData()
+        assertThat(certificateRepository.findById(certificate2.id!!).get()).doesNotHaveInitialRetentionPeriodData()
+        assertThat(certificateRepository.findById(certificate3.id!!).get()).hasInitialRetentionPeriodData()
+        assertThat(certificateRepository.findById(certificate4.id!!).get()).hasInitialRetentionPeriodData()
+
+        assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate1.sourceReference}", Level.INFO)).isTrue
+        assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate2.sourceReference}", Level.INFO)).isTrue
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
@@ -29,8 +29,6 @@ internal class InitialRetentionPeriodDataRemovalJobIntegrationTest : Integration
         assertThat(certificateRepository.findById(certificate2.id!!).get()).doesNotHaveInitialRetentionPeriodData()
         assertThat(certificateRepository.findById(certificate3.id!!).get()).hasInitialRetentionPeriodData()
         assertThat(certificateRepository.findById(certificate4.id!!).get()).hasInitialRetentionPeriodData()
-
-        assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate1.sourceReference}", Level.INFO)).isTrue
-        assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate2.sourceReference}", Level.INFO)).isTrue
+        assertThat(TestLogAppender.hasLog("Removed initial retention period data from 2 certificates", Level.INFO)).isTrue
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
@@ -29,7 +29,8 @@ internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
             sourceReference = certificate.sourceReference!!,
             gssCode = certificate.gssCode!!
         )
-        val expectedInitialRemovalDate = LocalDate.of(2023, 5, 16)
+        // currently 29 working days following issue date - refer to application.yml
+        val expectedInitialRemovalDate = LocalDate.of(2023, 5, 17)
 
         // When
         sqsMessagingTemplate.convertAndSend(applicationRemovedQueueName, payload)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
@@ -281,6 +281,40 @@ class CertificateAssert
     }
 
     /**
+     * Verifies that the data which needs to be removed after the initial retention period is null.
+     * @return this assertion object.
+     * @throws AssertionError if the data is not null.
+     */
+    fun doesNotHaveInitialRetentionPeriodData(): CertificateAssert {
+        // check that actual PrintRequest we want to make assertions on is not null.
+        isNotNull
+
+        this.actual?.printRequests?.forEach {
+            PrintRequestAssert(it).doesNotHaveInitialRetentionPeriodData()
+        }
+
+        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
+     * Verifies that the data which needs to be removed after the initial retention period still exists.
+     * @return this assertion object.
+     * @throws AssertionError if the data is null.
+     */
+    fun hasInitialRetentionPeriodData(): CertificateAssert {
+        // check that actual PrintRequest we want to make assertions on is not null.
+        isNotNull
+
+        this.actual?.printRequests?.forEach {
+            PrintRequestAssert(it).hasInitialRetentionPeriodData()
+        }
+
+        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
      * Verifies that the actual Certificate's issuingAuthority is equal to the given one.
      * @param issuingAuthority the given issuingAuthority to compare the actual Certificate's issuingAuthority to.
      * @return this assertion object.
@@ -345,7 +379,7 @@ class CertificateAssert
         // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
-        val printRequest = actual!!.printRequests.find { pr -> pr.requestDateTime!! == requestDateTime }
+        val printRequest = actual!!.printRequests.find { it.requestDateTime!! == requestDateTime }
 
         // check that given PrintRequest collection is not null.
         if (printRequest == null) {

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/PrintRequestAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/PrintRequestAssert.kt
@@ -504,9 +504,7 @@ class PrintRequestAssert
         // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
-        val printRequest = actual!!.statusHistory.find { pr ->
-            pr.status == status
-        }
+        val printRequest = actual!!.statusHistory.find { it.status == status }
 
         // check that given PrintRequest collection is not null.
         if (printRequest == null) {
@@ -614,6 +612,48 @@ class PrintRequestAssert
         // check
         if (actual!!.statusHistory.iterator().hasNext()) {
             failWithMessage(assertjErrorMessage, actual, actual!!.statusHistory)
+        }
+
+        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
+     * Verifies that the data which needs to be removed after the initial retention period is null.
+     * @return this assertion object.
+     * @throws AssertionError if the data is not null.
+     */
+    fun doesNotHaveInitialRetentionPeriodData(): PrintRequestAssert {
+        // check that actual PrintRequest we want to make assertions on is not null.
+        isNotNull
+
+        // we override the default error message with a more explicit one
+        val assertjErrorMessage = "\nExpecting :\n  <%s>\nnot to have initial retention period data"
+
+        // check
+        if (actual!!.delivery != null || actual!!.supportingInformationFormat != null) {
+            failWithMessage(assertjErrorMessage, actual)
+        }
+
+        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
+     * Verifies that the data which needs to be removed after the initial retention period still exists.
+     * @return this assertion object.
+     * @throws AssertionError if the data is null.
+     */
+    fun hasInitialRetentionPeriodData(): PrintRequestAssert {
+        // check that actual PrintRequest we want to make assertions on is not null.
+        isNotNull
+
+        // we override the default error message with a more explicit one
+        val assertjErrorMessage = "\nExpecting :\n  <%s>\n still to have initial retention period data"
+
+        // check
+        if (actual!!.delivery == null || actual!!.supportingInformationFormat == null) {
+            failWithMessage(assertjErrorMessage, actual)
         }
 
         // return the current assertion for method chaining

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -62,7 +62,8 @@ fun buildCertificate(
     sourceReference: String = aValidSourceReference(),
     applicationReceivedDateTime: Instant = aValidApplicationReceivedDateTime(),
     applicationReference: String = aValidApplicationReference(),
-    issueDate: LocalDate = aValidIssueDate()
+    issueDate: LocalDate = aValidIssueDate(),
+    initialRetentionRemovalDate: LocalDate? = null
 ): Certificate {
     val certificate = Certificate(
         id = id,
@@ -76,6 +77,7 @@ fun buildCertificate(
         suggestedExpiryDate = aValidSuggestedExpiryDate(),
         gssCode = gssCode,
         status = status,
+        initialRetentionRemovalDate = initialRetentionRemovalDate
     )
     printRequests.forEach { printRequest -> certificate.addPrintRequest(printRequest) }
     return certificate


### PR DESCRIPTION
This PR implements a scheduled task to remove specific data that needs to be removed from a certificate after the first (initial) retention period has ended.

This was supposed to be a simple task, but has ended up being more complicated due to going round in circles over the definition of the retention policy and establishing exactly which data needs to be removed!