### PR TITLE
EIP1-4574: EIP1:4616: Liquibase scripts to mark all existing AED document status to be PRINTED

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -25,4 +25,5 @@
     <include relativeToChangelogFile="true" file="ddl/0016_final_retention_data_removed_column.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0017_anonymous_elector_document_source_type.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0018_EIP1-4481_alter_photo_location_arn_column_in_tables.xml"/>
+    <include relativeToChangelogFile="true" file="migration/0002_EIP1-4616_update_aed_status.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/migration/0002_EIP1-4616_update_aed_status.xml
+++ b/src/main/resources/db/changelog/migration/0002_EIP1-4616_update_aed_status.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="vishal.gupta@valtech.com" id="0002_EIP1-4616_update_aed_status - populate existing status to be PRINTED">
+        <sql>
+            <comment>Setting all AED document statuses from 'GENERATED' to 'PRINTED'</comment>
+            UPDATE anonymous_elector_document_status aed_status
+            SET aed_status.status = 'PRINTED'
+            WHERE aed_status.status = 'GENERATED'
+        </sql>
+
+        <rollback/>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This PR follows existing PR https://github.com/cabinetoffice/eip-ero-print-api/pull/188 that sets the document status to PRINTED upon generation.