### PR TITLE
EIP1-4082 Remove SFTP session caching

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/SftpConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/SftpConfiguration.kt
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.expression.common.LiteralExpression
-import org.springframework.integration.file.remote.session.CachingSessionFactory
 import org.springframework.integration.file.remote.session.SessionFactory
 import org.springframework.integration.sftp.session.DefaultSftpSessionFactory
 import org.springframework.integration.sftp.session.SftpRemoteFileTemplate
@@ -40,16 +39,17 @@ class SftpConfiguration {
     }
 
     @Bean
-    fun sftpSessionFactory(properties: SftpProperties): SessionFactory<ChannelSftp.LsEntry> {
-        val factory = DefaultSftpSessionFactory(true)
-        factory.setHost(properties.host)
-        factory.setPort(properties.port)
-        factory.setUser(properties.user)
-        factory.setPassword(properties.password)
-        factory.setPrivateKey(ByteArrayResource(properties.privateKey.encodeToByteArray()))
-        factory.setAllowUnknownKeys(true)
-        return CachingSessionFactory(factory)
-    }
+    fun sftpSessionFactory(properties: SftpProperties): SessionFactory<ChannelSftp.LsEntry> =
+        with(properties) {
+            DefaultSftpSessionFactory(true).apply {
+                setHost(host)
+                setPort(port)
+                setUser(user)
+                setPassword(password)
+                setPrivateKey(ByteArrayResource(privateKey.encodeToByteArray()))
+                setAllowUnknownKeys(true)
+            }
+        }
 }
 
 @ConfigurationProperties(prefix = "sftp")


### PR DESCRIPTION
Identified issue with the Integrity SFTP server where connections were going stale and requests to their server were failing with IOExceptions.  The timeout of sessions on the Integrity server is 1 hour, with the A1 Printer having a 2 minute timeout.  As the frequency of connections is low, with the Zip writing scheduled to run at a maximum of once every 5 minutes and the Response file processing every 30 minutes it is thought that sessions in the SFTP cache are going stale between requests on the Integrity server.  As the interactions between the Print API and SFTP servers is infrequent the caching is being removed so sessions are closed after use.