### PR TITLE
EIP1-4156 - Calculate final retention period removal date for Elector Documents

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
@@ -7,6 +7,7 @@ import uk.gov.dluhc.printapi.config.DataRetentionConfiguration
 import java.time.DayOfWeek.SATURDAY
 import java.time.DayOfWeek.SUNDAY
 import java.time.LocalDate
+import java.time.Month
 import java.time.temporal.ChronoUnit
 
 /**
@@ -54,7 +55,7 @@ class CertificateRemovalDateResolver(
      * @return A [LocalDate] representing when the data should be removed
      */
     fun getElectorDocumentFinalRetentionPeriodRemovalDate(issueDate: LocalDate): LocalDate {
-        val firstJuly = LocalDate.of(issueDate.year, 7, 1)
+        val firstJuly = LocalDate.of(issueDate.year, Month.JULY, 1)
         val numberOfYears =
             when (issueDate.isBefore(firstJuly)) {
                 true -> 9L

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolver.kt
@@ -39,6 +39,30 @@ class CertificateRemovalDateResolver(
             issueDate.plusDays(this.toLong())
         }
 
+    /**
+     * Calculates the date that any remaining "Elector Document" data should be removed following the final retention
+     * period. The legislation stipulates that all remaining data should be removed on the tenth 1st July following the
+     * date the VAC's issue date.
+     *
+     * "Elector Document" here means either a [uk.gov.dluhc.printapi.database.entity.Certificate] or a
+     * [uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument]). but does not include
+     * [uk.gov.dluhc.printapi.database.entity.TemporaryCertificate], which has a different retention period.
+     *
+     * TODO - EIP1-3556 - add a separate calculation for Temporary Certificates.
+     *
+     * @param issueDate The date the Elector Document was issued.
+     * @return A [LocalDate] representing when the data should be removed
+     */
+    fun getElectorDocumentFinalRetentionPeriodRemovalDate(issueDate: LocalDate): LocalDate {
+        val firstJuly = LocalDate.of(issueDate.year, 7, 1)
+        val numberOfYears =
+            when (issueDate.isBefore(firstJuly)) {
+                true -> 9L
+                false -> 10L
+            }
+        return firstJuly.plusYears(numberOfYears)
+    }
+
     private fun getTotalDaysForWorkingDays(issueDate: LocalDate, requiredWorkingDays: Int, gssCode: String): Int {
         val upcomingBankHolidays = bankHolidayDataClient.getBankHolidayDates(BankHolidayDivision.fromGssCode(gssCode))
         var date = issueDate

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
@@ -1,8 +1,11 @@
 package uk.gov.dluhc.printapi.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
@@ -26,40 +29,67 @@ internal class CertificateRemovalDateResolverTest {
     @InjectMocks
     private lateinit var certificateRemovalDateResolver: CertificateRemovalDateResolver
 
-    @Test
-    fun `should get removal date for delivery info given upcoming bank holiday`() {
-        // Given
-        val gssCode = "E09000007"
-        val issueDate = LocalDate.of(2023, 1, 1)
-        val upcomingBankHoliday = LocalDate.of(2023, 2, 1)
-        val expectedRemovalDate = LocalDate.of(2023, 2, 9)
-        given(dataRetentionConfig.certificateInitialRetentionPeriod).willReturn(Period.ofDays(28))
-        given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(listOf(upcomingBankHoliday))
+    @Nested
+    inner class CertificateInitialRetentionPeriod {
+        @Test
+        fun `should get initial retention period removal date for delivery info given upcoming bank holiday`() {
+            // Given
+            val gssCode = "E09000007"
+            val issueDate = LocalDate.of(2023, 1, 1)
+            val upcomingBankHoliday = LocalDate.of(2023, 2, 1)
+            val expectedRemovalDate = LocalDate.of(2023, 2, 9)
+            given(dataRetentionConfig.certificateInitialRetentionPeriod).willReturn(Period.ofDays(28))
+            given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(listOf(upcomingBankHoliday))
 
-        // When
-        val actual = certificateRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
+            // When
+            val actual = certificateRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
 
-        // Then
-        assertThat(actual).isEqualTo(expectedRemovalDate)
-        verify(dataRetentionConfig).certificateInitialRetentionPeriod
-        verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+            // Then
+            assertThat(actual).isEqualTo(expectedRemovalDate)
+            verify(dataRetentionConfig).certificateInitialRetentionPeriod
+            verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+        }
+
+        @Test
+        fun `should get initial retention period removal date for delivery info given no upcoming bank holidays`() {
+            // Given
+            val gssCode = "E09000007"
+            val issueDate = LocalDate.of(2023, 1, 1)
+            val expectedRemovalDate = LocalDate.of(2023, 2, 8)
+            given(dataRetentionConfig.certificateInitialRetentionPeriod).willReturn(Period.ofDays(28))
+            given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(emptyList())
+
+            // When
+            val actual = certificateRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
+
+            // Then
+            assertThat(actual).isEqualTo(expectedRemovalDate)
+            verify(dataRetentionConfig).certificateInitialRetentionPeriod
+            verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+        }
     }
 
-    @Test
-    fun `should get removal date for delivery info given no upcoming bank holidays`() {
-        // Given
-        val gssCode = "E09000007"
-        val issueDate = LocalDate.of(2023, 1, 1)
-        val expectedRemovalDate = LocalDate.of(2023, 2, 8)
-        given(dataRetentionConfig.certificateInitialRetentionPeriod).willReturn(Period.ofDays(28))
-        given(bankHolidayDataClient.getBankHolidayDates(any(), any(), any())).willReturn(emptyList())
+    @Nested
+    inner class ElectorDocumentFinalRetentionPeriod {
+        @ParameterizedTest
+        @CsvSource(
+            "2023-01-01, 2032-07-01",
+            "2023-06-30, 2032-07-01",
+            "2023-07-01, 2033-07-01",
+            "2023-07-02, 2033-07-01",
+            "2024-01-01, 2033-07-01",
+            "2024-12-31, 2034-07-01"
+        )
+        fun `should get final retention period removal date for elector document`(issueDateStr: String, targetDateStr: String) {
+            // Given
+            val issueDate = LocalDate.parse(issueDateStr)
+            val expectedTargetDate = LocalDate.parse(targetDateStr)
 
-        // When
-        val actual = certificateRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(issueDate, gssCode)
+            // When
+            val actualTargetDate = certificateRemovalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(issueDate)
 
-        // Then
-        assertThat(actual).isEqualTo(expectedRemovalDate)
-        verify(dataRetentionConfig).certificateInitialRetentionPeriod
-        verify(bankHolidayDataClient).getBankHolidayDates(ENGLAND_AND_WALES)
+            // Then
+            assertThat(actualTargetDate).isEqualTo(expectedTargetDate)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/CertificateRemovalDateResolverTest.kt
@@ -80,10 +80,8 @@ internal class CertificateRemovalDateResolverTest {
             "2024-01-01, 2033-07-01",
             "2024-12-31, 2034-07-01"
         )
-        fun `should get final retention period removal date for elector document`(issueDateStr: String, targetDateStr: String) {
+        fun `should get final retention period removal date for elector document`(issueDate: LocalDate, expectedTargetDate: LocalDate) {
             // Given
-            val issueDate = LocalDate.parse(issueDateStr)
-            val expectedTargetDate = LocalDate.parse(targetDateStr)
 
             // When
             val actualTargetDate = certificateRemovalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(issueDate)


### PR DESCRIPTION
This PR covers the somewhat quirky requirement that any remaining Certificate/AED data should be removed on the "tenth 1st July" from the issue date.