### PR TITLE
EIP1-4653 enhance correlation id

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClient.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/client/ElectoralRegistrationOfficeManagementApiClient.kt
@@ -30,6 +30,8 @@ class ElectoralRegistrationOfficeManagementApiClient(
      * @throws [ElectoralRegistrationOfficeManagementApiException] concrete implementation if the API returns an error
      */
     fun getElectoralRegistrationOfficeGssCodes(eroId: String): List<String> {
+        logger.info { "Retrieving gss codes for ero $eroId" }
+
         val response = eroManagementWebClient
             .get()
             .uri("/eros/{eroId}", eroId)
@@ -37,6 +39,8 @@ class ElectoralRegistrationOfficeManagementApiClient(
             .bodyToMono(ElectoralRegistrationOfficeResponse::class.java)
             .onErrorResume { ex -> handleException(ex, mapOf("eroId" to eroId)) }
             .block()!!
+
+        logger.info { "Finished retrieving gss codes for ero $eroId" }
 
         return response.localAuthorities.map { it.gssCode }
     }
@@ -49,6 +53,8 @@ class ElectoralRegistrationOfficeManagementApiClient(
      * @throws [ElectoralRegistrationOfficeManagementApiException] concrete implementation if the API returns an error
      */
     fun getEro(gssCode: String): EroDto {
+        logger.info { "Retrieving Ero for gssCode $gssCode" }
+
         val response = eroManagementWebClient
             .get()
             .uri("/eros?gssCode=$gssCode")
@@ -56,6 +62,8 @@ class ElectoralRegistrationOfficeManagementApiClient(
             .bodyToMono(ElectoralRegistrationOfficesResponse::class.java)
             .onErrorResume { ex -> handleException(ex, mapOf("gssCode" to gssCode)) }
             .block()!!
+
+        logger.info { "Finished retrieving Ero for gssCode $gssCode" }
 
         if (response.eros.size != 1 ||
             response.eros[0].localAuthorities.filter { it.gssCode == gssCode }.size != 1

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/CorrelationIdMdcConfiguration.kt
@@ -1,17 +1,25 @@
 package uk.gov.dluhc.printapi.config
 
+import mu.KotlinLogging
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
 import org.slf4j.MDC
+import org.springframework.http.HttpHeaders
 import org.springframework.messaging.Message
 import org.springframework.messaging.support.GenericMessage
 import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.ClientRequest
+import org.springframework.web.reactive.function.client.ClientResponse
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.servlet.HandlerInterceptor
-import java.lang.Exception
+import reactor.core.publisher.Mono
 import java.util.UUID
 import javax.servlet.http.HttpServletRequest
 import javax.servlet.http.HttpServletResponse
+
+private val logger = KotlinLogging.logger {}
 
 /**
  * MVC Interceptor and AOP beans that set the correlation ID MDC variable for inclusion in all log statements.
@@ -25,11 +33,14 @@ const val CORRELATION_ID_HEADER = "x-correlation-id"
  * HTTP header `x-correlation-id` if set. This allows for passing and logging a consistent correlation ID between
  * disparate systems or processes.
  */
+
 @Component
 class CorrelationIdMdcInterceptor : HandlerInterceptor {
 
     override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
-        MDC.put(CORRELATION_ID, request.getHeader(CORRELATION_ID_HEADER) ?: generateCorrelationId())
+        val correlationId = request.getHeader(CORRELATION_ID_HEADER) ?: generateCorrelationId()
+        MDC.put(CORRELATION_ID, correlationId)
+        response.setHeader(CORRELATION_ID_HEADER, correlationId)
         return true
     }
 
@@ -40,6 +51,46 @@ class CorrelationIdMdcInterceptor : HandlerInterceptor {
         ex: Exception?
     ) {
         MDC.remove(CORRELATION_ID)
+    }
+}
+
+/**
+ * Webclient exchange filter that sets the correlation ID MDC variable of either a new value, or the
+ * current value found in the MDC context. This allows for passing and logging a consistent correlation ID between
+ * disparate systems or processes using the spring Webclient.
+ */
+@Component
+class CorrelationIdMdcExchangeFilter(private val mdcExchangeFilter: MDCExchangeFilter) : ExchangeFilterFunction {
+
+    /*
+        This is modelled as a set in case we need to talk to another system within the gov space that doesn't use 'x-correlation-id'.
+        Another commonly used identifier is 'X-Request-Id'. This allows us to send our 'x-correlation-id' as well as their specified one.
+    */
+    private val correlationHeaderNames: Set<String> = setOf(CORRELATION_ID_HEADER)
+
+    override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+        val currentCorrelationId = getCurrentCorrelationId()
+        val clientRequestModified = setCorrelationIdInRequest(request, currentCorrelationId)
+
+        return next.filter(mdcExchangeFilter).exchange(clientRequestModified)
+    }
+
+    private fun setCorrelationIdInRequest(request: ClientRequest, correlationId: String): ClientRequest {
+        return ClientRequest.from(request)
+            .headers { headers: HttpHeaders -> correlationHeaderNames.forEach { correlationHeaderName -> headers[correlationHeaderName] = correlationId } }
+            .build()
+    }
+
+    @Component
+    class MDCExchangeFilter : ExchangeFilterFunction {
+        override fun filter(request: ClientRequest, next: ExchangeFunction): Mono<ClientResponse> {
+            val contextMap = MDC.getCopyOfContextMap()
+            return next.exchange(request).doOnEach { _ ->
+                if (contextMap != null) {
+                    MDC.setContextMap(contextMap)
+                }
+            }
+        }
     }
 }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/WebClientConfiguration.kt
@@ -9,8 +9,9 @@ import org.springframework.web.reactive.function.client.WebClient
 class WebClientConfiguration {
 
     @Bean
-    fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String): WebClient =
+    fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String, correlationIdExchangeFilter: CorrelationIdMdcExchangeFilter): WebClient =
         WebClient.builder()
             .baseUrl(eroManagementApiUrl)
+            .filter(correlationIdExchangeFilter)
             .build()
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/WebClientConfiguration.kt
@@ -9,7 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient
 class WebClientConfiguration {
 
     @Bean
-    fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String, correlationIdExchangeFilter: CorrelationIdMdcExchangeFilter): WebClient =
+    fun eroManagementWebClient(@Value("\${api.ero-management.url}") eroManagementApiUrl: String, correlationIdExchangeFilter: CorrelationIdWebClientMdcExchangeFilter): WebClient =
         WebClient.builder()
             .baseUrl(eroManagementApiUrl)
             .filter(correlationIdExchangeFilter)

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -27,6 +27,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       summary: CORS support
       description: |
@@ -74,6 +80,12 @@ paths:
             type: string
           in: query
           required: true
+        - name: x-correlation-id
+          description: The correlation id for the the request
+          schema:
+            type: string
+          in: header
+          required: false
       tags:
         - Voter Authority Certificates (VAC)
       responses:
@@ -111,6 +123,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       deprecated: true
       summary: CORS support
@@ -195,6 +213,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       deprecated: true
       summary: CORS support
@@ -270,6 +294,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       summary: CORS support
       description: |
@@ -396,6 +426,12 @@ paths:
           example: 'E09000007'
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       summary: CORS support
       description: |
@@ -480,6 +516,12 @@ paths:
           type: string
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       summary: CORS support
       description: |
@@ -608,6 +650,12 @@ paths:
           example: 'E09000007'
         in: path
         required: true
+      - name: x-correlation-id
+        description: The correlation id for the the request
+        schema:
+          type: string
+        in: header
+        required: false
     options:
       summary: CORS support
       description: |
@@ -1174,6 +1222,9 @@ components:
         Access-Control-Allow-Headers:
           schema:
             type: string
+        x-correlation-id:
+          schema:
+            type: string
       content:
         application/json:
           schema:
@@ -1190,6 +1241,9 @@ components:
         Access-Control-Allow-Headers:
           schema:
             type: string
+        x-correlation-id:
+          schema:
+            type: string
       content:
         application/json:
           schema:
@@ -1204,6 +1258,9 @@ components:
           schema:
             type: string
         Access-Control-Allow-Headers:
+          schema:
+            type: string
+        x-correlation-id:
           schema:
             type: string
       content:

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.11.1'
+  version: '1.11.2'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -27,12 +27,6 @@ paths:
           type: string
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       summary: CORS support
       description: |
@@ -80,12 +74,6 @@ paths:
             type: string
           in: query
           required: true
-        - name: x-correlation-id
-          description: The correlation id for the the request
-          schema:
-            type: string
-          in: header
-          required: false
       tags:
         - Voter Authority Certificates (VAC)
       responses:
@@ -123,12 +111,6 @@ paths:
           type: string
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       deprecated: true
       summary: CORS support
@@ -213,12 +195,6 @@ paths:
           type: string
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       deprecated: true
       summary: CORS support
@@ -294,12 +270,6 @@ paths:
           type: string
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       summary: CORS support
       description: |
@@ -426,12 +396,6 @@ paths:
           example: 'E09000007'
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       summary: CORS support
       description: |
@@ -516,12 +480,6 @@ paths:
           type: string
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       summary: CORS support
       description: |
@@ -650,12 +608,6 @@ paths:
           example: 'E09000007'
         in: path
         required: true
-      - name: x-correlation-id
-        description: The correlation id for the the request
-        schema:
-          type: string
-        in: header
-        required: false
     options:
       summary: CORS support
       description: |
@@ -1222,9 +1174,6 @@ components:
         Access-Control-Allow-Headers:
           schema:
             type: string
-        x-correlation-id:
-          schema:
-            type: string
       content:
         application/json:
           schema:
@@ -1241,9 +1190,6 @@ components:
         Access-Control-Allow-Headers:
           schema:
             type: string
-        x-correlation-id:
-          schema:
-            type: string
       content:
         application/json:
           schema:
@@ -1258,9 +1204,6 @@ components:
           schema:
             type: string
         Access-Control-Allow-Headers:
-          schema:
-            type: string
-        x-correlation-id:
           schema:
             type: string
       content:

--- a/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/print-api-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print API SQS Message Types
-  version: '1.9.4'
+  version: '1.9.5'
   description: |-
     Print API SQS Message Types
     
@@ -12,6 +12,9 @@ info:
     
     The `paths` element is only being used in order to maintain the structure of the openApi spec, as `paths` are required 
     elements.
+    
+    The SQS listeners and producers in this API also consume/produce an optional x-correlation-id header that can be used
+    to trace requests.
 #
 # --------------------------------------------------------------------------------
 #

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/WiremockService.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/WiremockService.kt
@@ -8,6 +8,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.ok
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathMatching
+import com.github.tomakehurst.wiremock.matching.StringValuePattern
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.eromanagementapi.models.ElectoralRegistrationOfficeResponse
@@ -86,5 +87,9 @@ class WiremockService(private val wireMockServer: WireMockServer) {
 
     fun verifyEroManagementGetEro(gssCode: String) {
         wireMockServer.verify(1, getRequestedFor(urlEqualTo("/ero-management-api/eros?gssCode=$gssCode")))
+    }
+
+    fun verifyEroManagementGetEroByEroIdWithCorrelationId(eroId: String, correlationIdMatcher: StringValuePattern) {
+        wireMockServer.verify(1, getRequestedFor(urlEqualTo("/ero-management-api/eros/$eroId")).withHeader("x-correlation-id", correlationIdMatcher))
     }
 }


### PR DESCRIPTION
- Ensure correlation id is also returned in HTTP response
- Ensure correlation id is carried through in WebClient requests or Webclient is able to generate a new one.