### PR TITLE
EIP1-4154 - Retention period columns

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
@@ -74,7 +74,7 @@ class AnonymousElectorDocument(
     var gssCode: String,
 
     @field:NotNull
-    @field:Size(max = 7)
+    @field:Size(max = 30)
     var electoralRollNumber: String,
 
     @field:NotNull

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
@@ -97,12 +97,22 @@ class AnonymousElectorDocument(
 
     /**
      * The legislation stipulates there are two retention periods for AED related data. The first (initial)
-     * period applies to PII data that is not on the printed certificate itself (e.g. the addressee/address on the
-     * envelope), which needs to be removed 15 months after the AED is "issued".
-     * For standard (non-temporary) certificates, the retention period is considerably longer and is currently specified
-     * as the tenth 1st July.
+     * period (which this field relates to) applies to PII data that is not on the printed document itself (e.g. the
+     * addressee/address on the envelope). This needs to be removed 15 months after the AED is "issued" (generated).
+     * The second (final) retention period is handled by the `finalRetentionRemovalDate` field below.
      */
     var initialRetentionRemovalDate: LocalDate? = null,
+
+    /**
+     * Set to true after the initial retention period data is removed.
+     */
+    var initialRetentionDataRemoved: Boolean = false,
+
+    /**
+     * The date that all remaining document data should be removed after the second (final) retention period. This is
+     * currently specified as the tenth 1st July in the legislation.
+     */
+    var finalRetentionRemovalDate: LocalDate? = null,
 
     @CreationTimestamp
     var dateCreated: Instant? = null,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -73,11 +73,12 @@ class Certificate(
     var suggestedExpiryDate: LocalDate = issueDate.plusYears(10),
 
     /**
-     * The legislation stipulates there are two retention periods for certificate related data. The first (initial)
-     * period applies to PII data that is not on the printed certificate itself (e.g. the addressee/address on the
-     * envelope), which needs to be removed 28 (configurable) working days after the certificate is "issued".
-     * For standard (non-temporary) certificates, the retention period is considerably longer and is currently specified
-     * as the tenth 1st July.
+     * The legislation stipulates there are three retention periods for certificate related data. The first (initial)
+     * period (which this field relates to), applies to PII data that is not on the printed certificate itself (e.g. the
+     * addressee/address on the envelope). This needs to be removed 28 (configurable) working days after the
+     * certificate is "issued".
+     * The second retention period applies to Temporary Certificates (see [TemporaryCertificate]) and the third (final)
+     * retention period is handled by `finalRetentionRemovalDate` below.
      */
     var initialRetentionRemovalDate: LocalDate? = null,
 
@@ -85,6 +86,12 @@ class Certificate(
      * Set to true after the initial retention period data is removed.
      */
     var initialRetentionDataRemoved: Boolean = false,
+
+    /**
+     * The date that all remaining certificate data should be removed after the third (final) retention period. This is
+     * currently specified as the tenth 1st July in the legislation.
+     */
+    var finalRetentionRemovalDate: LocalDate? = null,
 
     /**
      * Certificate status corresponds to the current status of the most recent

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
@@ -4,10 +4,39 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
 import uk.gov.dluhc.printapi.database.entity.SourceType
+import java.time.LocalDate
 import java.util.UUID
 
 @Repository
 interface AnonymousElectorDocumentRepository : JpaRepository<AnonymousElectorDocument, UUID> {
 
     fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
+
+    fun findBySourceTypeAndInitialRetentionDataRemovedAndInitialRetentionRemovalDateBefore(
+        sourceType: SourceType,
+        initialRetentionDataRemoved: Boolean = false,
+        initialRetentionRemovalDate: LocalDate
+    ): List<AnonymousElectorDocument>
+
+    fun findBySourceTypeAndFinalRetentionRemovalDateBefore(
+        sourceType: SourceType,
+        finalRetentionRemovalDate: LocalDate
+    ): List<AnonymousElectorDocument>
+}
+
+object AnonymousElectorDocumentRepositoryExtensions {
+
+    fun AnonymousElectorDocumentRepository.findPendingRemovalOfInitialRetentionData(sourceType: SourceType): List<AnonymousElectorDocument> {
+        return findBySourceTypeAndInitialRetentionDataRemovedAndInitialRetentionRemovalDateBefore(
+            sourceType = sourceType,
+            initialRetentionRemovalDate = LocalDate.now()
+        )
+    }
+
+    fun AnonymousElectorDocumentRepository.findPendingRemovalOfFinalRetentionData(sourceType: SourceType): List<AnonymousElectorDocument> {
+        return findBySourceTypeAndFinalRetentionRemovalDateBefore(
+            sourceType = sourceType,
+            finalRetentionRemovalDate = LocalDate.now()
+        )
+    }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepository.kt
@@ -30,6 +30,11 @@ interface CertificateRepository : JpaRepository<Certificate, UUID> {
         initialRetentionRemovalDate: LocalDate
     ): List<Certificate>
 
+    fun findBySourceTypeAndFinalRetentionRemovalDateBefore(
+        sourceType: SourceType,
+        finalRetentionRemovalDate: LocalDate
+    ): List<Certificate>
+
     @Query(
         value = """
             SELECT COUNT(s) FROM PrintRequestStatus s
@@ -51,6 +56,13 @@ object CertificateRepositoryExtensions {
         return findBySourceTypeAndInitialRetentionDataRemovedAndInitialRetentionRemovalDateBefore(
             sourceType = sourceType,
             initialRetentionRemovalDate = LocalDate.now()
+        )
+    }
+
+    fun CertificateRepository.findPendingRemovalOfFinalRetentionData(sourceType: SourceType): List<Certificate> {
+        return findBySourceTypeAndFinalRetentionRemovalDateBefore(
+            sourceType = sourceType,
+            finalRetentionRemovalDate = LocalDate.now()
         )
     }
 }

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -22,4 +22,5 @@
     <include relativeToChangelogFile="true" file="ddl/0013_initial_retention_data_removed_column.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0014_create_anonymous_elector_document_tables.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0015_refactor_anonymous_elector_document_tables.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0016_final_retention_data_removed_column.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
+++ b/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="matt.wills@valtech.com" id="0016_EIP1-4154_alter_certificate - add final_retention_removal_date column" context="ddl">
+
+        <addColumn tableName="certificate">
+            <column name="final_retention_removal_date" type="date" afterColumn="initial_retention_data_removed"
+                    remarks="The date any remaining certificate data should be removed after the final retention period">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <createIndex tableName="certificate" indexName="certificate_final_retention_removal_date_idx">
+            <column name="source_type"/>
+            <column name="final_retention_removal_date"/>
+        </createIndex>
+
+        <rollback>
+            <dropColumn
+                tableName="certificate"
+                columnName="final_retention_removal_date"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="matt.wills@valtech.com" id="0016_EIP1-4154_alter_aed - add data retention columns" context="ddl">
+
+        <addColumn tableName="anonymous_elector_document">
+            <column name="initial_retention_data_removed" type="boolean" valueBoolean="false" afterColumn="initial_retention_removal_date"
+                    remarks="Indicates if initial retention period data has been removed from an AED">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <addColumn tableName="anonymous_elector_document">
+            <column name="final_retention_removal_date" type="date" afterColumn="initial_retention_data_removed"
+                    remarks="The date that all remaining data should be removed after the final retention period">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <!-- remove existing index based on just source type and initial_retention_removal_date -->
+        <dropIndex tableName="anonymous_elector_document" indexName="aed_initial_retention_removal_date_idx"/>
+
+        <!-- include initial_retention_data_removed column in new index -->
+        <createIndex tableName="anonymous_elector_document" indexName="aed_initial_retention_removal_idx">
+            <column name="source_type"/>
+            <column name="initial_retention_data_removed"/>
+            <column name="initial_retention_removal_date"/>
+        </createIndex>
+
+        <!-- create new index for final_retention_removal_date -->
+        <createIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_date_idx">
+            <column name="source_type"/>
+            <column name="final_retention_removal_date"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="anonymous_elector_document" indexName="aed_initial_retention_removal_idx"/>
+            <dropIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_date_idx"/>
+
+            <dropColumn
+                tableName="anonymous_elector_document"
+                columnName="initial_retention_data_removed"/>
+            <dropColumn
+                tableName="anonymous_elector_document"
+                columnName="final_retention_removal_date"/>
+
+            <!-- restore the original index based on source type and initial_retention_removal_date -->
+            <createIndex tableName="anonymous_elector_document" indexName="aed_initial_retention_removal_date_idx">
+                <column name="source_type"/>
+                <column name="initial_retention_removal_date"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
+++ b/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
@@ -14,7 +14,7 @@
             </column>
         </addColumn>
 
-        <createIndex tableName="certificate" indexName="certificate_final_retention_removal_date_idx">
+        <createIndex tableName="certificate" indexName="certificate_final_retention_removal_idx">
             <column name="source_type"/>
             <column name="final_retention_removal_date"/>
         </createIndex>
@@ -23,6 +23,8 @@
             <dropColumn
                 tableName="certificate"
                 columnName="final_retention_removal_date"/>
+
+            <dropIndex tableName="certificate" indexName="certificate_final_retention_removal_idx"/>
         </rollback>
     </changeSet>
 
@@ -33,9 +35,6 @@
                     remarks="Indicates if initial retention period data has been removed from an AED">
                 <constraints nullable="false"/>
             </column>
-        </addColumn>
-
-        <addColumn tableName="anonymous_elector_document">
             <column name="final_retention_removal_date" type="date" afterColumn="initial_retention_data_removed"
                     remarks="The date that all remaining data should be removed after the final retention period">
                 <constraints nullable="true"/>
@@ -53,14 +52,14 @@
         </createIndex>
 
         <!-- create new index for final_retention_removal_date -->
-        <createIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_date_idx">
+        <createIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_idx">
             <column name="source_type"/>
             <column name="final_retention_removal_date"/>
         </createIndex>
 
         <rollback>
             <dropIndex tableName="anonymous_elector_document" indexName="aed_initial_retention_removal_idx"/>
-            <dropIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_date_idx"/>
+            <dropIndex tableName="anonymous_elector_document" indexName="aed_final_retention_removal_idx"/>
 
             <dropColumn
                 tableName="anonymous_elector_document"
@@ -74,6 +73,20 @@
                 <column name="source_type"/>
                 <column name="initial_retention_removal_date"/>
             </createIndex>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="matt.wills@valtech.com" id="0016_EIP1-4154_alter_aed elector_roll_number width" context="ddl">
+        <modifyDataType
+            columnName="electoral_roll_number"
+            newDataType="varchar(30)"
+            tableName="anonymous_elector_document"/>
+
+        <rollback>
+            <modifyDataType
+                columnName="electoral_roll_number"
+                newDataType="varchar(7)"
+                tableName="anonymous_elector_document"/>
         </rollback>
     </changeSet>
 

--- a/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
+++ b/src/main/resources/db/changelog/ddl/0016_final_retention_data_removed_column.xml
@@ -79,13 +79,13 @@
     <changeSet author="matt.wills@valtech.com" id="0016_EIP1-4154_alter_aed elector_roll_number width" context="ddl">
         <modifyDataType
             columnName="electoral_roll_number"
-            newDataType="varchar(30)"
+            newDataType="varchar(30) NOT NULL"
             tableName="anonymous_elector_document"/>
 
         <rollback>
             <modifyDataType
                 columnName="electoral_roll_number"
-                newDataType="varchar(7)"
+                newDataType="varchar(7) NOT NULL"
                 tableName="anonymous_elector_document"/>
         </rollback>
     </changeSet>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepositoryIntegrationTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
+import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepositoryExtensions.findPendingRemovalOfFinalRetentionData
+import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepositoryExtensions.findPendingRemovalOfInitialRetentionData
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
+import java.time.LocalDate
+
+internal class AnonymousElectorDocumentRepositoryIntegrationTest : IntegrationTest() {
+
+    @Nested
+    inner class GetAnonymousElectorDocumentsForInitialRetentionDataRemoval {
+        @Test
+        fun `should find AEDs for removal of initial retention period data`() {
+            // Given
+            val expected1 = buildAnonymousElectorDocument(
+                initialRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+            val expected2 = buildAnonymousElectorDocument(
+                initialRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+
+            val other1 = buildAnonymousElectorDocument(
+                initialRetentionRemovalDate = LocalDate.now().minusDays(1),
+                initialRetentionDataRemoved = true // should be excluded
+            )
+
+            val other2 = buildAnonymousElectorDocument(
+                initialRetentionRemovalDate = LocalDate.now().plusDays(1)
+            )
+
+            anonymousElectorDocumentRepository.saveAll(listOf(other1, expected1, other2, expected2))
+
+            // When
+            val actual = anonymousElectorDocumentRepository.findPendingRemovalOfInitialRetentionData(VOTER_CARD)
+
+            // Then
+            assertThat(actual).containsExactlyInAnyOrder(expected1, expected2)
+        }
+    }
+
+    @Nested
+    inner class GetAnonymousElectorDocumentsForFinalRetentionDataRemoval {
+        @Test
+        fun `should find AEDs for removal of final retention period data`() {
+            // Given
+            val expected1 = buildAnonymousElectorDocument(
+                finalRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+            val expected2 = buildAnonymousElectorDocument(
+                finalRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+            val other = buildAnonymousElectorDocument(
+                finalRetentionRemovalDate = LocalDate.now().plusDays(1)
+            )
+
+            anonymousElectorDocumentRepository.saveAll(listOf(expected1, expected2, other))
+
+            // When
+            val actual = anonymousElectorDocumentRepository.findPendingRemovalOfFinalRetentionData(VOTER_CARD)
+
+            // Then
+            assertThat(actual).containsExactlyInAnyOrder(expected1, expected2)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
@@ -16,6 +16,7 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.DISPATCHE
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.PENDING_ASSIGNMENT_TO_BATCH
 import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
 import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findDistinctByPrintRequestStatusAndBatchId
+import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findPendingRemovalOfFinalRetentionData
 import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findPendingRemovalOfInitialRetentionData
 import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidAddressFormat
@@ -424,6 +425,31 @@ internal class CertificateRepositoryIntegrationTest : IntegrationTest() {
 
             // When
             val actual = certificateRepository.findPendingRemovalOfInitialRetentionData(VOTER_CARD)
+
+            // Then
+            assertThat(actual).containsExactlyInAnyOrder(expected1, expected2)
+        }
+    }
+
+    @Nested
+    inner class GetCertificatesForFinalRetentionDataRemoval {
+        @Test
+        fun `should find certificates for removal of final retention period data`() {
+            // Given
+            val expected1 = buildCertificate(
+                finalRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+            val expected2 = buildCertificate(
+                finalRetentionRemovalDate = LocalDate.now().minusDays(1)
+            )
+            val other = buildCertificate(
+                finalRetentionRemovalDate = LocalDate.now().plusDays(1)
+            )
+
+            certificateRepository.saveAll(listOf(expected1, expected2, other))
+
+            // When
+            val actual = certificateRepository.findPendingRemovalOfFinalRetentionData(VOTER_CARD)
 
             // Then
             assertThat(actual).containsExactlyInAnyOrder(expected1, expected2)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentBuilder.kt
@@ -43,8 +43,9 @@ fun buildAnonymousElectorDocument(
     aedStatuses: List<AnonymousElectorDocumentStatus> = listOf(buildAnonymousElectorDocumentStatus()),
     requestDateTime: Instant = aValidRequestDateTime(),
     userId: String = aValidUserId(),
-
-    initialRetentionRemovalDate: LocalDate? = null
+    initialRetentionRemovalDate: LocalDate? = null,
+    initialRetentionDataRemoved: Boolean = false,
+    finalRetentionRemovalDate: LocalDate? = null,
 ): AnonymousElectorDocument {
     return AnonymousElectorDocument(
         id = id,
@@ -58,6 +59,8 @@ fun buildAnonymousElectorDocument(
         photoLocationArn = photoLocationArn,
         contactDetails = contactDetails,
         initialRetentionRemovalDate = initialRetentionRemovalDate,
+        initialRetentionDataRemoved = initialRetentionDataRemoved,
+        finalRetentionRemovalDate = finalRetentionRemovalDate,
         aedTemplateFilename = aedTemplateFilename,
         electoralRollNumber = electoralRollNumber,
         issueDate = issueDate,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -64,7 +64,8 @@ fun buildCertificate(
     applicationReference: String = aValidApplicationReference(),
     issueDate: LocalDate = aValidIssueDate(),
     initialRetentionRemovalDate: LocalDate? = null,
-    initialRetentionDataRemoved: Boolean = false
+    initialRetentionDataRemoved: Boolean = false,
+    finalRetentionRemovalDate: LocalDate? = null,
 ): Certificate {
     val certificate = Certificate(
         id = id,
@@ -79,7 +80,8 @@ fun buildCertificate(
         gssCode = gssCode,
         status = status,
         initialRetentionRemovalDate = initialRetentionRemovalDate,
-        initialRetentionDataRemoved = initialRetentionDataRemoved
+        initialRetentionDataRemoved = initialRetentionDataRemoved,
+        finalRetentionRemovalDate = finalRetentionRemovalDate
     )
     printRequests.forEach { printRequest -> certificate.addPrintRequest(printRequest) }
     return certificate


### PR DESCRIPTION
This PR adds `finalRetentionRemovalDate` to the `Certificate` entity, so that we can set the date when any remaining certificate data should be removed.

Whilst in the area, I spotted that `AnonymousElectorDocument` was missing `initialRetentionDataRemoved`, which I had to add to `Certificate` retrospectively (presumably after @Neil-Massey initially created the AED entity), so I've included that here. It then seemed unreasonable not to add `finalRetentionRemovalDate` as well, even though both these columns are strictly part of [EIP1-3753](https://technologyprogramme.atlassian.net/browse/EIP1-3753) and [EIP1-3567](https://technologyprogramme.atlassian.net/browse/EIP1-3567) respectively.