### PR TITLE
EIP1-4953 - Consistent use of ErrorResponse

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
@@ -9,56 +9,98 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.context.request.RequestAttributes
+import org.springframework.web.context.request.RequestAttributes.SCOPE_REQUEST
 import org.springframework.web.context.request.WebRequest
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
 import uk.gov.dluhc.printapi.config.ApiRequestErrorAttributes
-import javax.servlet.RequestDispatcher
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import javax.servlet.RequestDispatcher.ERROR_STATUS_CODE
 
+/**
+ * Global Exception Handler. Handles specific exceptions thrown by the application by returning a suitable [ErrorResponse]
+ * response entity.
+ *
+ * Our standard pattern here is to return an [ErrorResponse]. Please think carefully about writing a response handler
+ * method that does not follow this pattern. Please try not to use [handleExceptionInternal] as this returns a response
+ * body of a simple string rather than a structured response body.
+ *
+ * Our preferred approach is to use the method [populateErrorResponseAndHandleExceptionInternal] which builds and returns
+ * the [ErrorResponse] complete with correctly populated status code field. This method also populates the message field
+ * of [ErrorResponse] from the exception. In the case that the exception message is not suitable for exposing through
+ * the REST API, this can be overridden by manually setting the message on the request attribute. eg:
+ *
+ * ```
+ *     request.setAttribute(ERROR_MESSAGE, "A simpler error message that does not expose internal detail", SCOPE_REQUEST)
+ * ```
+ *
+ */
 @ControllerAdvice
 class GlobalExceptionHandler(
     private var errorAttributes: ApiRequestErrorAttributes
 ) : ResponseEntityExceptionHandler() {
 
-    @ExceptionHandler(value = [CertificateNotFoundException::class, ExplainerDocumentNotFoundException::class])
-    fun handleResourceNotFound(e: RuntimeException, request: WebRequest): ResponseEntity<Any?>? {
-        return handleExceptionInternal(e, e.message, HttpHeaders(), NOT_FOUND, request)
+    /**
+     * Exception handler to return a 404 Not Found ErrorResponse
+     */
+    @ExceptionHandler(
+        value = [
+            CertificateNotFoundException::class,
+            ExplainerDocumentNotFoundException::class
+        ]
+    )
+    protected fun handleExceptionReturnNotFoundErrorResponse(
+        e: RuntimeException,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        return populateErrorResponseAndHandleExceptionInternal(e, NOT_FOUND, request)
     }
 
+    /**
+     * Exception handler to return a 400 Bad Request ErrorResponse
+     */
     @ExceptionHandler(
         value = [
             GenerateTemporaryCertificateValidationException::class,
             GenerateAnonymousElectorDocumentValidationException::class
         ]
     )
-    fun handleRequestValidationException(e: RuntimeException, request: WebRequest): ResponseEntity<Any> {
+    protected fun handleExceptionReturnBadRequestErrorResponse(
+        e: RuntimeException,
+        request: WebRequest
+    ): ResponseEntity<Any> {
         return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
+    /**
+     * Overrides the HttpMessageNotReadableException exception handler to return a 400 Bad Request ErrorResponse
+     */
     override fun handleHttpMessageNotReadable(
         e: HttpMessageNotReadableException,
         headers: HttpHeaders,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
-        return populateErrorResponseAndHandleExceptionInternal(e, status, request)
+        return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
+    /**
+     * Overrides the MethodArgumentNotValidException exception handler to return a 400 Bad Request ErrorResponse
+     */
     override fun handleMethodArgumentNotValid(
         e: MethodArgumentNotValidException,
         headers: HttpHeaders,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
-        return populateErrorResponseAndHandleExceptionInternal(e, status, request)
+        return populateErrorResponseAndHandleExceptionInternal(e, BAD_REQUEST, request)
     }
 
     private fun populateErrorResponseAndHandleExceptionInternal(
         exception: Exception,
         status: HttpStatus,
-        request: WebRequest
+        request: WebRequest,
     ): ResponseEntity<Any> {
-        request.setAttribute(RequestDispatcher.ERROR_STATUS_CODE, status.value(), RequestAttributes.SCOPE_REQUEST)
+        request.setAttribute(ERROR_STATUS_CODE, status.value(), SCOPE_REQUEST)
         val body = errorAttributes.getErrorResponse(request)
         return handleExceptionInternal(exception, body, HttpHeaders(), status, request)
     }

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.12.0'
+  version: '1.12.1'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -80,7 +80,7 @@ paths:
         '200':
           $ref: '#/components/responses/CertificateSummary'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: get-certificate-summary-by-application-id
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -159,7 +159,7 @@ paths:
         '200':
           $ref: '#/components/responses/CertificateSummary'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: deprecated-get-certificate-summary-by-application-id
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -324,13 +324,9 @@ paths:
                 type: string
                 example: attachment; filename="temporary-certificate-DGFF4E6420YHWPJYX560.pdf"
         '400':
-          description: Error response describing fields in the request payload that are in error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: generate-temporary-certificate
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -451,7 +447,7 @@ paths:
                 type: string
                 example: attachment; filename="temporary-certificate-explainer-document-E09000007.pdf"
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: generate-temporary-certificate-explainer-document
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -534,13 +530,9 @@ paths:
                 type: string
                 example: attachment; filename="anonymous-elector-document-DGFF4E6420YHWPJYX560.pdf"
         '400':
-          description: Error response describing fields in the request payload that are in error
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
+          $ref: '#/components/responses/400ErrorResponse'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: generate-anonymous-elector-document
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -573,7 +565,7 @@ paths:
         '200':
           $ref: '#/components/responses/AnonymousElectorDocumentSummaries'
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       operationId: get-anonymous-elector-document-summaries-by-application-id
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
@@ -664,7 +656,7 @@ paths:
                 type: string
                 example: attachment; filename="aed-explainer-document-E09000007.pdf"
         '404':
-          description: Not Found
+          $ref: '#/components/responses/404ErrorResponse'
       security:
         - eroUserCognitoUserPoolAuthorizer: [ ]
       x-amazon-apigateway-integration:
@@ -686,31 +678,11 @@ components:
   # Schema and Enum Definitions
   # --------------------------------------------------------------------------------
   schemas:
-    ConflictErrorResponse:
-      title: ConflictErrorResponse
-      description: Response describing errors in a web request for conflicts.
-      properties:
-        timestamp:
-          type: string
-          format: date-time
-          example: '2022-09-28T18:01:42.105Z'
-        status:
-          type: integer
-          example: 409
-        error:
-          type: string
-          example: 'Conflict'
-        message:
-          type: string
-          example: 'An application with applicationId = 34ed0c0bc47d8d741539ccac has an unexpected status RECEIVED'
-      required:
-        - timestamp
-        - status
-        - error
-        - message
     ErrorResponse:
       title: ErrorResponse
-      description: Response describing errors in a web request
+      description: |
+        A generic response body object describing errors in a web request, and can be used to communicate several
+        different types of error condition such as (but not limited to) `400 BAD REQUEST`, `409 CONFLICT` etc.
       properties:
         timestamp:
           type: string
@@ -724,8 +696,9 @@ components:
           example: 'Bad Request'
         message:
           type: string
-          example: 'Validation failed for object=paperVoterCardApplicationRequest. Error count: 14'
+          example: 'Validation failed for object=applicationRequest. Error count: 14'
         validationErrors:
+          description: Validation errors are only present if the error being described is a `400 BAD REQUEST`.
           type: array
           items:
             type: string
@@ -1203,6 +1176,74 @@ components:
   # Response Body Definitions
   # --------------------------------------------------------------------------------
   responses:
+    400ErrorResponse:
+      description: Error response for a HTTP 400 describing fields in the request payload that are in error
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 400
+            error: 'Bad Request'
+            message: 'Validation failed for object=applicationRequest. Error count: 14'
+            validationErrors: 'Error on field applicant.nino: rejected value [aaaaaaaaaaa], must match ^.{1,10}$'
+    404ErrorResponse:
+      description: |
+        Error response for a HTTP 404 describing the problem with the request.
+        Typical examples are resources such as the application not found.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 404
+            error: 'Not Found'
+            message: 'Certificate photo for voter card application with eroId=[some-ero] and applicationType=[VOTER_CARD] and applicationId=[507f1f77bcf86cd799439011] not found'
+    409ErrorResponse:
+      description: |
+        Error response for a HTTP 409 describing the problem with the request.
+        Typical examples are that an application's status(es) are not in the required state to perform the requested operation.
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+          example:
+            timestamp: '2022-09-28T18:01:42.105Z'
+            status: 409
+            error: 'Conflict'
+            message: 'An application with eroId = some-ero and applicationType = VOTER_CARD and applicationId = 507f1f77bcf86cd799439011 has an unexpected photoCheckStatus = ACCEPTED'
     CertificateSummary:
       description: Response containing a single Certificate summary
       headers:

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest.kt
@@ -2,13 +2,16 @@ package uk.gov.dluhc.printapi.rest
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
 import uk.gov.dluhc.printapi.database.entity.SourceType
 import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
+import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.models.PrintRequestStatus
 import uk.gov.dluhc.printapi.models.PrintRequestSummary
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
@@ -65,11 +68,16 @@ internal class DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest : I
             .bearerToken(getBearerToken(eroId = ERO_ID, groups = listOf("ero-$ERO_ID", "ero-vc-admin-$ERO_ID")))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
+            .expectStatus()
+            .isEqualTo(NOT_FOUND)
+            .returnResult(ErrorResponse::class.java)
 
         // Then
-        response.expectStatus().isNotFound
-        val actual = response.returnResult(String::class.java).responseBody.blockFirst()
-        assertThat(actual).isEqualTo("Certificate for eroId = $ERO_ID with sourceType = ${SourceType.VOTER_CARD} and sourceReference = $APPLICATION_ID not found")
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(NOT_FOUND.value())
+            .hasError("Not Found")
+            .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ${SourceType.VOTER_CARD} and sourceReference = $APPLICATION_ID not found")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAedExplainerDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAedExplainerDocumentIntegrationTest.kt
@@ -4,9 +4,12 @@ import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
 import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
@@ -49,11 +52,16 @@ internal class GenerateAedExplainerDocumentIntegrationTest : IntegrationTest() {
             .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
+            .expectStatus()
+            .isEqualTo(NOT_FOUND)
+            .returnResult(ErrorResponse::class.java)
 
         // Then
-        response.expectStatus().isNotFound
-        val actual = response.returnResult(String::class.java).responseBody.blockFirst()
-        assertThat(actual).isEqualTo("Anonymous Elector Document explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(NOT_FOUND.value())
+            .hasError("Not Found")
+            .hasMessage("Anonymous Elector Document explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
     }
 
     @Test
@@ -73,11 +81,16 @@ internal class GenerateAedExplainerDocumentIntegrationTest : IntegrationTest() {
             .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
+            .expectStatus()
+            .isEqualTo(NOT_FOUND)
+            .returnResult(ErrorResponse::class.java)
 
         // Then
-        response.expectStatus().isNotFound
-        val actual = response.returnResult(String::class.java).responseBody.blockFirst()
-        assertThat(actual).isEqualTo("Anonymous Elector Document explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(NOT_FOUND.value())
+            .hasError("Not Found")
+            .hasMessage("Anonymous Elector Document explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateTemporaryCertificateExplainerDocumentIntegrationTest.kt
@@ -4,9 +4,12 @@ import com.lowagie.text.pdf.PdfReader
 import com.lowagie.text.pdf.parser.PdfTextExtractor
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.MediaType
 import uk.gov.dluhc.eromanagementapi.models.LocalAuthorityResponse
 import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert.Companion.assertThat
 import uk.gov.dluhc.printapi.testsupport.bearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidLocalAuthorityName
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
@@ -49,11 +52,16 @@ internal class GenerateTemporaryCertificateExplainerDocumentIntegrationTest : In
             .bearerToken(getVCAdminBearerToken(eroId = ERO_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
+            .expectStatus()
+            .isEqualTo(NOT_FOUND)
+            .returnResult(ErrorResponse::class.java)
 
         // Then
-        response.expectStatus().isNotFound
-        val actual = response.returnResult(String::class.java).responseBody.blockFirst()
-        assertThat(actual).isEqualTo("Temporary certificate explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(NOT_FOUND.value())
+            .hasError("Not Found")
+            .hasMessage("Temporary certificate explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
     }
 
     @Test
@@ -73,11 +81,16 @@ internal class GenerateTemporaryCertificateExplainerDocumentIntegrationTest : In
             .bearerToken(getVCAdminBearerToken(eroId = ERO_ID))
             .contentType(MediaType.APPLICATION_JSON)
             .exchange()
+            .expectStatus()
+            .isEqualTo(NOT_FOUND)
+            .returnResult(ErrorResponse::class.java)
 
         // Then
-        response.expectStatus().isNotFound
-        val actual = response.returnResult(String::class.java).responseBody.blockFirst()
-        assertThat(actual).isEqualTo("Temporary certificate explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual)
+            .hasStatus(NOT_FOUND.value())
+            .hasError("Not Found")
+            .hasMessage("Temporary certificate explainer document not found for eroId $ERO_ID and gssCode $GSS_CODE")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/models/ErrorResponseAssert.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/assertj/assertions/models/ErrorResponseAssert.kt
@@ -1,0 +1,99 @@
+package uk.gov.dluhc.printapi.testsupport.assertj.assertions.models
+
+import org.assertj.core.api.AbstractAssert
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import java.time.OffsetDateTime
+
+class ErrorResponseAssert(actual: ErrorResponse?) :
+    AbstractAssert<ErrorResponseAssert, ErrorResponse?>(actual, ErrorResponseAssert::class.java) {
+
+    companion object {
+        fun assertThat(actual: ErrorResponse?) = ErrorResponseAssert(actual)
+
+        fun assertThat(actual: WebTestClient.ResponseSpec): ErrorResponseAssert {
+            val returnResult = actual.returnResult(ErrorResponse::class.java).responseBody.blockFirst()
+            return assertThat(returnResult)
+        }
+    }
+
+    fun hasTimestampNotBefore(expected: OffsetDateTime): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (timestamp.isBefore(expected)) {
+                failWithMessage("Expected timestamp to not be before $expected, but was $timestamp")
+            }
+        }
+        return this
+    }
+
+    fun hasTimestampNotAfter(expected: OffsetDateTime): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (timestamp.isAfter(expected)) {
+                failWithMessage("Expected timestamp to not be after $expected, but was $timestamp")
+            }
+        }
+        return this
+    }
+
+    fun hasStatus(expected: Int): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (status != expected) {
+                failWithMessage("Expected status $expected, but was $status")
+            }
+        }
+        return this
+    }
+
+    fun hasError(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (error != expected) {
+                failWithMessage("Expected error $expected, but was $error")
+            }
+        }
+        return this
+    }
+
+    fun hasMessage(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (message != expected) {
+                failWithMessage("Expected message $expected, but was $message")
+            }
+        }
+        return this
+    }
+
+    fun hasMessageContaining(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (!message.contains(expected)) {
+                failWithMessage("Expected message to contain $expected, but was $message")
+            }
+        }
+        return this
+    }
+
+    fun hasValidationError(expected: String): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (validationErrors?.any { it == expected } != true) {
+                failWithMessage("Expected a validation message $expected, but was $validationErrors")
+            }
+        }
+        return this
+    }
+
+    fun hasNoValidationErrors(): ErrorResponseAssert {
+        isNotNull
+        with(actual!!) {
+            if (validationErrors != null) {
+                failWithMessage("Expected no validation messages, but was $validationErrors")
+            }
+        }
+        return this
+    }
+}


### PR DESCRIPTION
This PR updates the openAPI spec and various implementations to make the declaration of REST API error statuses and the implementation consistent (consistent both in terms of a consistent API, and also consistent with VCA in respect of implementation)