### PR TITLE
EIP1-3823 Add secure endpoint to generate an Anonymous Elector Document (AED)

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AedPrintRequest.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AedPrintRequest.kt
@@ -54,7 +54,7 @@ class AedPrintRequest(
     var userId: String,
 
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
-    @JoinColumn(name = "print_request_id", nullable = false)
+    @JoinColumn(name = "aed_print_request_id", nullable = false)
     var statusHistory: MutableList<AedPrintRequestStatus> = mutableListOf(),
 
     @CreationTimestamp

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
@@ -66,6 +66,7 @@ class AnonymousElectorDocument(
     var photoLocationArn: String,
 
     @OneToOne(cascade = [CascadeType.ALL])
+    @JoinColumn(name = "aed_contact_details_id")
     var contactDetails: AedContactDetails?,
 
     @field:NotNull

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
@@ -12,8 +12,8 @@ data class GenerateAnonymousElectorDocumentDto(
     val firstName: String,
     val middleNames: String? = null,
     val surname: String,
-    val email: String,
-    val phoneNumber: String,
+    val email: String? = null,
+    val phoneNumber: String? = null,
     val address: AddressDto,
     val userId: String,
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
@@ -8,7 +8,7 @@ data class GenerateAnonymousElectorDocumentDto(
     val electoralRollNumber: String,
     val photoLocation: String,
     val certificateLanguage: CertificateLanguage,
-    val supportingInformationFormat: SupportingInformationFormat,
+    val supportingInformationFormat: SupportingInformationFormat?,
     val firstName: String,
     val middleNames: String? = null,
     val surname: String,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
@@ -25,8 +25,13 @@ class GlobalExceptionHandler(
         return handleExceptionInternal(e, e.message, HttpHeaders(), NOT_FOUND, request)
     }
 
-    @ExceptionHandler(value = [GenerateTemporaryCertificateValidationException::class])
-    fun handleGenerateTemporaryCertificateValidationException(e: RuntimeException, request: WebRequest): ResponseEntity<Any> {
+    @ExceptionHandler(
+        value = [
+            GenerateTemporaryCertificateValidationException::class,
+            GenerateAnonymousElectorDocumentValidationException::class
+        ]
+    )
+    fun handleRequestValidationException(e: RuntimeException, request: WebRequest): ResponseEntity<Any> {
         return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapper.kt
@@ -34,7 +34,7 @@ abstract class AnonymousElectorDocumentMapper {
     ): AnonymousElectorDocument
 
     @AfterMapping
-    protected fun addPrintRequestToAnonymousElectoralDocument(
+    protected fun addPrintRequestToAnonymousElectorDocument(
         aedRequest: GenerateAnonymousElectorDocumentDto,
         aedTemplateFilename: String,
         @MappingTarget anonymousElectorDocument: AnonymousElectorDocument

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/GenerateAnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/GenerateAnonymousElectorDocumentMapper.kt
@@ -1,0 +1,21 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.mapstruct.Mapper
+import uk.gov.dluhc.printapi.dto.GenerateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
+
+@Mapper(
+    uses =
+    [
+        CertificateLanguageMapper::class,
+        SourceTypeMapper::class,
+        SupportingInformationFormatMapper::class
+    ]
+)
+interface GenerateAnonymousElectorDocumentMapper {
+
+    fun toGenerateAnonymousElectorDocumentDto(
+        apiRequest: GenerateAnonymousElectorDocumentRequest,
+        userId: String
+    ): GenerateAnonymousElectorDocumentDto
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapper.kt
@@ -6,6 +6,7 @@ import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat as SupportingInformationFormatEntity
 import uk.gov.dluhc.printapi.dto.SupportingInformationFormat as SupportingInformationFormatDto
 import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat as SupportingInformationFormatModelEnum
+import uk.gov.dluhc.printapi.models.SupportingInformationFormat as SupportingInformationFormatApi
 
 @Mapper
 interface SupportingInformationFormatMapper {
@@ -26,4 +27,6 @@ interface SupportingInformationFormatMapper {
     fun toPrintRequestEntityEnum(supportingInformationFormat: SupportingInformationFormatModelEnum): SupportingInformationFormatEntity
 
     fun mapDtoToEntity(supportingInformationFormat: SupportingInformationFormatDto): SupportingInformationFormatEntity
+
+    fun mapApiToDto(supportingInformationFormat: SupportingInformationFormatApi): SupportingInformationFormatDto
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/AnonymousElectorDocumentController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/AnonymousElectorDocumentController.kt
@@ -9,19 +9,46 @@ import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
 import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.Authentication
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.printapi.dto.PdfFile
+import uk.gov.dluhc.printapi.mapper.GenerateAnonymousElectorDocumentMapper
+import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentService
 import uk.gov.dluhc.printapi.service.pdf.ExplainerPdfService
 import java.io.ByteArrayInputStream
+import javax.validation.Valid
 
 @RestController
 @CrossOrigin
 class AnonymousElectorDocumentController(
     @Qualifier("anonymousElectorDocumentExplainerPdfService") private val explainerPdfService: ExplainerPdfService,
+    private val generateAnonymousElectorDocumentMapper: GenerateAnonymousElectorDocumentMapper,
+    private val anonymousElectorDocumentService: AnonymousElectorDocumentService,
 ) {
+
+    @PostMapping("/eros/{eroId}/anonymous-elector-documents")
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    fun generateAnonymousElectorDocument(
+        @PathVariable eroId: String,
+        @RequestBody @Valid generateAnonymousElectorDocumentRequest: GenerateAnonymousElectorDocumentRequest,
+        authentication: Authentication
+    ): ResponseEntity<InputStreamResource> {
+        val userId = authentication.name
+        val dto = generateAnonymousElectorDocumentMapper.toGenerateAnonymousElectorDocumentDto(
+            generateAnonymousElectorDocumentRequest,
+            userId
+        )
+        return anonymousElectorDocumentService.generateAnonymousElectorDocument(eroId, dto).let { pdfFile ->
+            ResponseEntity.status(CREATED)
+                .headers(createPdfHttpHeaders(pdfFile))
+                .body(InputStreamResource(ByteArrayInputStream(pdfFile.contents)))
+        }
+    }
 
     @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
     @PostMapping(

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AedPdfTemplateDetailsFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AedPdfTemplateDetailsFactory.kt
@@ -32,7 +32,7 @@ class AedPdfTemplateDetailsFactory(
         printRequest: AedPrintRequest
     ): Map<String, String> {
         return mapOf(
-            pdfTemplateProperties.welsh.placeholder.electoralRollNumber to printRequest.electoralRollNumber,
+            pdfTemplateProperties.welsh.placeholder.electoralRollNumber to printRequest.electoralRollNumber.uppercase(),
             pdfTemplateProperties.welsh.placeholder.dateOfIssue to printRequest.issueDate.format(DATE_TIME_FORMATTER),
             pdfTemplateProperties.welsh.placeholder.certificateNumber to electorDocument.certificateNumber,
         )
@@ -43,7 +43,7 @@ class AedPdfTemplateDetailsFactory(
         printRequest: AedPrintRequest
     ): Map<String, String> {
         return mapOf(
-            pdfTemplateProperties.english.placeholder.electoralRollNumber to printRequest.electoralRollNumber,
+            pdfTemplateProperties.english.placeholder.electoralRollNumber to printRequest.electoralRollNumber.uppercase(),
             pdfTemplateProperties.english.placeholder.dateOfIssue to printRequest.issueDate.format(DATE_TIME_FORMATTER),
             pdfTemplateProperties.english.placeholder.certificateNumber to electorDocument.certificateNumber,
         )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
@@ -35,11 +35,11 @@ class AnonymousElectorDocumentService(
         try {
             eroClient.getEro(gssCode).also {
                 if (it.eroId != eroId) {
-                    throw GenerateAnonymousElectorDocumentValidationException("Anonymous Electoral Document gssCode '$gssCode' is not valid for eroId '$eroId'")
+                    throw GenerateAnonymousElectorDocumentValidationException("Anonymous Elector Document gssCode '$gssCode' is not valid for eroId '$eroId'")
                 }
             }
         } catch (error: ElectoralRegistrationOfficeNotFoundException) {
-            throw GenerateAnonymousElectorDocumentValidationException("Anonymous Electoral Document gssCode '$gssCode' does not exist")
+            throw GenerateAnonymousElectorDocumentValidationException("Anonymous Elector Document gssCode '$gssCode' does not exist")
         }
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -20,4 +20,5 @@
     <include relativeToChangelogFile="true" file="ddl/0011_initial_data_retention_period_changes.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0012_supporting_information_non_mandatory.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0013_initial_retention_data_removed_column.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0014_create_anonymous_elector_document_tables.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0014_create_anonymous_elector_document_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0014_create_anonymous_elector_document_tables.xml
@@ -71,9 +71,9 @@
             <column name="photo_location_arn" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="aed_contact_details" type="uuid">
+            <column name="aed_contact_details_id" type="uuid">
                 <constraints nullable="true"
-                             foreignKeyName="fk_aed_aed_contact_details"
+                             foreignKeyName="fk_aed_aed_contact_details_id"
                              references="aed_contact_details(id)"/>
             </column>
             <column name="initial_retention_removal_date" type="date" remarks="The date that certain data should be removed after the first retention period">

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.6.1'
+  version: '1.6.2'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -831,7 +831,7 @@ components:
           description: The electoral roll number allocated by the Local Authority to the elector.
         certificateLanguage:
           $ref: '#/components/schemas/CertificateLanguage'
-        SupportingInformationFormat:
+        supportingInformationFormat:
           $ref: '#/components/schemas/SupportingInformationFormat'
         photoLocation:
           type: string
@@ -875,7 +875,7 @@ components:
         - applicationReference
         - electoralRollNumber
         - certificateLanguage
-        - supportingInfoFormat
+        - supportingInformationFormat
         - photoLocation
         - firstName
         - surname

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -31,6 +31,7 @@ import software.amazon.awssdk.services.s3.S3Client
 import uk.gov.dluhc.printapi.client.BankHolidayDataClient
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_REQUEST_UPLOAD_PATH
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_RESPONSE_DOWNLOAD_PATH
+import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepository
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.database.repository.DeliveryRepository
 import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
@@ -128,6 +129,9 @@ internal abstract class IntegrationTest {
     @Autowired
     protected lateinit var temporaryCertificateRepository: TemporaryCertificateRepository
 
+    @Autowired
+    protected lateinit var anonymousElectorDocumentRepository: AnonymousElectorDocumentRepository
+
     @BeforeEach
     fun clearLogAppender() {
         TestLogAppender.reset()
@@ -155,6 +159,7 @@ internal abstract class IntegrationTest {
     fun clearDatabase() {
         clearRepository(certificateRepository, "certificateRepository")
         clearRepository(temporaryCertificateRepository, "temporaryCertificateRepository")
+        clearRepository(anonymousElectorDocumentRepository, "anonymousElectorDocumentRepository")
     }
 
     private fun clearRepository(repository: CrudRepository<*, *>, repoName: String) {

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapperTest.kt
@@ -97,7 +97,7 @@ class AnonymousElectorDocumentMapperTest {
         // Then
         verify(sourceTypeMapper).mapDtoToEntity(request.sourceType)
         verify(certificateLanguageMapper).mapDtoToEntity(request.certificateLanguage)
-        verify(supportingInformationFormatMapper).mapDtoToEntity(request.supportingInformationFormat)
+        verify(supportingInformationFormatMapper).mapDtoToEntity(request.supportingInformationFormat!!)
         verify(idFactory).vacNumber()
         verify(printRequestMapper).toPrintRequest(request, aedTemplateFilename)
         assertThat(actual).usingRecursiveComparison().isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/GenerateAnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/GenerateAnonymousElectorDocumentMapperTest.kt
@@ -1,0 +1,89 @@
+package uk.gov.dluhc.printapi.mapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import uk.gov.dluhc.printapi.dto.AddressDto
+import uk.gov.dluhc.printapi.dto.GenerateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildGenerateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.dto.CertificateLanguage as CertificateLanguageDto
+import uk.gov.dluhc.printapi.dto.SourceType as SourceTypeDto
+import uk.gov.dluhc.printapi.dto.SupportingInformationFormat as SupportingInformationFormatDto
+import uk.gov.dluhc.printapi.models.CertificateLanguage as CertificateLanguageApi
+import uk.gov.dluhc.printapi.models.SourceType as SourceTypeApi
+import uk.gov.dluhc.printapi.models.SupportingInformationFormat as SupportingInformationFormatApi
+
+@ExtendWith(MockitoExtension::class)
+class GenerateAnonymousElectorDocumentMapperTest {
+
+    @Mock
+    private lateinit var certificateLanguageMapper: CertificateLanguageMapper
+
+    @Mock
+    private lateinit var sourceTypeMapper: SourceTypeMapper
+
+    @Mock
+    private lateinit var supportingInformationFormatMapper: SupportingInformationFormatMapper
+
+    @InjectMocks
+    private lateinit var mapper: GenerateAnonymousElectorDocumentMapperImpl
+
+    @Test
+    fun `should map to GenerateAnonymousElectorDocumentDto DTO given API Request`() {
+        // Given
+        val userId = aValidUserId()
+        val apiRequest = buildGenerateAnonymousElectorDocumentRequest(
+            sourceType = SourceTypeApi.VOTER_MINUS_CARD,
+            certificateLanguage = CertificateLanguageApi.EN,
+            supportingInformationFormat = SupportingInformationFormatApi.STANDARD
+        )
+
+        given(sourceTypeMapper.mapApiToDto(any())).willReturn(SourceTypeDto.VOTER_CARD)
+        given(certificateLanguageMapper.mapApiToDto(any())).willReturn(CertificateLanguageDto.EN)
+        given(supportingInformationFormatMapper.mapApiToDto(any())).willReturn(SupportingInformationFormatDto.STANDARD)
+
+        val expected = GenerateAnonymousElectorDocumentDto(
+            gssCode = apiRequest.gssCode,
+            sourceType = SourceTypeDto.VOTER_CARD,
+            sourceReference = apiRequest.sourceReference,
+            applicationReference = apiRequest.applicationReference,
+            electoralRollNumber = apiRequest.electoralRollNumber,
+            photoLocation = apiRequest.photoLocation,
+            certificateLanguage = CertificateLanguageDto.EN,
+            supportingInformationFormat = SupportingInformationFormatDto.STANDARD,
+            firstName = apiRequest.firstName,
+            middleNames = apiRequest.middleNames,
+            surname = apiRequest.surname,
+            email = apiRequest.email,
+            phoneNumber = apiRequest.phoneNumber,
+            address = with(apiRequest.address) {
+                AddressDto(
+                    property = property,
+                    street = street,
+                    town = town,
+                    area = area,
+                    locality = locality,
+                    uprn = uprn,
+                    postcode = postcode
+                )
+            },
+            userId = userId
+        )
+
+        // When
+        val actual = mapper.toGenerateAnonymousElectorDocumentDto(apiRequest, userId)
+
+        // Then
+        verify(sourceTypeMapper).mapApiToDto(SourceTypeApi.VOTER_MINUS_CARD)
+        verify(certificateLanguageMapper).mapApiToDto(CertificateLanguageApi.EN)
+        verify(supportingInformationFormatMapper).mapApiToDto(SupportingInformationFormatApi.STANDARD)
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SupportingInformationFormatMapperTest.kt
@@ -8,6 +8,8 @@ import uk.gov.dluhc.printapi.printprovider.models.PrintRequest
 import uk.gov.dluhc.printapi.database.entity.SupportingInformationFormat as SupportingInformationFormatEntityEnum
 import uk.gov.dluhc.printapi.dto.SupportingInformationFormat as SupportingInformationFormatDto
 import uk.gov.dluhc.printapi.messaging.models.SupportingInformationFormat as SupportingInformationFormatModelEnum
+import uk.gov.dluhc.printapi.models.SupportingInformationFormat as SupportingInformationFormatApi
+
 class SupportingInformationFormatMapperTest {
 
     private val mapper = SupportingInformationFormatMapperImpl()
@@ -70,6 +72,20 @@ class SupportingInformationFormatMapperTest {
         // Given
         // When
         val actual = mapper.mapDtoToEntity(supportingInformationFormatModelEnum)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = ["STANDARD, STANDARD"])
+    fun `should map SupportingInformationFormat REST API enum to DTO enum`(
+        supportingInformationFormat: SupportingInformationFormatApi,
+        expected: SupportingInformationFormatDto
+    ) {
+        // Given
+        // When
+        val actual = mapper.mapApiToDto(supportingInformationFormat)
 
         // Then
         assertThat(actual).isEqualTo(expected)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -1,0 +1,240 @@
+package uk.gov.dluhc.printapi.rest
+
+import com.lowagie.text.pdf.PdfReader
+import com.lowagie.text.pdf.parser.PdfTextExtractor
+import liquibase.pro.packaged.it
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.util.ResourceUtils
+import software.amazon.awssdk.core.sync.RequestBody
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration
+import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.ErrorResponseAssert.Companion.assertThat
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildGenerateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
+import uk.gov.dluhc.printapi.testsupport.withBody
+import java.io.ByteArrayInputStream
+import java.util.UUID
+
+internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/anonymous-elector-documents"
+        private const val ERO_ID = "some-city-council"
+        private const val OTHER_ERO_ID = "other-city-council"
+        private const val GSS_CODE = "W06000023"
+        private const val AED_SAMPLE_PHOTO = "classpath:temporary-certificate-template/sample-certificate-photo.png"
+        private const val MAX_SIZE_2_MB = 2 * 1024 * 1024
+    }
+
+    @Test
+    fun `should return forbidden given user with bearer token missing required group to access service`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.post()
+            .uri(
+                URI_TEMPLATE,
+                ERO_ID,
+                GSS_CODE
+            )
+            .bearerToken(
+                getBearerToken(
+                    eroId = userGroupEroId,
+                    groups = listOf("ero-$userGroupEroId", "ero-vc-anonymous-admin-$userGroupEroId")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(buildGenerateAnonymousElectorDocumentRequest())
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return bad request given invalid request body`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val invalidGssCode = "invalid GSS Code"
+        val requestBody = buildGenerateAnonymousElectorDocumentRequest(
+            gssCode = invalidGssCode
+        )
+
+        // When
+        val response = webTestClient.post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(
+                getBearerToken(
+                    eroId = ERO_ID,
+                    groups = listOf("ero-$ERO_ID", "ero-vc-anonymous-admin-$ERO_ID")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Validation failed for object='generateAnonymousElectorDocumentRequest'. Error count: 1")
+            .hasValidationError("Error on field 'gssCode': rejected value [$invalidGssCode], size must be between 9 and 9")
+    }
+
+    @Test
+    fun `should return not found given no local authority found for the provided gss code`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCodeNoMatch(GSS_CODE)
+        val requestBody = buildGenerateAnonymousElectorDocumentRequest(gssCode = GSS_CODE)
+
+        // When
+        val response = webTestClient.post()
+            .uri(
+                URI_TEMPLATE,
+                ERO_ID
+            )
+            .bearerToken(
+                getBearerToken(
+                    eroId = ERO_ID,
+                    groups = listOf("ero-$ERO_ID", "ero-vc-anonymous-admin-$ERO_ID")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Anonymous Elector Document gssCode '$GSS_CODE' does not exist")
+    }
+
+    @Test
+    fun `should return not found given no local authority found for the provided ero and gss code`() {
+        // Given
+        val eroResponseHasDifferentEroIdToBearerTokenAndUri = buildElectoralRegistrationOfficeResponse(
+            id = OTHER_ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE))
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(
+            eroResponseHasDifferentEroIdToBearerTokenAndUri,
+            GSS_CODE
+        )
+        val requestBody = buildGenerateAnonymousElectorDocumentRequest(gssCode = GSS_CODE)
+
+        // When
+        val response = webTestClient.post()
+            .uri(
+                URI_TEMPLATE,
+                ERO_ID
+            )
+            .bearerToken(
+                getBearerToken(
+                    eroId = ERO_ID,
+                    groups = listOf("ero-$ERO_ID", "ero-vc-anonymous-admin-$ERO_ID")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(requestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Anonymous Elector Document gssCode '$GSS_CODE' is not valid for eroId '$ERO_ID'")
+    }
+
+    @Test
+    fun `should return AED pdf given valid request for authorised user`() {
+        // Given
+        val photoLocationArn = addPhotoToS3()
+        val request = buildGenerateAnonymousElectorDocumentRequest(photoLocation = photoLocationArn)
+        val localAuthorities: List<LocalAuthorityResponse> = listOf(
+            buildLocalAuthorityResponse(
+                gssCode = request.gssCode,
+            )
+        )
+        val eroResponse = buildElectoralRegistrationOfficeResponse(id = ERO_ID, localAuthorities = localAuthorities)
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByGssCode(eroResponse, request.gssCode)
+
+        // When
+        val response = webTestClient.mutate()
+            .codecs { it.defaultCodecs().maxInMemorySize(MAX_SIZE_2_MB) }
+            .build().post()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(
+                getBearerToken(
+                    eroId = ERO_ID,
+                    groups = listOf("ero-$ERO_ID", "ero-vc-anonymous-admin-$ERO_ID")
+                )
+            )
+            .contentType(MediaType.APPLICATION_JSON)
+            .withBody(request)
+            .exchange()
+            .expectStatus().isCreated
+            .expectHeader().contentType(MediaType.APPLICATION_PDF)
+            .expectBody(ByteArray::class.java)
+            .returnResult()
+
+        // Then
+        val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(
+            listOf(request.gssCode),
+            VOTER_CARD,
+            request.sourceReference
+        )
+        assertThat(electorDocuments).hasSize(1)
+        val temporaryCertificate = electorDocuments[0]
+        val contentDisposition = response.responseHeaders.contentDisposition
+        assertThat(contentDisposition.filename)
+            .isEqualTo("anonymous-elector-document-${temporaryCertificate.certificateNumber}.pdf")
+
+        val pdfContent = response.responseBody
+        assertThat(pdfContent).isNotNull
+        PdfReader(pdfContent).use { reader ->
+            val text = PdfTextExtractor(reader).getTextFromPage(1)
+            assertThat(text).contains(temporaryCertificate.certificateNumber)
+        }
+    }
+
+    private fun addPhotoToS3(): String {
+        val s3Resource = ResourceUtils.getFile(AED_SAMPLE_PHOTO).readBytes()
+        val s3Bucket = LocalStackContainerConfiguration.S3_BUCKET_CONTAINING_PHOTOS
+        val s3Path = "E09000007/0013a30ac9bae2ebb9b1239b/${UUID.randomUUID()}/8a53a30ac9bae2ebb9b1239b-test-photo.png"
+
+        // add resource to S3
+        s3Client.putObject(
+            PutObjectRequest.builder()
+                .bucket(s3Bucket)
+                .key(s3Path)
+                .build(),
+            RequestBody.fromInputStream(ByteArrayInputStream(s3Resource), s3Resource.size.toLong())
+        )
+        return "arn:aws:s3:::$s3Bucket/$s3Path"
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -13,6 +13,7 @@ import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration
 import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
 import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.testsupport.assertj.assertions.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
@@ -20,6 +21,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.getBearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildGenerateAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildValidAddress
 import uk.gov.dluhc.printapi.testsupport.withBody
 import java.io.ByteArrayInputStream
 import java.util.UUID
@@ -173,6 +175,30 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
         // Given
         val photoLocationArn = addPhotoToS3()
         val request = buildGenerateAnonymousElectorDocumentRequest(photoLocation = photoLocationArn)
+        processValidRequest(request)
+    }
+
+    @Test
+    fun `should return AED pdf given valid request for authorised user with all optional data omitted`() {
+        // Given
+        val photoLocationArn = addPhotoToS3()
+        val request = buildGenerateAnonymousElectorDocumentRequest(
+            photoLocation = photoLocationArn,
+            email = null,
+            phoneNumber = null,
+            address = buildValidAddress(
+                property = null,
+                locality = null,
+                town = null,
+                area = null,
+                uprn = null
+            )
+        )
+        processValidRequest(request)
+    }
+
+    private fun processValidRequest(request: GenerateAnonymousElectorDocumentRequest) {
+        // Given
         val localAuthorities: List<LocalAuthorityResponse> = listOf(
             buildLocalAuthorityResponse(
                 gssCode = request.gssCode,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -208,16 +208,16 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
             request.sourceReference
         )
         assertThat(electorDocuments).hasSize(1)
-        val temporaryCertificate = electorDocuments[0]
+        val electorDocument = electorDocuments[0]
         val contentDisposition = response.responseHeaders.contentDisposition
         assertThat(contentDisposition.filename)
-            .isEqualTo("anonymous-elector-document-${temporaryCertificate.certificateNumber}.pdf")
+            .isEqualTo("anonymous-elector-document-${electorDocument.certificateNumber}.pdf")
 
         val pdfContent = response.responseBody
         assertThat(pdfContent).isNotNull
         PdfReader(pdfContent).use { reader ->
             val text = PdfTextExtractor(reader).getTextFromPage(1)
-            assertThat(text).contains(temporaryCertificate.certificateNumber)
+            assertThat(text).contains(electorDocument.certificateNumber)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.dluhc.printapi.rest
 
 import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
-import liquibase.pro.packaged.it
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
@@ -99,7 +99,7 @@ internal class AnonymousElectorDocumentServiceTest {
             pdfFactory,
             anonymousElectorDocumentRepository
         )
-        Assertions.assertThat(exception).hasMessage("Anonymous Electoral Document gssCode 'N06000012' does not exist")
+        Assertions.assertThat(exception).hasMessage("Anonymous Elector Document gssCode 'N06000012' does not exist")
     }
 
     @Test
@@ -127,6 +127,6 @@ internal class AnonymousElectorDocumentServiceTest {
             anonymousElectorDocumentRepository
         )
         Assertions.assertThat(exception)
-            .hasMessage("Anonymous Electoral Document gssCode 'W06000023' is not valid for eroId 'bath-and-north-east-somerset-council'")
+            .hasMessage("Anonymous Elector Document gssCode 'W06000023' is not valid for eroId 'bath-and-north-east-somerset-council'")
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
@@ -1,0 +1,71 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.model
+
+import org.apache.commons.lang3.RandomStringUtils
+import uk.gov.dluhc.printapi.models.Address
+import uk.gov.dluhc.printapi.models.CertificateLanguage
+import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.models.SourceType
+import uk.gov.dluhc.printapi.models.SupportingInformationFormat
+import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker
+import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidElectoralRollNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidFirstName
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+
+fun buildGenerateAnonymousElectorDocumentRequest(
+    gssCode: String = aGssCode(),
+    sourceType: SourceType = SourceType.VOTER_MINUS_CARD,
+    sourceReference: String = aValidSourceReference(),
+    applicationReference: String = aValidApplicationReference(),
+    electoralRollNumber: String = aValidElectoralRollNumber(),
+    photoLocation: String = aPhotoArn(),
+    certificateLanguage: CertificateLanguage = CertificateLanguage.EN,
+    supportingInformationFormat: SupportingInformationFormat = SupportingInformationFormat.STANDARD,
+    firstName: String = aValidFirstName(),
+    middleNames: String? = null,
+    surname: String = aValidSurname(),
+    email: String = aValidEmailAddress(),
+    phoneNumber: String = aValidPhoneNumber(),
+    address: Address = buildValidAddress(),
+): GenerateAnonymousElectorDocumentRequest =
+    GenerateAnonymousElectorDocumentRequest(
+        gssCode = gssCode,
+        sourceType = sourceType,
+        sourceReference = sourceReference,
+        applicationReference = applicationReference,
+        electoralRollNumber = electoralRollNumber,
+        photoLocation = photoLocation,
+        certificateLanguage = certificateLanguage,
+        supportingInformationFormat = supportingInformationFormat,
+        firstName = firstName,
+        middleNames = middleNames,
+        surname = surname,
+        email = email,
+        phoneNumber = phoneNumber,
+        address = address
+    )
+
+fun buildValidAddress(
+    fakeAddress: net.datafaker.Address = DataFaker.faker.address(),
+    property: String? = fakeAddress.buildingNumber(),
+    street: String = fakeAddress.streetName(),
+    locality: String? = fakeAddress.streetName(),
+    town: String? = fakeAddress.city(),
+    area: String? = fakeAddress.state(),
+    postcode: String = fakeAddress.postcode(),
+    uprn: String? = RandomStringUtils.randomNumeric(12),
+): Address =
+    Address(
+        property = property,
+        street = street,
+        town = town,
+        area = area,
+        locality = locality,
+        uprn = uprn,
+        postcode = postcode
+    )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
@@ -29,8 +29,8 @@ fun buildGenerateAnonymousElectorDocumentRequest(
     firstName: String = aValidFirstName(),
     middleNames: String? = null,
     surname: String = aValidSurname(),
-    email: String = aValidEmailAddress(),
-    phoneNumber: String = aValidPhoneNumber(),
+    email: String? = aValidEmailAddress(),
+    phoneNumber: String? = aValidPhoneNumber(),
     address: Address = buildValidAddress(),
 ): GenerateAnonymousElectorDocumentRequest =
     GenerateAnonymousElectorDocumentRequest(


### PR DESCRIPTION
Example AED

![image](https://user-images.githubusercontent.com/54864568/220702696-f93b53c2-a57d-4611-b8b6-b803740a692b.png)

Mainly the mapper from REST API to DTO, Controller Method and Integration Test with few minor fixes and updates.