### PR TITLE
EIP1-4053 - Add DeliveryRepository to ensure Delivery data is removed

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -208,14 +208,6 @@ class Certificate(
         }
     }
 
-    fun removeInitialRetentionPeriodData() {
-        printRequests.forEach {
-            it.delivery = null
-            it.supportingInformationFormat = null
-        }
-        initialRetentionDataRemoved = true
-    }
-
     private fun processPrintRequestUpdate(update: () -> Unit) {
         update.invoke()
         assignStatus()

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/DeliveryRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/DeliveryRepository.kt
@@ -1,0 +1,14 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.dluhc.printapi.database.entity.Delivery
+import java.util.UUID
+
+/**
+ * Repository class for [Delivery] entities. This has been added to aid the removal of [Delivery] entities as part of
+ * the initial retention period data. Otherwise, it should only be necessary to use the top level
+ * [CertificateRepository].
+ */
+@Repository
+interface DeliveryRepository : JpaRepository<Delivery, UUID>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -32,6 +32,7 @@ import uk.gov.dluhc.printapi.client.BankHolidayDataClient
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_REQUEST_UPLOAD_PATH
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_RESPONSE_DOWNLOAD_PATH
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
+import uk.gov.dluhc.printapi.database.repository.DeliveryRepository
 import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
 import uk.gov.dluhc.printapi.jobs.BatchPrintRequestsJob
 import uk.gov.dluhc.printapi.jobs.InitialRetentionPeriodDataRemovalJob
@@ -120,6 +121,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var certificateRepository: CertificateRepository
+
+    @Autowired
+    protected lateinit var deliveryRepository: DeliveryRepository
 
     @Autowired
     protected lateinit var temporaryCertificateRepository: TemporaryCertificateRepository

--- a/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/jobs/InitialRetentionPeriodDataRemovalJobIntegrationTest.kt
@@ -19,6 +19,10 @@ internal class InitialRetentionPeriodDataRemovalJobIntegrationTest : Integration
         val certificate3 = buildCertificate(initialRetentionRemovalDate = LocalDate.now())
         val certificate4 = buildCertificate(initialRetentionRemovalDate = LocalDate.now().plusDays(1))
         certificateRepository.saveAll(listOf(certificate1, certificate2, certificate3, certificate4))
+        val deliveryId1 = certificate1.printRequests[0].delivery!!.id!!
+        val deliveryId2 = certificate2.printRequests[0].delivery!!.id!!
+        val deliveryId3 = certificate3.printRequests[0].delivery!!.id!!
+        val deliveryId4 = certificate4.printRequests[0].delivery!!.id!!
         TestLogAppender.reset()
 
         // When
@@ -29,6 +33,10 @@ internal class InitialRetentionPeriodDataRemovalJobIntegrationTest : Integration
         assertThat(certificateRepository.findById(certificate2.id!!).get()).initialRetentionPeriodDataIsRemoved()
         assertThat(certificateRepository.findById(certificate3.id!!).get()).hasInitialRetentionPeriodData()
         assertThat(certificateRepository.findById(certificate4.id!!).get()).hasInitialRetentionPeriodData()
+        assertThat(deliveryRepository.findById(deliveryId1)).isEmpty
+        assertThat(deliveryRepository.findById(deliveryId2)).isEmpty
+        assertThat(deliveryRepository.findById(deliveryId3)).isNotEmpty
+        assertThat(deliveryRepository.findById(deliveryId4)).isNotEmpty
         assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate1.sourceReference}", Level.INFO)).isTrue
         assertThat(TestLogAppender.hasLog("Removed initial retention period data from certificate with sourceReference ${certificate2.sourceReference}", Level.INFO)).isTrue
     }


### PR DESCRIPTION
More in-depth testing has revealed it's not enough just to set various values to `null` and then call `save()` on the `CertificateRepository`. That's not has how `CascadeType.ALL` works and is something I was always unsure about (I know, I should have tested this more thoroughly to begin with but haste got the better of me! 🙄 ).

Instead I've reluctantly introduced `DeliveryRepository` so I can call `delete()` on each one. This subsequently removes all child `address` entities as well (i.e. exactly how `CascadeType.ALL` is intended to work).