### PR TITLE
EIP1-4227 - Fix repository findBy method

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepository.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @Repository
 interface AnonymousElectorDocumentRepository : JpaRepository<AnonymousElectorDocument, UUID> {
 
-    fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): AnonymousElectorDocument?
+    fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
 
     fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): List<AnonymousElectorDocument>
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/TemporaryCertificateRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/TemporaryCertificateRepository.kt
@@ -10,7 +10,7 @@ import java.util.UUID
 @Repository
 interface TemporaryCertificateRepository : JpaRepository<TemporaryCertificate, UUID> {
 
-    fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): TemporaryCertificate?
+    fun findByGssCodeAndSourceTypeAndSourceReference(gssCode: String, sourceType: SourceType, sourceReference: String): List<TemporaryCertificate>
 
     fun findByGssCodeInAndSourceTypeAndSourceReference(gssCodes: List<String>, sourceType: SourceType, sourceReference: String): List<TemporaryCertificate>
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GenerateAnonymousElectorDocumentIntegrationTest.kt
@@ -225,30 +225,30 @@ internal class GenerateAnonymousElectorDocumentIntegrationTest : IntegrationTest
             .returnResult()
 
         // Then
-        val electorDocument = anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(
+        val electorDocuments = anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(
             request.gssCode,
             ANONYMOUS_ELECTOR_DOCUMENT,
             request.sourceReference
         )
 
-        assertThat(electorDocument).isNotNull
-        with(electorDocument!!) {
-            assertThat(statusHistory.size).isOne
-            assertThat(statusHistory.first().status).isEqualTo(AnonymousElectorDocumentStatus.Status.PRINTED)
+        assertThat(electorDocuments).isNotNull
+        electorDocuments.forEach {
+            assertThat(it.statusHistory.size).isOne
+            assertThat(it.statusHistory.first().status).isEqualTo(AnonymousElectorDocumentStatus.Status.PRINTED)
 
-            AnonymousElectorDocumentCertificateAssert(electorDocument)
+            AnonymousElectorDocumentCertificateAssert(it)
                 .hasId()
                 .hasDelivery(expectedDelivery)
                 .hasDateCreated()
 
             val contentDisposition = response.responseHeaders.contentDisposition
-            assertThat(contentDisposition.filename).isEqualTo("anonymous-elector-document-$certificateNumber.pdf")
+            assertThat(contentDisposition.filename).isEqualTo("anonymous-elector-document-${it.certificateNumber}.pdf")
 
             val pdfContent = response.responseBody
             assertThat(pdfContent).isNotNull
             PdfReader(pdfContent).use { reader ->
                 val text = PdfTextExtractor(reader).getTextFromPage(1)
-                assertThat(text).contains(certificateNumber)
+                assertThat(text).contains(it.certificateNumber)
                 assertThat(text).doesNotContainIgnoringCase(request.surname)
             }
         }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/AedDataRetentionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/AedDataRetentionServiceTest.kt
@@ -57,7 +57,7 @@ internal class AedDataRetentionServiceTest {
             val expectedInitialRetentionRemovalDate = LocalDate.of(2024, Month.APRIL, 1)
             val expectedFinalRetentionRemovalDate = LocalDate.of(2032, Month.JULY, 1)
             given(sourceTypeMapper.mapSqsToEntity(any())).willReturn(VOTER_CARD)
-            given(anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(anonymousElectorDocument)
+            given(anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(anonymousElectorDocument))
             given(removalDateResolver.getAedInitialRetentionPeriodRemovalDate(any())).willReturn(expectedInitialRetentionRemovalDate)
             given(removalDateResolver.getElectorDocumentFinalRetentionPeriodRemovalDate(any())).willReturn(expectedFinalRetentionRemovalDate)
 
@@ -80,7 +80,7 @@ internal class AedDataRetentionServiceTest {
                 sourceReference = "63774ff4bb4e7049b67182d9"
             )
             given(sourceTypeMapper.mapSqsToEntity(any())).willReturn(VOTER_CARD)
-            given(anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(null)
+            given(anonymousElectorDocumentRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(emptyList())
             TestLogAppender.reset()
 
             // When
@@ -93,8 +93,8 @@ internal class AedDataRetentionServiceTest {
             verifyNoInteractions(removalDateResolver)
             assertThat(
                 TestLogAppender.hasLog(
-                    "Anonymous Elector Document with sourceType = VOTER_CARD and sourceReference = 63774ff4bb4e7049b67182d9 not found",
-                    Level.ERROR
+                    "No Anonymous Elector Documents with sourceType = VOTER_CARD and sourceReference = 63774ff4bb4e7049b67182d9 found",
+                    Level.WARN
                 )
             ).isTrue
         }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/TemporaryCertificateDataRetentionServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/TemporaryCertificateDataRetentionServiceTest.kt
@@ -49,7 +49,7 @@ internal class TemporaryCertificateDataRetentionServiceTest {
             val temporaryCertificate = buildTemporaryCertificate(issueDate = issueDate)
             val expectedFinalRetentionRemovalDate = LocalDate.of(2024, JULY, 1)
             given(sourceTypeMapper.mapSqsToEntity(any())).willReturn(VOTER_CARD)
-            given(temporaryCertificateRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(temporaryCertificate)
+            given(temporaryCertificateRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(temporaryCertificate))
             given(removalDateResolver.getTempCertFinalRetentionPeriodRemovalDate(any())).willReturn(expectedFinalRetentionRemovalDate)
 
             // When
@@ -71,7 +71,7 @@ internal class TemporaryCertificateDataRetentionServiceTest {
                 sourceReference = "63774ff4bb4e7049b67182d9"
             )
             given(sourceTypeMapper.mapSqsToEntity(any())).willReturn(VOTER_CARD)
-            given(temporaryCertificateRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(null)
+            given(temporaryCertificateRepository.findByGssCodeAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(emptyList())
             TestLogAppender.reset()
 
             // When
@@ -84,8 +84,8 @@ internal class TemporaryCertificateDataRetentionServiceTest {
             verifyNoInteractions(removalDateResolver)
             assertThat(
                 TestLogAppender.hasLog(
-                    "Temporary certificate with sourceType = VOTER_CARD and sourceReference = 63774ff4bb4e7049b67182d9 not found",
-                    Level.ERROR
+                    "No Temporary Certificate with sourceType = VOTER_CARD and sourceReference = 63774ff4bb4e7049b67182d9 found",
+                    Level.WARN
                 )
             ).isTrue
         }


### PR DESCRIPTION
Fix to `findByGssCodeAndSourceTypeAndSourceReference()`, which returns a List, rather than single instance