### PR TITLE
EIP1-5159 - Added CorrelationIdRestTemplateClientHttpRequestInterceptor

### DIFF
--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestRestController.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestRestController.kt
@@ -1,0 +1,19 @@
+package uk.gov.dluhc.printapi.logging
+
+import mu.KotlinLogging
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * A simple REST Controller exposing a single endpoint to be used by [CorrelationIdMdcIntegrationTest]
+ */
+@RestController
+class TestRestController {
+
+    @GetMapping("/correlation-id-test-api")
+    fun correlationIdTestEndpoint() {
+        logger.info { "Test API successfully called" }
+    }
+}


### PR DESCRIPTION
This PR adds `CorrelationIdRestTemplateClientHttpRequestInterceptor` that can be used with `RestTemplate`; and also updates the integration tests so that the config class and its tests can be used "outside" of print-api (ie. so that we can move it into a shared library)

(not all the tests have been abstracted from print-api - still need to do the tests for the SQS listener and senders, and the scheduled jobs - we can look to do these another time)