### PR TITLE
EIP1-5311 - Refactored CorrelationIdMdcIntegrationTest

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -198,7 +198,7 @@ thread-pool:
 
 logging:
   pattern:
-    level: "%X{correlationId}%5p"
+    level: "%X{correlationId} %5p"
   level:
     com:
       jcraft:

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/LocalStackContainerConfiguration.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/LocalStackContainerConfiguration.kt
@@ -120,6 +120,8 @@ class LocalStackContainerConfiguration {
         val queueUrlProcessPrintResponses = localStackContainer.createSqsQueue(processPrintResponsesQueueName)
         val queueUrlApplicationRemoved = localStackContainer.createSqsQueue(applicationRemovedQueueName)
         val queueUrlRemoveCertificate = localStackContainer.createSqsQueue(removeCertificateQueueName)
+        localStackContainer.createSqsQueue("correlation-id-test-queue")
+
         val apiUrl = "http://${localStackContainer.host}:${localStackContainer.getMappedPort(DEFAULT_PORT)}"
 
         TestPropertyValues.of(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestScheduledJob.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestScheduledJob.kt
@@ -1,0 +1,16 @@
+package uk.gov.dluhc.printapi.logging
+
+import mu.KotlinLogging
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class TestScheduledJob {
+
+    @Scheduled(cron = Scheduled.CRON_DISABLED)
+    fun run() {
+        logger.info { "Test scheduled job successfully called" }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestSqsListener.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/logging/TestSqsListener.kt
@@ -1,0 +1,21 @@
+package uk.gov.dluhc.printapi.logging
+
+import io.awspring.cloud.messaging.listener.annotation.SqsListener
+import mu.KotlinLogging
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+@Component
+class TestSqsListener {
+
+    @SqsListener("correlation-id-test-queue")
+    fun handleMessage(payload: TestSqsMessage) {
+        logger.info { "Test SQS listener successfully called" }
+    }
+}
+
+data class TestSqsMessage(
+    val id: UUID = UUID.randomUUID()
+)


### PR DESCRIPTION
Refactored CorrelationIdMdcIntegrationTest so it is abstracted away from any print-api specific implementations
This means it will be much easier to pull out into the other API repos, and then into a shared library as and when we get there