### PR TITLE
EIP1-3549: EIP1-4173: add SourceType.anonymous-elector-document

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SourceType.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/SourceType.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.printapi.database.entity
 
 enum class SourceType {
-    VOTER_CARD
+    VOTER_CARD,
+    ANONYMOUS_ELECTOR_DOCUMENT,
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/SourceType.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/SourceType.kt
@@ -2,4 +2,5 @@ package uk.gov.dluhc.printapi.dto
 
 enum class SourceType {
     VOTER_CARD,
+    ANONYMOUS_ELECTOR_DOCUMENT,
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapper.kt
@@ -14,6 +14,7 @@ interface SourceTypeMapper {
     fun mapSqsToEntity(sourceType: SourceTypeSqsModel): SourceTypeEntity
 
     @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
+    @ValueMapping(source = "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT", target = "ANONYMOUS_ELECTOR_DOCUMENT")
     fun mapApiToDto(sourceType: SourceTypeApi): SourceTypeDto
 
     fun mapDtoToEntity(sourceType: SourceTypeDto): SourceTypeEntity

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapper.kt
@@ -10,6 +10,7 @@ import uk.gov.dluhc.printapi.models.SourceType as SourceTypeApi
 @Mapper
 interface SourceTypeMapper {
     @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")
+    @ValueMapping(source = "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT", target = "ANONYMOUS_ELECTOR_DOCUMENT")
     fun mapSqsToEntity(sourceType: SourceTypeSqsModel): SourceTypeEntity
 
     @ValueMapping(source = "VOTER_MINUS_CARD", target = "VOTER_CARD")

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -23,4 +23,5 @@
     <include relativeToChangelogFile="true" file="ddl/0014_create_anonymous_elector_document_tables.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0015_refactor_anonymous_elector_document_tables.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0016_final_retention_data_removed_column.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0017_anonymous_elector_document_source_type.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0017_anonymous_elector_document_source_type.xml
+++ b/src/main/resources/db/changelog/ddl/0017_anonymous_elector_document_source_type.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="rob.ororke@valtech.com" id="0017_EIP-4173_anonymous_elector_document modify source_type column" context="ddl">
+        <modifyDataType
+            columnName="source_type"
+            newDataType="varchar(30) NOT NULL"
+            tableName="anonymous_elector_document"/>
+
+        <rollback>
+            <modifyDataType
+                columnName="source_type"
+                newDataType="varchar(20) NOT NULL"
+                tableName="anonymous_elector_document"/>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.8.0'
+  version: '1.8.1'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -771,6 +771,7 @@ components:
       type: string
       enum:
         - voter-card
+        - anonymous-elector-document
 
     CertificateLanguage:
       title: CertificateLanguage

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.9.3'
+  version: '1.9.4'
   description: |-
     Print API SQS Message Types
     
@@ -171,6 +171,7 @@ components:
       type: string
       enum:
         - voter-card
+        - anonymous-elector-document
 
     CertificateLanguage:
       title: CertificateLanguage

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapperTest.kt
@@ -12,7 +12,12 @@ class SourceTypeMapperTest {
     private val mapper = SourceTypeMapperImpl()
 
     @ParameterizedTest
-    @CsvSource(value = ["VOTER_MINUS_CARD, VOTER_CARD"])
+    @CsvSource(
+        value = [
+            "VOTER_MINUS_CARD, VOTER_CARD",
+            "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT, ANONYMOUS_ELECTOR_DOCUMENT"
+        ]
+    )
     fun `should map sqs model source type to entity`(sourceTypeModel: SourceTypeSqsModel, sourceTypeEntity: SourceTypeEntity) {
         // Given
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/SourceTypeMapperTest.kt
@@ -15,7 +15,7 @@ class SourceTypeMapperTest {
     @CsvSource(
         value = [
             "VOTER_MINUS_CARD, VOTER_CARD",
-            "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT, ANONYMOUS_ELECTOR_DOCUMENT"
+            "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT, ANONYMOUS_ELECTOR_DOCUMENT",
         ]
     )
     fun `should map sqs model source type to entity`(sourceTypeModel: SourceTypeSqsModel, sourceTypeEntity: SourceTypeEntity) {
@@ -28,7 +28,12 @@ class SourceTypeMapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = ["VOTER_MINUS_CARD, VOTER_CARD"])
+    @CsvSource(
+        value = [
+            "VOTER_MINUS_CARD, VOTER_CARD",
+            "ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT, ANONYMOUS_ELECTOR_DOCUMENT",
+        ]
+    )
     fun `should map api source type to dto`(sourceTypeApi: SourceTypeApi, sourceTypeDto: SourceTypeDto) {
         // Given
         // When
@@ -39,7 +44,12 @@ class SourceTypeMapperTest {
     }
 
     @ParameterizedTest
-    @CsvSource(value = ["VOTER_CARD, VOTER_CARD"])
+    @CsvSource(
+        value = [
+            "VOTER_CARD, VOTER_CARD",
+            "ANONYMOUS_ELECTOR_DOCUMENT, ANONYMOUS_ELECTOR_DOCUMENT"
+        ]
+    )
     fun `should map dto source type to entity`(sourceTypeDto: SourceTypeDto, sourceTypeEntity: SourceTypeEntity) {
         // Given
         // When

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -11,7 +11,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration
-import uk.gov.dluhc.printapi.database.entity.SourceType.VOTER_CARD
+import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
 import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.testsupport.assertj.assertions.ErrorResponseAssert.Companion.assertThat
@@ -230,7 +230,7 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
         // Then
         val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(
             listOf(request.gssCode),
-            VOTER_CARD,
+            ANONYMOUS_ELECTOR_DOCUMENT,
             request.sourceReference
         )
         assertThat(electorDocuments).hasSize(1)
@@ -244,6 +244,7 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
         PdfReader(pdfContent).use { reader ->
             val text = PdfTextExtractor(reader).getTextFromPage(1)
             assertThat(text).contains(electorDocument.certificateNumber)
+            assertThat(text).doesNotContainIgnoringCase(request.surname)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
@@ -19,7 +19,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
 
 fun buildGenerateAnonymousElectorDocumentRequest(
     gssCode: String = aGssCode(),
-    sourceType: SourceType = SourceType.VOTER_MINUS_CARD,
+    sourceType: SourceType = SourceType.ANONYMOUS_MINUS_ELECTOR_MINUS_DOCUMENT,
     sourceReference: String = aValidSourceReference(),
     applicationReference: String = aValidApplicationReference(),
     electoralRollNumber: String = aValidElectoralRollNumber(),


### PR DESCRIPTION
This PR adds SourceType.anonymous-elector-document to the print-api-sqs-messaging.yaml spec