### PR TITLE
EIP1-4574: EIP1:4666: Rename address fields in print-api spec

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/GenerateAnonymousElectorDocumentDto.kt
@@ -14,6 +14,6 @@ data class GenerateAnonymousElectorDocumentDto(
     val surname: String,
     val email: String? = null,
     val phoneNumber: String? = null,
-    val address: AddressDto,
+    val registeredAddress: AddressDto,
     val userId: String,
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapper.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.printapi.mapper
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.dluhc.printapi.database.entity.AedContactDetails
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.dto.GenerateAnonymousElectorDocumentDto
@@ -42,6 +43,9 @@ abstract class AnonymousElectorDocumentMapper {
         aedRequest: GenerateAnonymousElectorDocumentDto,
         aedTemplateFilename: String
     ): AnonymousElectorDocument
+
+    @Mapping(target = "address", source = "registeredAddress")
+    protected abstract fun toAedContactDetailsEntity(aedRequest: GenerateAnonymousElectorDocumentDto): AedContactDetails
 
     protected fun issueDate(): LocalDate = LocalDate.now(clock)
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
@@ -21,10 +21,10 @@ class AnonymousElectorDocumentService(
 ) {
 
     @Transactional
-    fun generateAnonymousElectorDocument(eroId: String, request: GenerateAnonymousElectorDocumentDto): PdfFile {
-        verifyGssCodeIsValidForEro(eroId, request.gssCode)
-        val filename = pdfTemplateDetailsFactory.getTemplateFilename(request.gssCode)
-        with(anonymousElectorDocumentMapper.toAnonymousElectorDocument(request, filename)) {
+    fun generateAnonymousElectorDocument(eroId: String, dto: GenerateAnonymousElectorDocumentDto): PdfFile {
+        verifyGssCodeIsValidForEro(eroId, dto.gssCode)
+        val filename = pdfTemplateDetailsFactory.getTemplateFilename(dto.gssCode)
+        with(anonymousElectorDocumentMapper.toAnonymousElectorDocument(dto, filename)) {
             val templateDetails = pdfTemplateDetailsFactory.getTemplateDetails(this)
             val contents = pdfFactory.createPdfContents(templateDetails)
             anonymousElectorDocumentRepository.save(this)

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -830,7 +830,7 @@ components:
           type: string
           maxLength: 255
           description: The addressee to be printed in addition to the delivery address
-        address:
+        deliveryAddress:
           $ref: '#/components/schemas/Address'
         addressFormat:
           $ref: '#/components/schemas/AddressFormat'
@@ -838,7 +838,7 @@ components:
         - deliveryClass
         - deliveryAddressType
         - addressee
-        - address
+        - deliveryAddress
         - addressFormat
 
     DeliveryClass:

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.10.0'
+  version: '1.11.0'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -1140,7 +1140,7 @@ components:
           maxLength: 50
           description: The applicant's phone number. Null if not known
           example: 01234 567890
-        address:
+        registeredAddress:
           $ref: '#/components/schemas/Address'
         delivery:
           # TODO make delivery as mandatory (EIP1-4668) once changes in VCA (EIP1-4665) are completed. TODO
@@ -1156,7 +1156,7 @@ components:
         - photoLocation
         - firstName
         - surname
-        - address
+        - registeredAddress
 
   #
   # Response Body Definitions

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/AnonymousElectorDocumentMapperTest.kt
@@ -96,7 +96,7 @@ class AnonymousElectorDocumentMapperTest {
                         surname = surname,
                         email = email,
                         phoneNumber = phoneNumber,
-                        address = with(address) {
+                        address = with(registeredAddress) {
                             Address(
                                 street = street,
                                 postcode = postcode,
@@ -131,6 +131,42 @@ class AnonymousElectorDocumentMapperTest {
     }
 
     @Nested
+    inner class ToAedContactDetailsEntity {
+
+        @Test
+        fun `should map to AedContactDetails entity given GenerateAnonymousElectorDocumentDto`() {
+            // Given
+            val request = buildGenerateAnonymousElectorDocumentDto()
+            val expected = with(request) {
+                AedContactDetails(
+                    firstName = firstName,
+                    middleNames = middleNames,
+                    surname = surname,
+                    email = email,
+                    phoneNumber = phoneNumber,
+                    address = with(registeredAddress) {
+                        Address(
+                            street = street,
+                            postcode = postcode,
+                            property = property,
+                            locality = locality,
+                            town = town,
+                            area = area,
+                            uprn = uprn
+                        )
+                    },
+                )
+            }
+
+            // When
+            val actual = mapper.toAedContactDetailsEntity(request)
+
+            // Then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+        }
+    }
+
+    @Nested
     inner class ToGenerateAnonymousElectorDocumentDto {
         @Test
         fun `should map to GenerateAnonymousElectorDocumentDto DTO given API Request`() {
@@ -160,7 +196,7 @@ class AnonymousElectorDocumentMapperTest {
                 surname = apiRequest.surname,
                 email = apiRequest.email,
                 phoneNumber = apiRequest.phoneNumber,
-                address = with(apiRequest.address) {
+                registeredAddress = with(apiRequest.registeredAddress) {
                     AddressDto(
                         property = property,
                         street = street,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -43,11 +43,7 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
         val userGroupEroId = anotherValidEroId(ERO_ID)
 
         webTestClient.post()
-            .uri(
-                URI_TEMPLATE,
-                ERO_ID,
-                GSS_CODE
-            )
+            .uri(URI_TEMPLATE, ERO_ID, GSS_CODE)
             .bearerToken(getVCAnonymousAdminBearerToken(eroId = userGroupEroId))
             .contentType(MediaType.APPLICATION_JSON)
             .withBody(buildGenerateAnonymousElectorDocumentRequest())
@@ -165,7 +161,7 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
         val request = buildGenerateAnonymousElectorDocumentRequest(
             photoLocation = photoLocationArn,
             email = null, phoneNumber = null,
-            address = buildValidAddress(
+            registeredAddress = buildValidAddress(
                 property = null, locality = null, town = null, area = null, uprn = null
             )
         )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/GenerateAnonymousElectorDocumentDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/GenerateAnonymousElectorDocumentDtoBuilder.kt
@@ -34,7 +34,7 @@ fun buildGenerateAnonymousElectorDocumentDto(
     surname: String = aValidSurname(),
     email: String = aValidEmailAddress(),
     phoneNumber: String = aValidPhoneNumber(),
-    address: AddressDto = buildValidAddressDto(),
+    registeredAddress: AddressDto = buildValidAddressDto(),
     userId: String = aValidUserId(),
 ): GenerateAnonymousElectorDocumentDto =
     GenerateAnonymousElectorDocumentDto(
@@ -51,7 +51,7 @@ fun buildGenerateAnonymousElectorDocumentDto(
         surname = surname,
         email = email,
         phoneNumber = phoneNumber,
-        address = address,
+        registeredAddress = registeredAddress,
         userId = userId
     )
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/GenerateAnonymousElectorDocumentDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/GenerateAnonymousElectorDocumentDtoBuilder.kt
@@ -19,6 +19,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceTypeDto
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+import net.datafaker.providers.base.Address as DataFakerAddress
 
 fun buildGenerateAnonymousElectorDocumentDto(
     gssCode: String = aGssCode(),
@@ -56,7 +57,7 @@ fun buildGenerateAnonymousElectorDocumentDto(
     )
 
 fun buildValidAddressDto(
-    fakeAddress: net.datafaker.providers.base.Address = DataFaker.faker.address(),
+    fakeAddress: DataFakerAddress = DataFaker.faker.address(),
     property: String? = fakeAddress.buildingNumber(),
     street: String = fakeAddress.streetName(),
     locality: String? = fakeAddress.streetName(),

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
@@ -32,7 +32,7 @@ fun buildGenerateAnonymousElectorDocumentRequest(
     surname: String = aValidSurname(),
     email: String? = aValidEmailAddress(),
     phoneNumber: String? = aValidPhoneNumber(),
-    address: Address = buildValidAddress(),
+    registeredAddress: Address = buildValidAddress(),
     delivery: CertificateDelivery? = null // TODO EIP-4668 makes this `delivery` field as mandatory
 ): GenerateAnonymousElectorDocumentRequest =
     GenerateAnonymousElectorDocumentRequest(
@@ -49,7 +49,7 @@ fun buildGenerateAnonymousElectorDocumentRequest(
         surname = surname,
         email = email,
         phoneNumber = phoneNumber,
-        address = address,
+        registeredAddress = registeredAddress,
         delivery = delivery
     )
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/GenerateAnonymousElectorDocumentRequestBuilder.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
 import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+import net.datafaker.providers.base.Address as DataFakerAddress
 
 fun buildGenerateAnonymousElectorDocumentRequest(
     gssCode: String = aGssCode(),
@@ -54,7 +55,7 @@ fun buildGenerateAnonymousElectorDocumentRequest(
     )
 
 fun buildValidAddress(
-    fakeAddress: net.datafaker.providers.base.Address = DataFaker.faker.address(),
+    fakeAddress: DataFakerAddress = DataFaker.faker.address(),
     property: String? = fakeAddress.buildingNumber(),
     street: String = fakeAddress.streetName(),
     locality: String? = fakeAddress.streetName(),
@@ -62,7 +63,7 @@ fun buildValidAddress(
     area: String? = fakeAddress.state(),
     postcode: String = fakeAddress.postcode(),
     uprn: String? = RandomStringUtils.randomNumeric(12),
-): Address =
+) =
     Address(
         property = property,
         street = street,


### PR DESCRIPTION
This needs to be merged just in time when vca [PR](https://github.com/cabinetoffice/eip-ero-voter-card-applications-api/pull/575)  is approved and ready to be merged

- [x] VCA API PR https://github.com/cabinetoffice/eip-ero-voter-card-applications-api/pull/575 approved and ready to be merged? 