### PR TITLE
EIP1-3765 Include the number of print requests with batch id for processing to prevent part processing batches

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/EmptyBatchException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/EmptyBatchException.kt
@@ -1,9 +1,0 @@
-package uk.gov.dluhc.printapi.exception
-
-import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
-import java.lang.RuntimeException
-
-data class EmptyBatchException(
-    private val batchId: String,
-    private val status: Status
-) : RuntimeException("No certificates found for batchId = $batchId and status = $status")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/InsufficientPrintRequestsInBatchException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/InsufficientPrintRequestsInBatchException.kt
@@ -1,0 +1,11 @@
+package uk.gov.dluhc.printapi.exception
+
+import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
+import java.lang.RuntimeException
+
+data class InsufficientPrintRequestsInBatchException(
+    private val batchId: String,
+    private val status: Status,
+    private val foundCount: Int,
+    private val expectedCount: Int?
+) : RuntimeException("Found $foundCount ${if (expectedCount != null) "of $expectedCount " else ""}certificates for batchId = $batchId and status = $status")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListener.kt
@@ -20,7 +20,7 @@ class ProcessPrintRequestBatchMessageListener(
         with(payload) {
             logger.info("Processing print batch request for batchId: $batchId")
 
-            processPrintBatchService.processBatch(batchId)
+            processPrintBatchService.processBatch(batchId, printRequestCount)
 
             logger.info("Successfully processed print request for batchId: $batchId")
         }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -26,13 +26,15 @@ class CertificateBatchingService(
     private val clock: Clock
 ) {
     @Transactional
-    fun batchPendingCertificates(): Set<String> {
+    fun batchPendingCertificates(): List<Pair<String, Int>> {
         val batches = batchCertificates()
         batches.forEach { (batchId, batchOfCertificates) ->
             certificateRepository.saveAll(batchOfCertificates)
             logger.info { "Certificate ids ${batchOfCertificates.map { it.id }} assigned to batch [$batchId]" }
         }
-        return batches.keys
+        return batches.map { (batchId, certificates) ->
+            Pair(batchId, countPrintRequestsAssignedToBatch(certificates, batchId))
+        }
     }
 
     fun batchCertificates(): Map<String, List<Certificate>> {

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingService.kt
@@ -26,14 +26,14 @@ class CertificateBatchingService(
     private val clock: Clock
 ) {
     @Transactional
-    fun batchPendingCertificates(): List<Pair<String, Int>> {
+    fun batchPendingCertificates(): List<BatchInfo> {
         val batches = batchCertificates()
         batches.forEach { (batchId, batchOfCertificates) ->
             certificateRepository.saveAll(batchOfCertificates)
             logger.info { "Certificate ids ${batchOfCertificates.map { it.id }} assigned to batch [$batchId]" }
         }
         return batches.map { (batchId, certificates) ->
-            Pair(batchId, countPrintRequestsAssignedToBatch(certificates, batchId))
+            BatchInfo(batchId, countPrintRequestsAssignedToBatch(certificates, batchId))
         }
     }
 
@@ -85,3 +85,8 @@ class CertificateBatchingService(
         }
     }
 }
+
+data class BatchInfo(
+    val batchId: String,
+    val printRequestCount: Int,
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/FilenameFactory.kt
@@ -2,7 +2,6 @@ package uk.gov.dluhc.printapi.service
 
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.database.entity.Certificate
-import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
 import java.time.Clock
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -13,17 +12,11 @@ import java.time.format.DateTimeFormatter
 class FilenameFactory(private val clock: Clock) {
 
     fun createZipFilename(batchId: String, certificates: List<Certificate>): String {
-        return createFilename(batchId, printRequestCount(batchId, certificates), "zip")
+        return createFilename(batchId, countPrintRequestsAssignedToBatch(certificates, batchId), "zip")
     }
 
     fun createPrintRequestsFilename(batchId: String, certificates: List<Certificate>): String {
-        return createFilename(batchId, printRequestCount(batchId, certificates), "psv")
-    }
-
-    private fun printRequestCount(batchId: String, certificates: List<Certificate>): Int {
-        return certificates
-            .flatMap { it.printRequests }
-            .count { it.getCurrentStatus().status == Status.ASSIGNED_TO_BATCH && it.batchId == batchId }
+        return createFilename(batchId, countPrintRequestsAssignedToBatch(certificates, batchId), "psv")
     }
 
     private fun createFilename(batchId: String, count: Int, ext: String): String {

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounter.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounter.kt
@@ -1,0 +1,10 @@
+package uk.gov.dluhc.printapi.service
+
+import uk.gov.dluhc.printapi.database.entity.Certificate
+import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus
+
+fun countPrintRequestsAssignedToBatch(certificates: List<Certificate>, batchId: String): Int =
+    certificates
+        .flatMap { it.printRequests }
+        .filter { it.batchId == batchId }
+        .count { it.getCurrentStatus().status == PrintRequestStatus.Status.ASSIGNED_TO_BATCH }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsService.kt
@@ -18,9 +18,9 @@ class PrintRequestsService(
 
         // split into batches and save to database before sending messages to SQS
         certificateBatchingService.batchPendingCertificates()
-            .onEach { batchId ->
-                processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId))
-                logger.info { "Batch [$batchId] submitted to queue" }
+            .onEach { (batchId, printRequestCount) ->
+                processPrintRequestQueue.submit(ProcessPrintRequestBatchMessage(batchId, printRequestCount))
+                logger.info { "Batch [$batchId] containing $printRequestCount print requests submitted to queue" }
             }
         logger.info { "Completed batching certificate Print Requests" }
     }

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.9.2'
+  version: '1.9.3'
   description: |-
     Print API SQS Message Types
     
@@ -289,6 +289,9 @@ components:
         batchId:
           type: string
           description: The batch ID
+        printRequestCount:
+          type: integer
+          description: The number of print requests included in the batch
       required:
         - batchId
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
@@ -117,7 +117,7 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
         2022-11-24 19:50:21.118 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [    Test worker] u.g.d.p.service.PrintRequestsService     : Looking for certificate Print Requests to assign to a new batch
         2022-11-24 19:50:21.143 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [    Test worker] u.g.d.p.s.CertificateBatchingService     : Certificate with id [cca679f5-5a3d-47f8-95f4-9b924fcab789] assigned to batch [cab0f871e14a48e6b5511422b12d5999]
         2022-11-24 19:50:21.409 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [enerContainer-6] .ProcessPrintRequestBatchMessageListener : Processing print batch request for batchId: cab0f871e14a48e6b5511422b12d5999
-        2022-11-24 19:50:21.410 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [    Test worker] u.g.d.p.service.PrintRequestsService     : Batch [cab0f871e14a48e6b5511422b12d5999] submitted to queue
+        2022-11-24 19:50:21.410 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [    Test worker] u.g.d.p.service.PrintRequestsService     : Batch [cab0f871e14a48e6b5511422b12d5999] containing 1 print requests submitted to queue
         2022-11-24 19:50:21.412 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [    Test worker] u.g.d.p.service.PrintRequestsService     : Completed batching certificate Print Requests
         2022-11-24 19:50:21.483 40dd2a03c7384affa779cdb6ad744f98 INFO 69738 --- [enerContainer-6] .ProcessPrintRequestBatchMessageListener : Successfully processed print request for batchId: cab0f871e14a48e6b5511422b12d5999
          */
@@ -131,7 +131,7 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
             batchPrintRequestsJob.run()
 
             // Then
-            await.atMost(5, TimeUnit.SECONDS).untilAsserted {
+            await.atMost(10, TimeUnit.SECONDS).untilAsserted {
                 val logEvent = TestLogAppender.getLogEventMatchingRegex(
                     "Looking for certificate Print Requests to assign to a new batch",
                     Level.INFO
@@ -147,7 +147,7 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
                 ).hasCorrelationId(expectedCorrelationId)
                 assertThat(
                     TestLogAppender.getLogEventMatchingRegex(
-                        "Batch \\[.{32}\\] submitted to queue",
+                        "Batch \\[.{32}\\] containing .{1} print requests submitted to queue",
                         Level.INFO
                     )
                 ).hasCorrelationId(expectedCorrelationId)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
@@ -92,7 +92,7 @@ internal class CertificateBatchingServiceTest {
         assertThat(firstBatchOfCertificates.size).isEqualTo(4)
         val secondBatchOfCertificates = savedCertificatesArgumentCaptor.secondValue
         assertThat(secondBatchOfCertificates.size).isEqualTo(3)
-        assertThat(batchIds).containsExactly(batchId1, batchId2)
+        assertThat(batchIds).containsExactly(Pair(batchId1, 4), Pair(batchId2, 3))
     }
 
     @Test
@@ -131,7 +131,7 @@ internal class CertificateBatchingServiceTest {
         )
         verify(idFactory).batchId()
         verify(certificateRepository).saveAll(capture(savedCertificatesArgumentCaptor))
-        assertThat(batchIds).containsExactly(batchId)
+        assertThat(batchIds).containsExactly(Pair(batchId, 1))
         val savedCertificates = savedCertificatesArgumentCaptor.value!!
         assertThat(savedCertificates.size).isEqualTo(1)
         assertThat(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateBatchingServiceTest.kt
@@ -92,7 +92,7 @@ internal class CertificateBatchingServiceTest {
         assertThat(firstBatchOfCertificates.size).isEqualTo(4)
         val secondBatchOfCertificates = savedCertificatesArgumentCaptor.secondValue
         assertThat(secondBatchOfCertificates.size).isEqualTo(3)
-        assertThat(batchIds).containsExactly(Pair(batchId1, 4), Pair(batchId2, 3))
+        assertThat(batchIds).containsExactly(BatchInfo(batchId1, 4), BatchInfo(batchId2, 3))
     }
 
     @Test
@@ -131,7 +131,7 @@ internal class CertificateBatchingServiceTest {
         )
         verify(idFactory).batchId()
         verify(certificateRepository).saveAll(capture(savedCertificatesArgumentCaptor))
-        assertThat(batchIds).containsExactly(Pair(batchId, 1))
+        assertThat(batchIds).containsExactly(BatchInfo(batchId, 1))
         val savedCertificates = savedCertificatesArgumentCaptor.value!!
         assertThat(savedCertificates.size).isEqualTo(1)
         assertThat(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
@@ -1,0 +1,135 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.ASSIGNED_TO_BATCH
+import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.SENT_TO_PRINT_PROVIDER
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
+import java.time.Instant
+
+class PrintRequestCounterTest {
+
+    @Nested
+    inner class CountPrintRequestsAssignedToBatch {
+        @Test
+        fun `should determine count given no print requests found for provided batchId`() {
+            // Given
+            val batchId = "4143d442a2424740afa3ce5eae630aaf"
+            val otherBatchId = "bdbf4054cc904c4abf61cd6bb9171b55"
+            val certificates = listOf(
+                buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = otherBatchId,
+                            printRequestStatuses = listOf(buildPrintRequestStatus(status = ASSIGNED_TO_BATCH))
+                        )
+                    )
+                )
+            )
+            val expectedPrintRequestCount = 0
+
+            // When
+            val actual = countPrintRequestsAssignedToBatch(certificates, batchId)
+
+            // Then
+            assertThat(actual).isEqualTo(expectedPrintRequestCount)
+        }
+
+        @Test
+        fun `should determine count given no print requests found with current status of ASSIGNED_TO_BATCH`() {
+            // Given
+            val batchId = "4143d442a2424740afa3ce5eae630aaf"
+            val latestEventTimestamp = Instant.now().minusSeconds(10)
+            val certificates = listOf(
+                buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(
+                                buildPrintRequestStatus(
+                                    status = ASSIGNED_TO_BATCH,
+                                    eventDateTime = latestEventTimestamp.minusSeconds(30)
+                                ),
+                                buildPrintRequestStatus(
+                                    status = SENT_TO_PRINT_PROVIDER, eventDateTime = latestEventTimestamp
+                                )
+                            )
+                        )
+                    )
+                ),
+            )
+            val expectedPrintRequestCount = 0
+
+            // When
+            val actual = countPrintRequestsAssignedToBatch(certificates, batchId)
+
+            // Then
+            assertThat(actual).isEqualTo(expectedPrintRequestCount)
+        }
+
+        @Test
+        fun `should determine count given several certificates with differing print requests`() {
+            // Given
+            val batchId = "4143d442a2424740afa3ce5eae630aaf"
+            val otherBatchId = "bdbf4054cc904c4abf61cd6bb9171b55"
+            val certificates = listOf(
+                // cert with one print request for current batch and one historic
+                buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = otherBatchId,
+                            printRequestStatuses = listOf(
+                                buildPrintRequestStatus(
+                                    status = ASSIGNED_TO_BATCH,
+                                    eventDateTime = Instant.now().minusSeconds(30)
+                                ),
+                                buildPrintRequestStatus(
+                                    status = SENT_TO_PRINT_PROVIDER,
+                                    eventDateTime = Instant.now().minusSeconds(10)
+                                ),
+                            )
+                        ),
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(
+                                buildPrintRequestStatus(status = ASSIGNED_TO_BATCH),
+                            )
+                        )
+                    )
+                ),
+                // cert with two print requests for current batch
+                buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(buildPrintRequestStatus(status = ASSIGNED_TO_BATCH))
+                        ),
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(buildPrintRequestStatus(status = ASSIGNED_TO_BATCH))
+                        )
+                    )
+                ),
+                // cert with one print request for current batch
+                buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(buildPrintRequestStatus(status = ASSIGNED_TO_BATCH))
+                        )
+                    )
+                ),
+            )
+            val expectedPrintRequestCount = 4
+
+            // When
+            val actual = countPrintRequestsAssignedToBatch(certificates, batchId)
+
+            // Then
+            assertThat(actual).isEqualTo(expectedPrintRequestCount)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
@@ -27,10 +27,10 @@ class PrintRequestsServiceTest {
     @Test
     fun `should process print requests and submit to queue`() {
         // Given
-        val batchId1 = aValidBatchId()
-        val batchId2 = aValidBatchId()
-        val batchId3 = aValidBatchId()
-        val batchIds = setOf(batchId1, batchId2, batchId3)
+        val batch1 = Pair(aValidBatchId(), 6)
+        val batch2 = Pair(aValidBatchId(), 23)
+        val batch3 = Pair(aValidBatchId(), 2)
+        val batchIds = listOf(batch1, batch2, batch3)
         given(certificateBatchingService.batchPendingCertificates()).willReturn(batchIds)
 
         // When
@@ -38,9 +38,9 @@ class PrintRequestsServiceTest {
 
         // Then
         verify(certificateBatchingService).batchPendingCertificates()
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId1))
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId2))
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batchId3))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch1.first, batch1.second))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch2.first, batch2.second))
+        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch3.first, batch3.second))
         verifyNoMoreInteractions(processPrintRequestQueue)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestsServiceTest.kt
