### PR TITLE
EIP1-4155 - Set finalRetentionRemovalDate

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/CertificateDataRetentionService.kt
@@ -36,8 +36,8 @@ class CertificateDataRetentionService(
                 sourceType = sourceType,
                 sourceReference = sourceReference
             )?.also {
-                it.initialRetentionRemovalDate = certificateRemovalDateResolver
-                    .getCertificateInitialRetentionPeriodRemovalDate(it.issueDate, gssCode)
+                it.initialRetentionRemovalDate = certificateRemovalDateResolver.getCertificateInitialRetentionPeriodRemovalDate(it.issueDate, gssCode)
+                it.finalRetentionRemovalDate = certificateRemovalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(it.issueDate)
                 certificateRepository.save(it)
             }
                 ?: logger.error { "Certificate with sourceType = $sourceType and sourceReference = $sourceReference not found" }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.TimeUnit
 internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
 
     @Test
-    fun `should process message and set delivery info removal date`() {
+    fun `should process message and set initial and final removal dates`() {
         // Given
         val certificate = buildCertificate(
             issueDate = LocalDate.of(2023, 4, 1), // to include 3 bank holidays in calculation
@@ -31,6 +31,7 @@ internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
         )
         // currently 29 working days following issue date - refer to application.yml
         val expectedInitialRemovalDate = LocalDate.of(2023, 5, 17)
+        val expectedFinalRemovalDate = LocalDate.of(2032, 7, 1)
 
         // When
         sqsMessagingTemplate.convertAndSend(applicationRemovedQueueName, payload)
@@ -41,6 +42,7 @@ internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
             assertThat(response).hasSize(1)
             val saved = response[0]
             assertThat(saved).hasInitialRetentionRemovalDate(expectedInitialRemovalDate)
+            assertThat(saved).hasFinalRetentionRemovalDate(expectedFinalRemovalDate)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListenerTest.kt
@@ -10,6 +10,9 @@ import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildDelivery
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildApplicationRemovedMessage
 import java.time.LocalDate
+import java.time.Month.APRIL
+import java.time.Month.JULY
+import java.time.Month.MAY
 import java.util.concurrent.TimeUnit
 
 internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
@@ -18,7 +21,7 @@ internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
     fun `should process message and set initial and final removal dates`() {
         // Given
         val certificate = buildCertificate(
-            issueDate = LocalDate.of(2023, 4, 1), // to include 3 bank holidays in calculation
+            issueDate = LocalDate.of(2023, APRIL, 1), // to include 3 bank holidays in calculation
             printRequests = listOf(
                 buildPrintRequest(delivery = buildDelivery()),
                 buildPrintRequest(delivery = buildDelivery())
@@ -30,8 +33,8 @@ internal class ApplicationRemovedMessageListenerTest : IntegrationTest() {
             gssCode = certificate.gssCode!!
         )
         // currently 29 working days following issue date - refer to application.yml
-        val expectedInitialRemovalDate = LocalDate.of(2023, 5, 17)
-        val expectedFinalRemovalDate = LocalDate.of(2032, 7, 1)
+        val expectedInitialRemovalDate = LocalDate.of(2023, MAY, 17)
+        val expectedFinalRemovalDate = LocalDate.of(2032, JULY, 1)
 
         // When
         sqsMessagingTemplate.convertAndSend(applicationRemovedQueueName, payload)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
@@ -281,6 +281,29 @@ class CertificateAssert
     }
 
     /**
+     * Verifies that the actual Certificate's finalRetentionRemovalDate is equal to the given one.
+     * @param finalRetentionRemovalDate the given finalRetentionRemovalDate to compare the actual Certificate's one.
+     * @return this assertion object.
+     * @throws AssertionError - if the actual Certificate's finalRetentionRemovalDate is not equal to the given one.
+     */
+    fun hasFinalRetentionRemovalDate(finalRetentionRemovalDate: LocalDate?): CertificateAssert {
+        // check that actual Certificate we want to make assertions on is not null.
+        isNotNull
+
+        // overrides the default error message with a more explicit one
+        val assertjErrorMessage = "\nExpecting finalRetentionRemovalDate of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>"
+
+        // null safe check
+        val actualFinalRetentionRemovalDate = actual!!.finalRetentionRemovalDate
+        if (!Objects.deepEquals(actualFinalRetentionRemovalDate, finalRetentionRemovalDate)) {
+            failWithMessage(assertjErrorMessage, actual, finalRetentionRemovalDate, actualFinalRetentionRemovalDate)
+        }
+
+        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
      * Verifies that the data which needs to be removed after the initial retention period is null.
      * @return this assertion object.
      * @throws AssertionError if the data is not null.


### PR DESCRIPTION
This PR sets the `finalRetentionRemovalDate` (in addition to the `initialRetentionRemovalDate`) when a VCA application is removed from VCA.