### PR TITLE
EIP1-3765 Remove duplicate print requests from count

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounter.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounter.kt
@@ -7,4 +7,5 @@ fun countPrintRequestsAssignedToBatch(certificates: List<Certificate>, batchId: 
     certificates
         .flatMap { it.printRequests }
         .filter { it.batchId == batchId }
+        .distinct()
         .count { it.getCurrentStatus().status == PrintRequestStatus.Status.ASSIGNED_TO_BATCH }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
@@ -9,6 +9,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
 import java.time.Instant
+import java.util.UUID
 
 class PrintRequestCounterTest {
 
@@ -62,6 +63,49 @@ class PrintRequestCounterTest {
                 ),
             )
             val expectedPrintRequestCount = 0
+
+            // When
+            val actual = countPrintRequestsAssignedToBatch(certificates, batchId)
+
+            // Then
+            assertThat(actual).isEqualTo(expectedPrintRequestCount)
+        }
+
+        @Test
+        fun `should determine count given same certificate included in list`() {
+            // Given
+            val batchId = "4143d442a2424740afa3ce5eae630aaf"
+            val otherBatchId = "bdbf4054cc904c4abf61cd6bb9171b55"
+            // certificate with one print request for current batch and one historic
+            val certificate = buildCertificate(
+                    printRequests = listOf(
+                        buildPrintRequest(
+                            batchId = otherBatchId,
+                            printRequestStatuses = listOf(
+                                buildPrintRequestStatus(
+                                    status = ASSIGNED_TO_BATCH,
+                                    eventDateTime = Instant.now().minusSeconds(30)
+                                ),
+                                buildPrintRequestStatus(
+                                    status = SENT_TO_PRINT_PROVIDER,
+                                    eventDateTime = Instant.now().minusSeconds(10)
+                                ),
+                            )
+                        ).also {
+                            it.id = UUID.randomUUID()
+                        },
+                        buildPrintRequest(
+                            batchId = batchId,
+                            printRequestStatuses = listOf(
+                                buildPrintRequestStatus(status = ASSIGNED_TO_BATCH),
+                            )
+                        ).also {
+                            it.id = UUID.randomUUID()
+                        },
+                    )
+                )
+            val certificates = listOf(certificate, certificate, certificate, certificate, certificate)
+            val expectedPrintRequestCount = 1
 
             // When
             val actual = countPrintRequestsAssignedToBatch(certificates, batchId)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintRequestCounterTest.kt
@@ -78,32 +78,32 @@ class PrintRequestCounterTest {
             val otherBatchId = "bdbf4054cc904c4abf61cd6bb9171b55"
             // certificate with one print request for current batch and one historic
             val certificate = buildCertificate(
-                    printRequests = listOf(
-                        buildPrintRequest(
-                            batchId = otherBatchId,
-                            printRequestStatuses = listOf(
-                                buildPrintRequestStatus(
-                                    status = ASSIGNED_TO_BATCH,
-                                    eventDateTime = Instant.now().minusSeconds(30)
-                                ),
-                                buildPrintRequestStatus(
-                                    status = SENT_TO_PRINT_PROVIDER,
-                                    eventDateTime = Instant.now().minusSeconds(10)
-                                ),
-                            )
-                        ).also {
-                            it.id = UUID.randomUUID()
-                        },
-                        buildPrintRequest(
-                            batchId = batchId,
-                            printRequestStatuses = listOf(
-                                buildPrintRequestStatus(status = ASSIGNED_TO_BATCH),
-                            )
-                        ).also {
-                            it.id = UUID.randomUUID()
-                        },
-                    )
+                printRequests = listOf(
+                    buildPrintRequest(
+                        batchId = otherBatchId,
+                        printRequestStatuses = listOf(
+                            buildPrintRequestStatus(
+                                status = ASSIGNED_TO_BATCH,
+                                eventDateTime = Instant.now().minusSeconds(30)
+                            ),
+                            buildPrintRequestStatus(
+                                status = SENT_TO_PRINT_PROVIDER,
+                                eventDateTime = Instant.now().minusSeconds(10)
+                            ),
+                        )
+                    ).also {
+                        it.id = UUID.randomUUID()
+                    },
+                    buildPrintRequest(
+                        batchId = batchId,
+                        printRequestStatuses = listOf(
+                            buildPrintRequestStatus(status = ASSIGNED_TO_BATCH),
+                        )
+                    ).also {
+                        it.id = UUID.randomUUID()
+                    },
                 )
+            )
             val certificates = listOf(certificate, certificate, certificate, certificate, certificate)
             val expectedPrintRequestCount = 1
 


### PR DESCRIPTION
Found issue with the number of requests being included in the SQS message being more than it should as double counting print requests.