@@ -27,9 +27,9 @@ class PrintRequestsServiceTest {
     @Test
     fun `should process print requests and submit to queue`() {
         // Given
-        val batch1 = Pair(aValidBatchId(), 6)
-        val batch2 = Pair(aValidBatchId(), 23)
-        val batch3 = Pair(aValidBatchId(), 2)
+        val batch1 = BatchInfo(aValidBatchId(), 6)
+        val batch2 = BatchInfo(aValidBatchId(), 23)
+        val batch3 = BatchInfo(aValidBatchId(), 2)
         val batchIds = listOf(batch1, batch2, batch3)
         given(certificateBatchingService.batchPendingCertificates()).willReturn(batchIds)
 
@@ -38,9 +38,24 @@ class PrintRequestsServiceTest {
 
         // Then
         verify(certificateBatchingService).batchPendingCertificates()
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch1.first, batch1.second))
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch2.first, batch2.second))
-        verify(processPrintRequestQueue).submit(ProcessPrintRequestBatchMessage(batch3.first, batch3.second))
+        verify(processPrintRequestQueue).submit(
+            ProcessPrintRequestBatchMessage(
+                batch1.batchId,
+                batch1.printRequestCount
+            )
+        )
+        verify(processPrintRequestQueue).submit(
+            ProcessPrintRequestBatchMessage(
+                batch2.batchId,
+                batch2.printRequestCount
+            )
+        )
+        verify(processPrintRequestQueue).submit(
+            ProcessPrintRequestBatchMessage(
+                batch3.batchId,
+                batch3.printRequestCount
+            )
+        )
         verifyNoMoreInteractions(processPrintRequestQueue)
     }
 }


### PR DESCRIPTION
Occasionally print requests that have been assigned to a batch are never sent to the print provider.  Either the SQS message is never processed successfully and ends on the DLQ or it is processed but misses some of the print requests included in the batch.  To tighten the processing the SQS message includes a count of the print requests in the batch.  When processing the SQS message the processing verifies that the expected number of print requests is loaded from the database.