### PR TITLE
Printer responsible for Issued Date (DRAFT - DO NOT MERGE).

### DIFF
--- a/src/main/resources/yamlschema/PrintRequest.yaml
+++ b/src/main/resources/yamlschema/PrintRequest.yaml
@@ -19,11 +19,21 @@ properties:
     maxLength: 255
     description: Issuing authority (LA/ERO/VJB)
     example: Camden Borough Council
+  issueDate:
+    type: string
+    format: date
+    description: |-
+      Only supplied in the case of a re-print. 
+      Returned in Print Response from printer if not a re-print.
+    example: '2022-06-01'
   suggestedExpiryDate:
     type: string
     format: date
-    example: '2022-06-01'
-    description: issueDate + 10 years
+    example: '2023-06-01'
+    description: |-
+      Only supplied in the case of a re-print. 
+      Returned in Print Response from printer if not a re-print.
+      issueDate + 10 years
   requestDateTime:
     type: string
     format: date-time
@@ -171,8 +181,6 @@ properties:
 required:
   - requestId
   - issuingAuthorityEn
-  - issueDate
-  - suggestedExpiryDate
   - requestDateTime
   - cardFirstname
   - cardSurname

--- a/src/main/resources/yamlschema/PrintRequest.yaml
+++ b/src/main/resources/yamlschema/PrintRequest.yaml
@@ -19,11 +19,6 @@ properties:
     maxLength: 255
     description: Issuing authority (LA/ERO/VJB)
     example: Camden Borough Council
-  issueDate:
-    type: string
-    format: date
-    description: The issue date of the Voter Authority Card
-    example: '2022-06-01'
   suggestedExpiryDate:
     type: string
     format: date

--- a/src/main/resources/yamlschema/PrintResponse.yaml
+++ b/src/main/resources/yamlschema/PrintResponse.yaml
@@ -21,7 +21,6 @@ properties:
     enum:
       - PROCESSED
       - IN-PRODUCTION
-      - PRINTED
       - DISPATCHED
       - NOT-DELIVERED
   status:
@@ -34,14 +33,14 @@ properties:
     type: string
     format: date
     description: |-
-      Only returned when the statusStep is PRINTED for the initial print. This is the legal issuedDate.
+      Only returned when the statusStep is IN-PRODUCTION for the initial print. This is the legal issuedDate.
       If the issueDate was supplied as a re-print. This will not be returned.
     example: '2022-06-01'    
   suggestedExpiryDate:
     type: string
     format: date
     description: |-
-      Only returned when the statusStep is PRINTED for the initial print. This is the legal issuedDate + 10 years.
+      Only returned when the statusStep is IN-PRODUCTION for the initial print. This is the legal issuedDate + 10 years.
       If the suggestedExpiryDate was supplied as a re-print. This will not be returned.
     example: '2032-06-01'  
   message:

--- a/src/main/resources/yamlschema/PrintResponse.yaml
+++ b/src/main/resources/yamlschema/PrintResponse.yaml
@@ -16,10 +16,12 @@ properties:
     example: '2022-06-01T14:23:03.000Z'
   statusStep:
     type: string
-    description: The current print step this update relates to
+    description: |-
+      The current print step this update relates to.
     enum:
       - PROCESSED
       - IN-PRODUCTION
+      - PRINTED
       - DISPATCHED
       - NOT-DELIVERED
   status:
@@ -31,8 +33,17 @@ properties:
   issueDate:
     type: string
     format: date
-    description: Required when status is IN-PRODUCTION and indicates the actual issue date of the Voter Certificate.
+    description: |-
+      Only returned when the statusStep is PRINTED for the initial print. This is the legal issuedDate.
+      If the issueDate was supplied as a re-print. This will not be returned.
     example: '2022-06-01'    
+  suggestedExpiryDate:
+    type: string
+    format: date
+    description: |-
+      Only returned when the statusStep is PRINTED for the initial print. This is the legal issuedDate + 10 years.
+      If the suggestedExpiryDate was supplied as a re-print. This will not be returned.
+    example: '2032-06-01'  
   message:
     type: string
     maxLength: 255

--- a/src/main/resources/yamlschema/PrintResponse.yaml
+++ b/src/main/resources/yamlschema/PrintResponse.yaml
@@ -28,6 +28,11 @@ properties:
       - SUCCESS
       - FAILED
     description: Indicates if the step change was successful or not.
+  issueDate:
+    type: string
+    format: date
+    description: Required when status is IN-PRODUCTION and indicates the actual issue date of the Voter Certificate.
+    example: '2022-06-01'    
   message:
     type: string
     maxLength: 255


### PR DESCRIPTION
This PR is DRAFT and for review with EIP and Print Provider.

The issued date needs to be when the certificate is actually printed, therefore the print provider needs to supply the actual date of printing / issued date.

Where the certificate is a re-print, EROP needs to supply the original issuedDate as previously supplied by the printer.