### PR TITLE
EIP1-2479: EIP1:4481: Move photo_location_arn column to parent Certificate entity

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocument.kt
@@ -62,7 +62,7 @@ class AnonymousElectorDocument(
     var supportingInformationFormat: SupportingInformationFormat?,
 
     @field:NotNull
-    @field:Size(max = 255)
+    @field:Size(max = 1024)
     var photoLocationArn: String,
 
     @OneToOne(cascade = [CascadeType.ALL])

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/Certificate.kt
@@ -106,6 +106,10 @@ class Certificate(
     @field:Size(max = 80)
     var gssCode: String? = null,
 
+    @field:NotNull
+    @field:Size(max = 1024)
+    var photoLocationArn: String? = null,
+
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
     @JoinColumn(name = "certificate_id", nullable = false)
     var printRequests: MutableList<PrintRequest> = mutableListOf(),

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/PrintRequest.kt
@@ -66,10 +66,6 @@ class PrintRequest(
     @Enumerated(EnumType.STRING)
     var supportingInformationFormat: SupportingInformationFormat? = null,
 
-    @field:NotNull
-    @field:Size(max = 255)
-    var photoLocationArn: String? = null,
-
     @OneToOne(cascade = [CascadeType.ALL])
     var delivery: Delivery? = null,
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/TemporaryCertificate.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/TemporaryCertificate.kt
@@ -84,7 +84,7 @@ class TemporaryCertificate(
     var certificateLanguage: CertificateLanguage? = null,
 
     @field:NotNull
-    @field:Size(max = 255)
+    @field:Size(max = 1024)
     var photoLocationArn: String? = null,
 
     @field:NotNull

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapper.kt
@@ -22,6 +22,7 @@ abstract class CertificateMapper {
     @Mapping(target = "vacNumber", expression = "java( idFactory.vacNumber() )")
     @Mapping(source = "ero.englishContactDetails.name", target = "issuingAuthority")
     @Mapping(source = "ero.welshContactDetails.name", target = "issuingAuthorityCy")
+    @Mapping(source = "message.photoLocation", target = "photoLocationArn")
     abstract fun toCertificate(
         message: SendApplicationToPrintMessage,
         ero: EroDto

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapper.kt
@@ -35,7 +35,6 @@ abstract class PrintRequestMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "vacVersion", constant = "A")
     @Mapping(target = "requestId", expression = "java( idFactory.requestId() )")
-    @Mapping(source = "message.photoLocation", target = "photoLocationArn")
     @Mapping(target = "statusHistory", expression = "java( initialStatus() )")
     @Mapping(target = "eroEnglish", expression = "java( toEnglishContactDetails(ero) )")
     @Mapping(target = "eroWelsh", expression = "java( toWelshContactDetails(message, ero) )")

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/ApplicationRemovedMessageListener.kt
@@ -21,7 +21,11 @@ class ApplicationRemovedMessageListener(
     @SqsListener("\${sqs.application-removed-queue-name}")
     override fun handleMessage(@Valid @Payload payload: ApplicationRemovedMessage) {
         with(payload) {
-            logger.info { "ApplicationRemovedMessage for application with source type [$sourceType] and source reference [$sourceReference]" }
+            logger.info {
+                "ApplicationRemovedMessage for application with source type [$sourceType] " +
+                    "and source reference [$sourceReference] " +
+                    "and gssCode [$gssCode]"
+            }
             certificateDataRetentionService.handleSourceApplicationRemoved(payload)
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactory.kt
@@ -45,9 +45,8 @@ class PrintFileDetailsFactory(
         requests: MutableList<PrintRequest>,
         photos: MutableList<PhotoLocation>
     ) {
-        val photoArn = pendingPrintRequest.photoLocationArn!!
         val photoLocation =
-            photoLocationFactory.create(pendingPrintRequest.batchId!!, pendingPrintRequest.requestId!!, photoArn)
+            photoLocationFactory.create(pendingPrintRequest.batchId!!, pendingPrintRequest.requestId!!, certificate.photoLocationArn!!)
         val printRequest = certificateToPrintRequestMapper.map(certificate, pendingPrintRequest, photoLocation.zipPath)
         requests.add(printRequest)
         photos.add(photoLocation)

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -24,4 +24,5 @@
     <include relativeToChangelogFile="true" file="ddl/0015_refactor_anonymous_elector_document_tables.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0016_final_retention_data_removed_column.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0017_anonymous_elector_document_source_type.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
@@ -24,6 +24,7 @@
             UPDATE certificate cert
             INNER JOIN print_request pr on cert.id = pr.certificate_id
             SET cert.photo_location_arn = pr.photo_location_arn
+            WHERE cert.photo_location_arn IS NULL
         </sql>
 
         <rollback/>

--- a/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
@@ -8,7 +8,7 @@
     <changeSet author="vishal.gupta@valtech.com" id="0018a_EIP1-4481_add_photo_location_arn_to_certificate_table - add photo_location_arn column" context="ddl">
         <addColumn tableName="certificate">
             <column name="photo_location_arn" type="varchar(1024)" afterColumn="status">
-                <constraints nullable="false"/>
+                <constraints nullable="true"/>
             </column>
         </addColumn>
 
@@ -20,14 +20,18 @@
 
     <changeSet author="vishal.gupta@valtech.com" id="0018b_EIP1-4481_certificate_table_data_migration - populate photo_location_arn column of certificate">
         <sql>
-            <comment>Populating [photo_location_arn] of a certificate entity from any of the matching print_requests [photo_location_arn]</comment>
+            <comment>Populating [photo_location_arn] column of certificate entity from any of the matching print_requests [photo_location_arn] column</comment>
             UPDATE certificate cert
-            INNER JOIN print_request pr on cert.id = pr.certificate_id
+            INNER JOIN print_request pr
+            ON cert.id = pr.certificate_id
             SET cert.photo_location_arn = pr.photo_location_arn
             WHERE cert.photo_location_arn IS NULL
         </sql>
+        <modifyDataType tableName="certificate" columnName="photo_location_arn" newDataType="varchar(1024) NOT NULL"/>
 
-        <rollback/>
+        <rollback>
+            <modifyDataType tableName="certificate" columnName="photo_location_arn" newDataType="varchar(1024)"/>
+        </rollback>
     </changeSet>
 
     <changeSet author="vishal.gupta@valtech.com" id="0018c_EIP1-4481_remove_photo_location_arn_column_in_print_request_table - Drop photo_location_arn column" context="ddl">
@@ -36,9 +40,18 @@
         <rollback>
             <addColumn tableName="print_request">
                 <column name="photo_location_arn" type="varchar(255)" afterColumn="supporting_information_format">
-                    <constraints nullable="false"/>
+                    <constraints nullable="true"/>
                 </column>
             </addColumn>
+
+            <sql>
+                <comment>Populating [photo_location_arn] of a every print_requests from certificate entity [photo_location_arn] column</comment>
+                UPDATE print_request pr
+                INNER JOIN certificate cert
+                ON cert.id = pr.certificate_id
+                SET pr.photo_location_arn = cert.photo_location_arn
+            </sql>
+            <modifyDataType tableName="print_request" columnName="photo_location_arn" newDataType="varchar(255) NOT NULL"/>
         </rollback>
     </changeSet>
 

--- a/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
@@ -19,7 +19,7 @@
 
     <changeSet author="vishal.gupta@valtech.com" id="0018b1_EIP1-4481_certificate_table_data_migration - populate photo_location_arn column of certificate">
         <sql>
-            <comment>Populating [photo_location_arn] column of certificate entity from any of the matching print_requests [photo_location_arn] column</comment>
+            <comment>Populating [photo_location_arn] column of certificate entity from most recent matching print_request [photo_location_arn] column</comment>
             UPDATE certificate cert
             SET cert.photo_location_arn = (SELECT pr.photo_location_arn FROM print_request pr WHERE pr.certificate_id = cert.id ORDER BY pr.date_created DESC LIMIT 1)
         </sql>

--- a/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018a_EIP1-4481_add_photo_location_arn_to_certificate_table - add photo_location_arn column" context="ddl">
+        <addColumn tableName="certificate">
+            <column name="photo_location_arn" type="varchar(1024)" afterColumn="status">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+
+        <rollback>
+            <dropColumn tableName="certificate" columnName="photo_location_arn"/>
+        </rollback>
+    </changeSet>
+
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018b_EIP1-4481_certificate_table_data_migration - populate photo_location_arn column of certificate">
+        <sql>
+            <comment>Populating [photo_location_arn] of a certificate entity from any of the matching print_requests [photo_location_arn]</comment>
+            UPDATE certificate cert
+            INNER JOIN print_request pr on cert.id = pr.certificate_id
+            SET cert.photo_location_arn = pr.photo_location_arn
+        </sql>
+
+        <rollback/>
+    </changeSet>
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018c_EIP1-4481_remove_photo_location_arn_column_in_print_request_table - Drop photo_location_arn column" context="ddl">
+        <dropColumn tableName="print_request" columnName="photo_location_arn"/>
+
+        <rollback>
+            <addColumn tableName="print_request">
+                <column name="photo_location_arn" type="varchar(255)" afterColumn="supporting_information_format">
+                    <constraints nullable="false"/>
+                </column>
+            </addColumn>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018d_EIP1-4481_alter_photo_location_arn_column_in_temporary_certificate_table - Increase photo_location_arn column size" context="ddl">
+        <modifyDataType tableName="temporary_certificate" columnName="photo_location_arn" newDataType="varchar(1024) NOT NULL"/>
+
+        <rollback>
+            <modifyDataType tableName="temporary_certificate" columnName="photo_location_arn" newDataType="varchar(255) NOT NULL"/>
+        </rollback>
+    </changeSet>
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018e_EIP1-4481_alter_photo_location_arn_column_in_anonymous_elector_document_table - Increase photo_location_arn column size" context="ddl">
+        <modifyDataType tableName="anonymous_elector_document" columnName="photo_location_arn" newDataType="varchar(1024) NOT NULL"/>
+
+        <rollback>
+            <modifyDataType tableName="anonymous_elector_document" columnName="photo_location_arn" newDataType="varchar(255) NOT NULL"/>
+        </rollback>
+    </changeSet>
+
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
+++ b/src/main/resources/db/changelog/ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml
@@ -17,16 +17,15 @@
         </rollback>
     </changeSet>
 
-
-    <changeSet author="vishal.gupta@valtech.com" id="0018b_EIP1-4481_certificate_table_data_migration - populate photo_location_arn column of certificate">
+    <changeSet author="vishal.gupta@valtech.com" id="0018b1_EIP1-4481_certificate_table_data_migration - populate photo_location_arn column of certificate">
         <sql>
             <comment>Populating [photo_location_arn] column of certificate entity from any of the matching print_requests [photo_location_arn] column</comment>
             UPDATE certificate cert
-            INNER JOIN print_request pr
-            ON cert.id = pr.certificate_id
-            SET cert.photo_location_arn = pr.photo_location_arn
-            WHERE cert.photo_location_arn IS NULL
+            SET cert.photo_location_arn = (SELECT pr.photo_location_arn FROM print_request pr WHERE pr.certificate_id = cert.id ORDER BY pr.date_created DESC LIMIT 1)
         </sql>
+    </changeSet>
+
+    <changeSet author="vishal.gupta@valtech.com" id="0018b2_EIP1-4481_certificate_table_data_migration - make photo_location_arn column non-nullable">
         <modifyDataType tableName="certificate" columnName="photo_location_arn" newDataType="varchar(1024) NOT NULL"/>
 
         <rollback>
@@ -71,5 +70,20 @@
         </rollback>
     </changeSet>
 
+    <changeSet author="vishal.gupta@valtech.com" id="0018f_EIP1-4481_alter_certificate_final_retention_removal_idx - Adds id to existing index" context="ddl">
+        <dropIndex tableName="certificate" indexName="certificate_final_retention_removal_idx"/>
+        <createIndex tableName="certificate" indexName="certificate_final_retention_removal_idx">
+            <column name="source_type"/>
+            <column name="final_retention_removal_date"/>
+            <column name="id"/>
+        </createIndex>
+
+        <rollback>
+            <createIndex tableName="certificate" indexName="certificate_final_retention_removal_idx">
+                <column name="source_type"/>
+                <column name="final_retention_removal_date"/>
+            </createIndex>
+        </rollback>
+    </changeSet>
 
 </databaseChangeLog>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/CertificateRepositoryIntegrationTest.kt
@@ -79,7 +79,8 @@ internal class CertificateRepositoryIntegrationTest : IntegrationTest() {
                 issueDate = aValidIssueDate(),
                 suggestedExpiryDate = aValidSuggestedExpiryDate(),
                 gssCode = aGssCode(),
-                status = null
+                status = null,
+                photoLocationArn = aPhotoArn(),
             )
             val deliveryAddress = Address(
                 street = aValidAddressStreet(),
@@ -110,7 +111,6 @@ internal class CertificateRepositoryIntegrationTest : IntegrationTest() {
                 surname = aValidSurname(),
                 certificateLanguage = aValidCertificateLanguage(),
                 supportingInformationFormat = aValidSupportingInformationFormat(),
-                photoLocationArn = aPhotoArn(),
                 delivery = delivery,
                 eroEnglish = eroEnglish,
                 eroWelsh = null,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/CorrelationIdMdcIntegrationTest.kt
@@ -291,12 +291,9 @@ internal class CorrelationIdMdcIntegrationTest : IntegrationTest() {
     private fun saveCertificate(certificateId: UUID): Certificate {
         val certificate = buildCertificate(
             id = certificateId,
+            photoLocationArn = s3Resource(),
             status = Status.PENDING_ASSIGNMENT_TO_BATCH,
-            printRequests = listOf(
-                buildPrintRequest(
-                    photoLocationArn = s3Resource()
-                )
-            )
+            printRequests = listOf(buildPrintRequest())
         )
         return certificateRepository.save(certificate)
     }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateMapperTest.kt
@@ -77,7 +77,6 @@ class CertificateMapperTest {
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = CertificateLanguageEntity.EN,
-                photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
                         addressee = addressee,
@@ -125,6 +124,7 @@ class CertificateMapperTest {
                 issueDate = LocalDate.now(),
                 printRequests = mutableListOf(printRequest),
                 status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                photoLocationArn = photoLocation,
             )
         }
 
@@ -163,7 +163,6 @@ class CertificateMapperTest {
                 middleNames = middleNames,
                 surname = surname,
                 certificateLanguage = CertificateLanguageEntity.EN,
-                photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
                         addressee = addressee,
@@ -211,6 +210,7 @@ class CertificateMapperTest {
                 issueDate = LocalDate.now(),
                 printRequests = mutableListOf(printRequest),
                 status = Status.PENDING_ASSIGNMENT_TO_BATCH,
+                photoLocationArn = photoLocation,
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateToPrintRequestMapperTest.kt
@@ -100,7 +100,6 @@ class CertificateToPrintRequestMapperTest {
             surname = surname,
             certificateLanguage = certificateLanguage,
             supportingInformationFormat = supportingInformationFormat,
-            photoLocationArn = photoLocation,
             delivery = delivery,
             eroEnglish = eroEnglish,
             eroWelsh = null,
@@ -120,6 +119,7 @@ class CertificateToPrintRequestMapperTest {
             suggestedExpiryDate = suggestedExpiryDate,
             status = Status.PENDING_ASSIGNMENT_TO_BATCH,
             gssCode = gssCode,
+            photoLocationArn = photoLocation,
             printRequests = mutableListOf(printRequest)
         )
 
@@ -201,7 +201,6 @@ class CertificateToPrintRequestMapperTest {
             surname = surname,
             certificateLanguage = certificateLanguage,
             supportingInformationFormat = supportingInformationFormat,
-            photoLocationArn = photoLocation,
             delivery = delivery,
             eroEnglish = eroEnglish,
             eroWelsh = eroWelsh,
@@ -221,6 +220,7 @@ class CertificateToPrintRequestMapperTest {
             suggestedExpiryDate = suggestedExpiryDate,
             status = Status.PENDING_ASSIGNMENT_TO_BATCH,
             gssCode = gssCode,
+            photoLocationArn = photoLocation,
             printRequests = mutableListOf(printRequest)
         )
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/PrintRequestMapperTest.kt
@@ -113,7 +113,6 @@ class PrintRequestMapperTest {
                 surname = surname,
                 certificateLanguage = certificateLanguageEntity,
                 supportingInformationFormat = supportingInformationFormatEntityEnum,
-                photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
                         addressee = addressee,
@@ -203,7 +202,6 @@ class PrintRequestMapperTest {
                 surname = surname,
                 certificateLanguage = CertificateLanguageEntity.EN,
                 supportingInformationFormat = supportingInformationFormatEntityEnum,
-                photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
                         addressee = addressee,
@@ -289,7 +287,6 @@ class PrintRequestMapperTest {
                 surname = surname,
                 certificateLanguage = CertificateLanguageEntity.CY,
                 supportingInformationFormat = supportingInformationFormatEntityEnum,
-                photoLocationArn = photoLocation,
                 delivery = with(delivery) {
                     Delivery(
                         addressee = addressee,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/ProcessPrintRequestBatchMessageListenerIntegrationTest.kt
@@ -53,11 +53,11 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
         // save certificates in MySQL
         var certificate = buildCertificate(
             status = ASSIGNED_TO_BATCH,
+            photoLocationArn = "arn:aws:s3:::$s3Bucket/$s3Path",
             printRequests = mutableListOf(
                 buildPrintRequest(
                     batchId = batchId,
                     requestId = requestId,
-                    photoLocationArn = "arn:aws:s3:::$s3Bucket/$s3Path",
                     printRequestStatuses = listOf(
                         buildPrintRequestStatus(
                             status = ASSIGNED_TO_BATCH,
@@ -118,11 +118,11 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
         // save certificates in MySQL
         var certificate = buildCertificate(
             status = ASSIGNED_TO_BATCH,
+            photoLocationArn = "arn:aws:s3:::$s3Bucket/$s3Path",
             printRequests = mutableListOf(
                 buildPrintRequest(
                     batchId = batchId,
                     requestId = firstRequestId,
-                    photoLocationArn = "arn:aws:s3:::$s3Bucket/$s3Path",
                     printRequestStatuses = listOf(
                         buildPrintRequestStatus(
                             status = ASSIGNED_TO_BATCH,
@@ -133,7 +133,6 @@ internal class ProcessPrintRequestBatchMessageListenerIntegrationTest : Integrat
                 buildPrintRequest(
                     batchId = batchId,
                     requestId = secondRequestId,
-                    photoLocationArn = "arn:aws:s3:::$s3Bucket/$s3Path",
                     printRequestStatuses = listOf(
                         buildPrintRequestStatus(
                             status = ASSIGNED_TO_BATCH,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/SendApplicationToPrintMessageListenerIntegrationTest.kt
@@ -71,7 +71,7 @@ internal class SendApplicationToPrintMessageListenerIntegrationTest : Integratio
         wireMockService.stubEroManagementGetEroByGssCode(ero, gssCode)
 
         val expected = with(payload) {
-            val certificate = buildCertificate(
+            val certificate = Certificate(
                 id = UUID.randomUUID(),
                 sourceReference = sourceReference,
                 applicationReference = applicationReference,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/PrintFileDetailsFactoryTest.kt
@@ -47,9 +47,9 @@ internal class PrintFileDetailsFactoryTest {
             batchId = batchId,
             printRequestStatuses = listOf(buildPrintRequestStatus(status = Status.ASSIGNED_TO_BATCH)),
             requestId = requestId,
-            photoLocationArn = photoArn
         )
         val certificate = buildCertificate(
+            photoLocationArn = photoArn,
             printRequests = mutableListOf(currentPrintRequest)
         )
         val certificates = listOf(certificate)
@@ -84,15 +84,14 @@ internal class PrintFileDetailsFactoryTest {
             batchId = batchId,
             printRequestStatuses = listOf(buildPrintRequestStatus(status = Status.ASSIGNED_TO_BATCH)),
             requestId = firstRequestId,
-            photoLocationArn = photoArn
         )
         val secondPrintRequest = buildPrintRequest(
             batchId = batchId,
             printRequestStatuses = listOf(buildPrintRequestStatus(status = Status.ASSIGNED_TO_BATCH)),
             requestId = secondRequestId,
-            photoLocationArn = photoArn
         )
         val certificate = buildCertificate(
+            photoLocationArn = photoArn,
             printRequests = mutableListOf(firstPrintRequest, secondPrintRequest)
         )
         val certificates = listOf(certificate)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/CertificateAssert.kt
@@ -37,7 +37,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's applicationReceivedDateTime is not equal to the given one.
      */
     fun hasApplicationReceivedDateTime(applicationReceivedDateTime: Instant?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         val assertjErrorMessage =
@@ -63,7 +62,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's applicationReference is not equal to the given one.
      */
     fun hasApplicationReference(applicationReference: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -85,7 +83,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's createdBy is null.
      */
     fun hasCreatedBy(): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -95,7 +92,6 @@ class CertificateAssert
             .overridingErrorMessage(assertjErrorMessage, actual)
             .isNotNull
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -106,7 +102,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's createdBy is not equal to the given one.
      */
     fun hasCreatedBy(createdBy: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -118,7 +113,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, createdBy, actualCreatedBy)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -128,7 +122,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's dateCreated is null.
      */
     fun hasDateCreated(): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -138,7 +131,6 @@ class CertificateAssert
             .overridingErrorMessage(assertjErrorMessage, actual)
             .isNotNull
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -149,7 +141,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's dateCreated is not equal to the given one.
      */
     fun hasDateCreated(dateCreated: Instant?, margin: Long = 1): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         val assertjErrorMessage =
@@ -175,7 +166,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's gssCode is not equal to the given one.
      */
     fun hasGssCode(gssCode: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -187,7 +177,27 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, gssCode, actualGssCode)
         }
 
-        // return the current assertion for method chaining
+        return this
+    }
+
+    /**
+     * Verifies that the actual Certificate's photoLocationArn is equal to the given one.
+     * @param photoLocationArn the given photoLocationArn to compare the actual Certificate's photoLocationArn to.
+     * @return this assertion object.
+     * @throws AssertionError - if the actual Certificate's photoLocationArn is not equal to the given one.
+     */
+    fun hasPhotoLocationArn(photoLocationArn: String?): CertificateAssert {
+        isNotNull
+
+        // overrides the default error message with a more explicit one
+        val assertjErrorMessage = "\nExpecting photoLocationArn of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>"
+
+        // null safe check
+        val actualPhotoLocationArn = actual!!.photoLocationArn
+        if (!Objects.deepEquals(actualPhotoLocationArn, photoLocationArn)) {
+            failWithMessage(assertjErrorMessage, actual, photoLocationArn, actualPhotoLocationArn)
+        }
+
         return this
     }
 
@@ -197,7 +207,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's id is null.
      */
     fun hasId(): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -207,7 +216,6 @@ class CertificateAssert
             .overridingErrorMessage(assertjErrorMessage, actual)
             .isNotNull
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -218,7 +226,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's id is not equal to the given one.
      */
     fun hasId(id: UUID?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -230,7 +237,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, id, actualId)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -241,7 +247,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's issueDate is not equal to the given one.
      */
     fun hasIssueDate(issueDate: LocalDate?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -253,7 +258,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, issueDate, actualIssueDate)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -264,7 +268,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's initialRetentionRemovalDate is not equal to the given one.
      */
     fun hasInitialRetentionRemovalDate(initialRetentionRemovalDate: LocalDate?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -276,7 +279,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, initialRetentionRemovalDate, actualInitialRetentionRemovalDate)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -287,7 +289,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's finalRetentionRemovalDate is not equal to the given one.
      */
     fun hasFinalRetentionRemovalDate(finalRetentionRemovalDate: LocalDate?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -299,7 +300,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, finalRetentionRemovalDate, actualFinalRetentionRemovalDate)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -309,7 +309,6 @@ class CertificateAssert
      * @throws AssertionError if the data is not null.
      */
     fun initialRetentionPeriodDataIsRemoved(): CertificateAssert {
-        // check that actual PrintRequest we want to make assertions on is not null.
         isNotNull
 
         if (this.actual?.initialRetentionDataRemoved == false) {
@@ -320,7 +319,6 @@ class CertificateAssert
             PrintRequestAssert(it).doesNotHaveInitialRetentionPeriodData()
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -330,7 +328,6 @@ class CertificateAssert
      * @throws AssertionError if the data is null.
      */
     fun hasInitialRetentionPeriodData(): CertificateAssert {
-        // check that actual PrintRequest we want to make assertions on is not null.
         isNotNull
 
         if (this.actual?.initialRetentionDataRemoved == true) {
@@ -341,7 +338,6 @@ class CertificateAssert
             PrintRequestAssert(it).hasInitialRetentionPeriodData()
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -352,7 +348,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's issuingAuthority is not equal to the given one.
      */
     fun hasIssuingAuthority(issuingAuthority: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -364,7 +359,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, issuingAuthority, actualIssuingAuthority)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -375,7 +369,6 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests does not contain all given PrintRequest elements.
      */
     fun hasPrintRequests(printRequests: Collection<PrintRequest>): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         for (printRequest in printRequests) {
@@ -389,7 +382,6 @@ class CertificateAssert
                 .hasSurname(printRequest.surname)
                 .hasCertificateLanguage(printRequest.certificateLanguage)
                 .hasSupportingInformationFormat(printRequest.supportingInformationFormat)
-                .hasPhotoLocationArn(printRequest.photoLocationArn)
                 .hasDelivery(printRequest.delivery!!)
                 .hasEroEnglish(printRequest.eroEnglish!!)
                 .hasEroWelsh(printRequest.eroWelsh)
@@ -402,12 +394,10 @@ class CertificateAssert
                 .hasVersion()
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
     fun hasPrintRequest(requestDateTime: Instant): PrintRequestAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         val printRequest = actual!!.printRequests.find { it.requestDateTime!! == requestDateTime }
@@ -417,7 +407,6 @@ class CertificateAssert
             failWithMessage("Expecting printRequest to exist with requestDateTime of `$requestDateTime")
         }
 
-        // return the print request assertion to continue assertions on the print request
         return PrintRequestAssert(printRequest)
     }
 
@@ -428,13 +417,11 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests does not contain all given PrintRequest elements.
      */
     fun hasOnlyPrintRequests(vararg printRequests: PrintRequest?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
         Iterables.instance().assertContainsOnly(info, actual!!.printRequests, printRequests)
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -445,7 +432,6 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests does not contain all given PrintRequest elements.
      */
     fun hasOnlyPrintRequests(printRequests: Collection<PrintRequest?>?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // check that given PrintRequest collection is not null.
@@ -457,7 +443,6 @@ class CertificateAssert
         // check with standard error message, to set another message call: info.overridingErrorMessage("my error message");
         Iterables.instance().assertContainsOnly(info, actual!!.printRequests, printRequests.toTypedArray())
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -469,13 +454,11 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests contains any given PrintRequest elements.
      */
     fun doesNotHavePrintRequests(vararg printRequests: PrintRequest?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // check with standard error message (use overridingErrorMessage before contains to set your own message).
         Iterables.instance().assertDoesNotContain(info, actual!!.printRequests, printRequests)
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -487,7 +470,6 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests contains any given PrintRequest elements.
      */
     fun doesNotHavePrintRequests(printRequests: Collection<PrintRequest?>?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // check that given PrintRequest collection is not null.
@@ -499,7 +481,6 @@ class CertificateAssert
         // check with standard error message (use overridingErrorMessage before contains to set your own message).
         Iterables.instance().assertDoesNotContain(info, actual!!.printRequests, printRequests.toTypedArray())
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -509,7 +490,6 @@ class CertificateAssert
      * @throws AssertionError if the actual Certificate's printRequests is not empty.
      */
     fun hasNoPrintRequests(): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // we override the default error message with a more explicit one
@@ -520,7 +500,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, actual!!.printRequests)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -531,7 +510,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's sourceReference is not equal to the given one.
      */
     fun hasSourceReference(sourceReference: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -543,7 +521,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, sourceReference, actualSourceReference)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -554,7 +531,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's sourceType is not equal to the given one.
      */
     fun hasSourceType(sourceType: SourceType?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -566,7 +542,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, sourceType, actualSourceType)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -577,7 +552,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's status is not equal to the given one.
      */
     fun hasStatus(status: Status?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -589,7 +563,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, status, actualStatus)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -600,7 +573,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's suggestedExpiryDate is not equal to the given one.
      */
     fun hasSuggestedExpiryDate(suggestedExpiryDate: LocalDate?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -612,7 +584,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, suggestedExpiryDate, actualSuggestedExpiryDate)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -622,7 +593,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's vacNumber is null or does not match pattern.
      */
     fun hasVacNumber(): CertificateAssert {
-        // check that actual PrintRequest we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -634,7 +604,6 @@ class CertificateAssert
             .overridingErrorMessage(assertjErrorMessage, actual, actualVacNumber)
             .containsPattern(Regex("^[A-Za-z\\d]{20}\$").pattern)
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -645,7 +614,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's vacNumber is not equal to the given one.
      */
     fun hasVacNumber(vacNumber: String?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -657,7 +625,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, vacNumber, actualVacNumber)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -667,7 +634,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's version is null.
      */
     fun hasVersion(): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -677,7 +643,6 @@ class CertificateAssert
             .overridingErrorMessage(assertjErrorMessage, actual)
             .isNotNull
 
-        // return the current assertion for method chaining
         return this
     }
 
@@ -688,7 +653,6 @@ class CertificateAssert
      * @throws AssertionError - if the actual Certificate's version is not equal to the given one.
      */
     fun hasVersion(version: Long?): CertificateAssert {
-        // check that actual Certificate we want to make assertions on is not null.
         isNotNull
 
         // overrides the default error message with a more explicit one
@@ -700,7 +664,6 @@ class CertificateAssert
             failWithMessage(assertjErrorMessage, actual, version, actualVersion)
         }
 
-        // return the current assertion for method chaining
         return this
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/PrintRequestAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/PrintRequestAssert.kt
@@ -363,29 +363,6 @@ class PrintRequestAssert
     }
 
     /**
-     * Verifies that the actual PrintRequest's photoLocationArn is equal to the given one.
-     * @param photoLocationArn the given photoLocationArn to compare the actual PrintRequest's photoLocationArn to.
-     * @return this assertion object.
-     * @throws AssertionError - if the actual PrintRequest's photoLocationArn is not equal to the given one.
-     */
-    fun hasPhotoLocationArn(photoLocationArn: String?): PrintRequestAssert {
-        // check that actual PrintRequest we want to make assertions on is not null.
-        isNotNull
-
-        // overrides the default error message with a more explicit one
-        val assertjErrorMessage = "\nExpecting photoLocationArn of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>"
-
-        // null safe check
-        val actualPhotoLocationArn = actual!!.photoLocationArn
-        if (!Objects.deepEquals(actualPhotoLocationArn, photoLocationArn)) {
-            failWithMessage(assertjErrorMessage, actual, photoLocationArn, actualPhotoLocationArn)
-        }
-
-        // return the current assertion for method chaining
-        return this
-    }
-
-    /**
      * Verifies that the actual PrintRequest's requestDateTime is equal to within margin of the given one.
      * @param requestDateTime the given requestDateTime to compare the actual PrintRequest's requestDateTime to.
      * @return this assertion object.

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -58,6 +58,7 @@ fun buildCertificate(
         )
     ),
     gssCode: String = aGssCode(),
+    photoLocationArn: String = aPhotoArn(),
     sourceType: SourceType = aValidSourceType(),
     sourceReference: String = aValidSourceReference(),
     applicationReceivedDateTime: Instant = aValidApplicationReceivedDateTime(),
@@ -66,6 +67,8 @@ fun buildCertificate(
     initialRetentionRemovalDate: LocalDate? = null,
     initialRetentionDataRemoved: Boolean = false,
     finalRetentionRemovalDate: LocalDate? = null,
+    issuingAuthority: String = aValidIssuingAuthority(),
+    issuingAuthorityCy: String? = null,
 ): Certificate {
     val certificate = Certificate(
         id = id,
@@ -74,10 +77,12 @@ fun buildCertificate(
         sourceReference = sourceReference,
         applicationReference = applicationReference,
         applicationReceivedDateTime = applicationReceivedDateTime,
-        issuingAuthority = aValidIssuingAuthority(),
+        issuingAuthority = issuingAuthority,
+        issuingAuthorityCy = issuingAuthorityCy,
         issueDate = issueDate,
         suggestedExpiryDate = aValidSuggestedExpiryDate(),
         gssCode = gssCode,
+        photoLocationArn = photoLocationArn,
         status = status,
         initialRetentionRemovalDate = initialRetentionRemovalDate,
         initialRetentionDataRemoved = initialRetentionDataRemoved,
@@ -95,7 +100,6 @@ fun buildPrintRequest(
     eroWelsh: ElectoralRegistrationOffice? = null,
     delivery: Delivery = buildDelivery(),
     batchId: String? = null,
-    photoLocationArn: String? = aPhotoArn(),
     userId: String = aValidUserId(),
 ): PrintRequest {
     val printRequest = PrintRequest(
@@ -106,7 +110,6 @@ fun buildPrintRequest(
         surname = aValidSurname(),
         certificateLanguage = aValidCertificateLanguage(),
         supportingInformationFormat = aValidSupportingInformationFormat(),
-        photoLocationArn = photoLocationArn,
         delivery = delivery,
         eroEnglish = eroEnglish,
         eroWelsh = eroWelsh,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/CertificateBuilder.kt
@@ -67,8 +67,6 @@ fun buildCertificate(
     initialRetentionRemovalDate: LocalDate? = null,
     initialRetentionDataRemoved: Boolean = false,
     finalRetentionRemovalDate: LocalDate? = null,
-    issuingAuthority: String = aValidIssuingAuthority(),
-    issuingAuthorityCy: String? = null,
 ): Certificate {
     val certificate = Certificate(
         id = id,
@@ -77,8 +75,7 @@ fun buildCertificate(
         sourceReference = sourceReference,
         applicationReference = applicationReference,
         applicationReceivedDateTime = applicationReceivedDateTime,
-        issuingAuthority = issuingAuthority,
-        issuingAuthorityCy = issuingAuthorityCy,
+        issuingAuthority = aValidIssuingAuthority(),
         issueDate = issueDate,
         suggestedExpiryDate = aValidSuggestedExpiryDate(),
         gssCode = gssCode,


### PR DESCRIPTION
- Enabler for Matt's PR https://github.com/cabinetoffice/eip-ero-print-api/pull/184 
- Moves `photo_location_arn` column from `print_request` table to `certificate` table. All the values are copied over to this new column
- Length is increased from `255` to `1024` as fileName itself could be 255 chars, so if someone adds a fileName more than 255 chars, the s3Arn length won't be enough


New column in `certificate` table
<img width="1243" alt="image" src="https://user-images.githubusercontent.com/73763010/224020684-29d8894f-51fe-465b-93b2-f7936612a6bb.png">

*Before changes*
<img width="958" alt="image" src="https://user-images.githubusercontent.com/73763010/224021259-d1e98b08-19f4-4e26-96a3-11d5080c10cd.png">

**Changed applied which removed column from `print_request` table**  
<img width="935" alt="image" src="https://user-images.githubusercontent.com/73763010/224020862-3499ea6e-ab4e-40f2-8661-e0707c4af869.png">


**Changeset**
<img width="1669" alt="image" src="https://user-images.githubusercontent.com/73763010/224089263-408f6b9a-a0fb-44d8-81d4-16ba00b207b1.png">

**Updated index**
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/73763010/224089025-f92d674b-5bc5-48e6-b490-f707acb2a837.png">

*Evidence that scripts and migration ran successfully on populated data*
<img width="1508" alt="image" src="https://user-images.githubusercontent.com/73763010/224096485-e380b1d8-7d1c-43dd-8f3e-0e0123fe5424.png">

