### PR TITLE
Feature/EIP1-5662 Test for no results

### DIFF
--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
@@ -196,8 +196,6 @@ internal class GetAnonymousElectorDocumentsByApplicationIdIntegrationTest : Inte
 
         // Then
         val actual = response.responseBody.blockFirst()
-        assertThat(actual).isNotNull
-        assertThat(actual!!.anonymousElectorDocuments).isNotNull
-        assertThat(actual.anonymousElectorDocuments).isEmpty()
+        assertThat(actual!!.anonymousElectorDocuments).isEmpty()
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
@@ -174,4 +174,30 @@ internal class GetAnonymousElectorDocumentsByApplicationIdIntegrationTest : Inte
             .usingRecursiveComparison()
             .isEqualTo(listOf(expectedFirstRecord, expectedSecondRecord))
     }
+
+    @Test
+    fun `should return empty list given no AEDs exist for application ID`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        // When
+        val response = webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus().isOk
+            .returnResult(AnonymousElectorDocumentsResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        assertThat(actual).isNotNull
+        assertThat(actual!!.anonymousElectorDocuments).isNotNull
+        assertThat(actual.anonymousElectorDocuments).isEmpty()
+    }
 }


### PR DESCRIPTION
This PR adds an integration test to ensure an empty collection is returned if there are no AEDs for an applicationId.