### PR TITLE
EIP1:5626: Summary view repository and mappers + Liquibase 

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
@@ -1,0 +1,64 @@
+package uk.gov.dluhc.printapi.database.entity
+
+import org.hibernate.Hibernate
+import org.hibernate.annotations.Type
+import uk.gov.dluhc.printapi.database.repository.UUIDCharType
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.Id
+import javax.persistence.Table
+
+@Table(name = "v_anonymous_elector_document_summary")
+@Entity
+class AnonymousElectorDocumentSummary(
+
+    @Id
+    @Type(type = UUIDCharType)
+    var id: UUID,
+
+    var gssCode: String,
+
+    @Enumerated(EnumType.STRING)
+    var sourceType: SourceType,
+
+    var electoralRollNumber: String,
+
+    var sanitizedElectoralRollNumber: String,
+
+    var certificateNumber: String,
+
+    var sourceReference: String,
+
+    var applicationReference: String,
+
+    var issueDate: LocalDate,
+
+    var dateCreated: Instant,
+
+    var firstName: String,
+
+    var surname: String,
+
+    var sanitizedSurname: String,
+
+    var postcode: String
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+        other as AnonymousElectorDocumentSummary
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int = javaClass.hashCode()
+
+    @Override
+    override fun toString(): String {
+        return this::class.simpleName + "(gssCode = $gssCode, sourceReference = $sourceReference, applicationReference = $applicationReference)"
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AnonymousElectorDocumentSummary.kt
@@ -18,34 +18,21 @@ class AnonymousElectorDocumentSummary(
 
     @Id
     @Type(type = UUIDCharType)
-    var id: UUID,
-
-    var gssCode: String,
-
+    val id: UUID,
+    val gssCode: String,
     @Enumerated(EnumType.STRING)
-    var sourceType: SourceType,
-
-    var electoralRollNumber: String,
-
-    var sanitizedElectoralRollNumber: String,
-
-    var certificateNumber: String,
-
-    var sourceReference: String,
-
-    var applicationReference: String,
-
-    var issueDate: LocalDate,
-
-    var dateCreated: Instant,
-
-    var firstName: String,
-
-    var surname: String,
-
-    var sanitizedSurname: String,
-
-    var postcode: String
+    val sourceType: SourceType,
+    val electoralRollNumber: String,
+    val sanitizedElectoralRollNumber: String,
+    val certificateNumber: String,
+    val sourceReference: String,
+    val applicationReference: String,
+    val issueDate: LocalDate,
+    val dateCreated: Instant,
+    val firstName: String,
+    val surname: String,
+    val sanitizedSurname: String,
+    val postcode: String
 ) {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -59,6 +46,6 @@ class AnonymousElectorDocumentSummary(
 
     @Override
     override fun toString(): String {
-        return this::class.simpleName + "(gssCode = $gssCode, sourceReference = $sourceReference, applicationReference = $applicationReference)"
+        return this::class.simpleName + "(id = $id, gssCode = $gssCode, sourceReference = $sourceReference, applicationReference = $applicationReference)"
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.springframework.data.repository.PagingAndSortingRepository
+import org.springframework.stereotype.Repository
+import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
+import uk.gov.dluhc.printapi.database.entity.SourceType
+import java.util.UUID
+
+@Repository
+interface AnonymousElectorDocumentSummaryRepository :
+    PagingAndSortingRepository<AnonymousElectorDocumentSummary, UUID> {
+
+    fun findByGssCodeInAndSourceTypeOrderByIssueDateDescSanitizedSurnameAsc(
+        gssCodes: List<String>,
+        sourceType: SourceType,
+    ): List<AnonymousElectorDocumentSummary>
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
@@ -1,5 +1,7 @@
 package uk.gov.dluhc.printapi.database.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
@@ -10,8 +12,9 @@ import java.util.UUID
 interface AnonymousElectorDocumentSummaryRepository :
     PagingAndSortingRepository<AnonymousElectorDocumentSummary, UUID> {
 
-    fun findByGssCodeInAndSourceTypeOrderByIssueDateDescSanitizedSurnameAsc(
+    fun findAllByGssCodeInAndSourceType(
         gssCodes: List<String>,
         sourceType: SourceType,
-    ): List<AnonymousElectorDocumentSummary>
+        pageRequest: Pageable
+    ): Page<AnonymousElectorDocumentSummary>
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchSummaryDto.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.printapi.dto.aed
+
+import java.time.Instant
+import java.time.LocalDate
+
+class AnonymousSearchSummaryDto(
+    val gssCode: String,
+    val sourceReference: String,
+    val applicationReference: String,
+    val certificateNumber: String,
+    val electoralRollNumber: String,
+    val firstName: String,
+    val surname: String,
+    val postcode: String,
+    val issueDate: LocalDate,
+    val dateTimeCreated: Instant,
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapper.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.printapi.mapper.aed
+
+import org.mapstruct.Mapper
+import org.mapstruct.Mapping
+import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryDto
+import uk.gov.dluhc.printapi.mapper.InstantMapper
+import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary as AnonymousElectorDocumentSummaryEntity
+import uk.gov.dluhc.printapi.models.AedSearchSummary as AedSearchSummaryApi
+
+@Mapper(uses = [InstantMapper::class])
+interface AnonymousSearchSummaryMapper {
+
+    @Mapping(target = "dateTimeCreated", source = "dateCreated")
+    fun toAnonymousSearchSummaryDto(entity: AnonymousElectorDocumentSummaryEntity): AnonymousSearchSummaryDto
+
+    fun toAnonymousSearchSummaryApi(dto: AnonymousSearchSummaryDto): AedSearchSummaryApi
+}

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -34,4 +34,5 @@
     <include relativeToChangelogFile="true" file="ddl/0024_create_aed_summary_view.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0025_alter_aed_application_ref_not_null.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0026_alter_delivery_add_collection_reason.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0027_update_aed_summary_view.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0026_update_aed_summary_view.xml
+++ b/src/main/resources/db/changelog/ddl/0026_update_aed_summary_view.xml
@@ -31,14 +31,14 @@
                         gss_code,
                         source_type,
                         source_reference,
-                        max(request_date_time) as mostRecentRequestDateTime
+                        max(request_date_time) as most_recent_aed_request_date_time
                     FROM anonymous_elector_document
                     GROUP BY gss_code, source_type, source_reference
                 ) latest_aed_records_per_source_reference
             ON aed.gss_code = latest_aed_records_per_source_reference.gss_code
             AND aed.source_type = latest_aed_records_per_source_reference.source_type
             AND aed.source_reference = latest_aed_records_per_source_reference.source_reference
-            AND aed.request_date_time = latest_aed_records_per_source_reference.mostRecentRequestDateTime
+            AND aed.request_date_time = latest_aed_records_per_source_reference.most_recent_aed_request_date_time
         </createView>
 
         <rollback>

--- a/src/main/resources/db/changelog/ddl/0026_update_aed_summary_view.xml
+++ b/src/main/resources/db/changelog/ddl/0026_update_aed_summary_view.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="vishal.gupta@valtech.com" id="0026_update_aed_summary_view - Adds id to AED summary view" context="ddl">
+        <comment>Adding id to Anonymous Elector Document summary view</comment>
+        <createView viewName="v_anonymous_elector_document_summary" replaceIfExists = "true">
+            SELECT
+            aed.id,
+            aed.gss_code,
+            aed.source_type,
+            aed.electoral_roll_number,
+            aed.sanitized_electoral_roll_number,
+            aed.certificate_number,
+            aed.source_reference,
+            aed.application_reference,
+            aed.issue_date,
+            aed.date_created,
+            contact.first_name,
+            contact.surname,
+            contact.sanitized_surname,
+            addr.postcode
+            FROM anonymous_elector_document aed
+            JOIN aed_contact_details contact ON aed.aed_contact_details_id = contact.id
+            JOIN address addr on contact.address_id = addr.id
+            JOIN (
+                    SELECT
+                        gss_code,
+                        source_type,
+                        source_reference,
+                        max(request_date_time) as mostRecentRequestDateTime
+                    FROM anonymous_elector_document
+                    GROUP BY gss_code, source_type, source_reference
+                ) latest_aed_records_per_source_reference
+            ON aed.gss_code = latest_aed_records_per_source_reference.gss_code
+            AND aed.source_type = latest_aed_records_per_source_reference.source_type
+            AND aed.source_reference = latest_aed_records_per_source_reference.source_reference
+            AND aed.request_date_time = latest_aed_records_per_source_reference.mostRecentRequestDateTime
+        </createView>
+
+        <rollback>
+            <comment>Reverting to previous version of Anonymous Elector Document summary view</comment>
+            <createView viewName="v_anonymous_elector_document_summary" replaceIfExists = "true">
+                SELECT
+                aed.gss_code,
+                aed.source_type,
+                aed.electoral_roll_number,
+                aed.sanitized_electoral_roll_number,
+                aed.certificate_number,
+                aed.source_reference,
+                aed.application_reference,
+                aed.issue_date,
+                aed.date_created,
+                contact.first_name,
+                contact.surname,
+                contact.sanitized_surname,
+                addr.postcode
+                FROM anonymous_elector_document aed
+                JOIN aed_contact_details contact ON aed.aed_contact_details_id = contact.id
+                JOIN address addr on contact.address_id = addr.id
+                JOIN (
+                        SELECT
+                            gss_code,
+                            source_type,
+                            source_reference,
+                            max(request_date_time) as mostRecentRequestDateTime
+                        FROM anonymous_elector_document
+                        GROUP BY gss_code, source_type, source_reference
+                     ) latest_aed_records_per_source_reference
+                ON aed.gss_code = latest_aed_records_per_source_reference.gss_code
+                AND aed.source_type = latest_aed_records_per_source_reference.source_type
+                AND aed.source_reference = latest_aed_records_per_source_reference.source_reference
+                AND aed.request_date_time = latest_aed_records_per_source_reference.mostRecentRequestDateTime
+            </createView>
+        </rollback>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0027_update_aed_summary_view.xml
+++ b/src/main/resources/db/changelog/ddl/0027_update_aed_summary_view.xml
@@ -5,8 +5,8 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
 
-    <changeSet author="vishal.gupta@valtech.com" id="0026_update_aed_summary_view - Adds id to AED summary view" context="ddl">
-        <comment>Adding id to Anonymous Elector Document summary view</comment>
+    <changeSet author="vishal.gupta@valtech.com" id="0027_update_aed_summary_view - Adds aed id to an existing AED summary view" context="ddl">
+        <comment>Adding anonymous_elector_document id to existing Anonymous Elector Document summary view</comment>
         <createView viewName="v_anonymous_elector_document_summary" replaceIfExists = "true">
             SELECT
             aed.id,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/IntegrationTest.kt
@@ -33,6 +33,7 @@ import uk.gov.dluhc.printapi.client.BankHolidayDataClient
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_REQUEST_UPLOAD_PATH
 import uk.gov.dluhc.printapi.config.SftpContainerConfiguration.Companion.PRINT_RESPONSE_DOWNLOAD_PATH
 import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepository
+import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentSummaryRepository
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.database.repository.TemporaryCertificateRepository
 import uk.gov.dluhc.printapi.jobs.BatchPrintRequestsJob
@@ -144,6 +145,9 @@ internal abstract class IntegrationTest {
 
     @Autowired
     protected lateinit var anonymousElectorDocumentRepository: AnonymousElectorDocumentRepository
+
+    @Autowired
+    protected lateinit var anonymousElectorDocumentSummaryRepository: AnonymousElectorDocumentSummaryRepository
 
     @Autowired
     protected lateinit var testDeliveryRepository: TestDeliveryRepository

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
@@ -1,0 +1,100 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
+import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAedContactDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocumentSummaryViewFromAedEntity
+import java.time.LocalDate
+
+internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : IntegrationTest() {
+
+    @Nested
+    inner class FindByGssCodeInAndSourceTypeOrderByDateCreatedDescSanitizedSurnameAsc {
+
+        @Test
+        fun `should returns empty list when summary view has no records`() {
+            // Given
+            val gssCode = aGssCode()
+
+            // When
+            val actual = anonymousElectorDocumentSummaryRepository
+                .findByGssCodeInAndSourceTypeOrderByIssueDateDescSanitizedSurnameAsc(
+                    gssCodes = listOf(gssCode),
+                    sourceType = ANONYMOUS_ELECTOR_DOCUMENT
+                )
+
+            // Then
+            assertThat(actual).isNotNull.isEmpty()
+        }
+
+        @Test
+        fun `should returns empty list when no matching gssCode record exists`() {
+            // Given
+            val gssCode = aGssCode()
+            val otherAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
+            anonymousElectorDocumentRepository.saveAll(listOf(otherAed))
+
+            // When
+            val actual = anonymousElectorDocumentSummaryRepository
+                .findByGssCodeInAndSourceTypeOrderByIssueDateDescSanitizedSurnameAsc(
+                    gssCodes = listOf(gssCode),
+                    sourceType = ANONYMOUS_ELECTOR_DOCUMENT
+                )
+
+            // Then
+            assertThat(actual).isNotNull.isEmpty()
+        }
+
+        @Test
+        fun `should find AEDs for a given gssCode and source type in required ordering`() {
+            // Given
+            val gssCode = aGssCode()
+            val currentDate = LocalDate.now()
+
+            val aed1 = buildAnonymousElectorDocument(
+                gssCode = gssCode,
+                issueDate = currentDate.minusDays(10),
+                contactDetails = buildAedContactDetails(surname = "Z")
+            )
+            val aed2 = buildAnonymousElectorDocument(
+                gssCode = gssCode,
+                issueDate = currentDate.minusDays(10),
+                contactDetails = buildAedContactDetails(surname = "A")
+            )
+            val aed3 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(10))
+            val aed4 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
+            val otherAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
+
+            anonymousElectorDocumentRepository.saveAll(listOf(aed1, aed2, aed3, aed4, otherAed))
+
+            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed3)
+            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed4)
+            val expectedSummaryRecord3 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed2)
+            val expectedSummaryRecord4 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed1)
+            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherAed)
+
+            // When
+            val actual = anonymousElectorDocumentSummaryRepository
+                .findByGssCodeInAndSourceTypeOrderByIssueDateDescSanitizedSurnameAsc(
+                    gssCodes = listOf(gssCode),
+                    sourceType = ANONYMOUS_ELECTOR_DOCUMENT
+                )
+
+            // Then
+            assertThat(actual)
+                .doesNotContain(otherAedSummaryRecord)
+                .containsExactlyInAnyOrder(
+                    expectedSummaryRecord1,
+                    expectedSummaryRecord2,
+                    expectedSummaryRecord3,
+                    expectedSummaryRecord4
+                )
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
@@ -23,7 +23,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
     inner class FindByGssCodeInAndSourceTypeOrderByDateCreatedDescSanitizedSurnameAsc {
 
         @Test
-        fun `should returns empty list when summary view has no records`() {
+        fun `should return empty list when summary view has no records`() {
             // Given
             val gssCode = aGssCode()
 
@@ -40,7 +40,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
         }
 
         @Test
-        fun `should returns empty list when no matching gssCode record exists`() {
+        fun `should return empty list when no matching gssCode record exists`() {
             // Given
             val gssCode = aGssCode()
             val otherAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
@@ -67,7 +67,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
             val aed1SourceReference = aValidSourceReference()
             val aed1ApplicationReference = aValidApplicationReference()
 
-            val aed1InitialDocument = buildAnonymousElectorDocument(
+            val application1InitialAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
@@ -75,26 +75,26 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
                 requestDateTime = currentDateTimeInstant.minusSeconds(10),
                 contactDetails = buildAedContactDetails(surname = "A")
             )
-            val aed1SecondDocument = buildAnonymousElectorDocument(
+            val application1SecondAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
                 issueDate = currentDate.minusDays(10),
                 requestDateTime = currentDateTimeInstant.minusSeconds(9),
-                contactDetails = aed1InitialDocument.contactDetails!!
+                contactDetails = application1InitialAed.contactDetails!!
             )
-            val aed1LatestDocument = buildAnonymousElectorDocument(
+            val application1LatestAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant, // View will return this latest record
-                contactDetails = aed1InitialDocument.contactDetails!!
+                contactDetails = application1InitialAed.contactDetails!!
             )
 
             val aed2SourceReference = aValidSourceReference()
             val aed2ApplicationReference = aValidApplicationReference()
-            val aed2InitialDocument = buildAnonymousElectorDocument(
+            val application2InitialAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
@@ -102,39 +102,39 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
                 requestDateTime = currentDateTimeInstant.minusSeconds(10),
                 contactDetails = buildAedContactDetails(surname = "Z")
             )
-            val aed2SecondDocument = buildAnonymousElectorDocument(
+            val application2SecondAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant.minusSeconds(8),
-                contactDetails = aed2InitialDocument.contactDetails!!
+                contactDetails = application2InitialAed.contactDetails!!
             )
-            val aed2LatestDocument = buildAnonymousElectorDocument(
+            val application2LatestAed = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant, // View will return this latest record
-                contactDetails = aed2InitialDocument.contactDetails!!
+                contactDetails = application2InitialAed.contactDetails!!
             )
-            val aed3Document = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(10))
-            val aed4Document = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
-            val otherAedDocument = buildAnonymousElectorDocument(gssCode = anotherGssCode())
+            val application3AedDocument = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(10))
+            val application4AedDocument = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
+            val otherApplicationAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
 
             anonymousElectorDocumentRepository.saveAll(
                 listOf(
-                    aed1InitialDocument, aed1SecondDocument, aed1LatestDocument,
-                    aed2InitialDocument, aed2SecondDocument, aed2LatestDocument,
-                    aed3Document, aed4Document, otherAedDocument
+                    application1InitialAed, application1SecondAed, application1LatestAed,
+                    application2InitialAed, application2SecondAed, application2LatestAed,
+                    application3AedDocument, application4AedDocument, otherApplicationAed
                 )
             )
 
-            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed3Document)
-            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed4Document)
-            val expectedSummaryRecord3 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed1LatestDocument)
-            val expectedSummaryRecord4 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed2LatestDocument)
-            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherAedDocument)
+            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application3AedDocument)
+            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application4AedDocument)
+            val expectedSummaryRecord3 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application1LatestAed)
+            val expectedSummaryRecord4 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application2LatestAed)
+            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherApplicationAed)
 
             // When
             val actual = anonymousElectorDocumentSummaryRepository
@@ -161,17 +161,17 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
             val gssCode = aGssCode()
             val currentDate = LocalDate.now()
 
-            val aed1 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
-            val aed2 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
-            val aed3 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(1))
-            val aed4 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(2))
-            val otherAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
+            val application1Aed = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
+            val application2Aed = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
+            val application3Aed = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(1))
+            val application4Aed = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(2))
+            val otherApplicationAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
 
-            anonymousElectorDocumentRepository.saveAll(listOf(aed1, aed2, aed3, aed4, otherAed))
+            anonymousElectorDocumentRepository.saveAll(listOf(application1Aed, application2Aed, application3Aed, application4Aed, otherApplicationAed))
 
-            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed3)
-            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed4)
-            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherAed)
+            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application3Aed)
+            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(application4Aed)
+            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherApplicationAed)
 
             // When
             val actual = anonymousElectorDocumentSummaryRepository

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepositoryIntegrationTest.kt
@@ -59,7 +59,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
         }
 
         @Test
-        fun `should find all AEDs for a given gssCode and source type pages`() {
+        fun `should find all AEDs for a given gssCode and source type`() {
             // Given
             val gssCode = aGssCode()
             val currentDate = LocalDate.now()
@@ -67,7 +67,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
             val aed1SourceReference = aValidSourceReference()
             val aed1ApplicationReference = aValidApplicationReference()
 
-            val aed1FirstCertificate = buildAnonymousElectorDocument(
+            val aed1InitialDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
@@ -75,26 +75,26 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
                 requestDateTime = currentDateTimeInstant.minusSeconds(10),
                 contactDetails = buildAedContactDetails(surname = "A")
             )
-            val aed1SecondCertificate = buildAnonymousElectorDocument(
+            val aed1SecondDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
                 issueDate = currentDate.minusDays(10),
                 requestDateTime = currentDateTimeInstant.minusSeconds(9),
-                contactDetails = aed1FirstCertificate.contactDetails!!
+                contactDetails = aed1InitialDocument.contactDetails!!
             )
-            val aed1LatestCertificate = buildAnonymousElectorDocument(
+            val aed1LatestDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed1SourceReference,
                 applicationReference = aed1ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant, // View will return this latest record
-                contactDetails = aed1FirstCertificate.contactDetails!!
+                contactDetails = aed1InitialDocument.contactDetails!!
             )
 
             val aed2SourceReference = aValidSourceReference()
             val aed2ApplicationReference = aValidApplicationReference()
-            val aed2FirstCertificate = buildAnonymousElectorDocument(
+            val aed2InitialDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
@@ -102,39 +102,39 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
                 requestDateTime = currentDateTimeInstant.minusSeconds(10),
                 contactDetails = buildAedContactDetails(surname = "Z")
             )
-            val aed2SecondCertificate = buildAnonymousElectorDocument(
+            val aed2SecondDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant.minusSeconds(8),
-                contactDetails = aed2FirstCertificate.contactDetails!!
+                contactDetails = aed2InitialDocument.contactDetails!!
             )
-            val aed2LatestCertificate = buildAnonymousElectorDocument(
+            val aed2LatestDocument = buildAnonymousElectorDocument(
                 gssCode = gssCode,
                 sourceReference = aed2SourceReference,
                 applicationReference = aed2ApplicationReference,
                 issueDate = currentDate.minusDays(9),
                 requestDateTime = currentDateTimeInstant, // View will return this latest record
-                contactDetails = aed2FirstCertificate.contactDetails!!
+                contactDetails = aed2InitialDocument.contactDetails!!
             )
-            val aed3 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(10))
-            val aed4 = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
-            val otherAed = buildAnonymousElectorDocument(gssCode = anotherGssCode())
+            val aed3Document = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate.plusDays(10))
+            val aed4Document = buildAnonymousElectorDocument(gssCode = gssCode, issueDate = currentDate)
+            val otherAedDocument = buildAnonymousElectorDocument(gssCode = anotherGssCode())
 
             anonymousElectorDocumentRepository.saveAll(
                 listOf(
-                    aed1FirstCertificate, aed1SecondCertificate, aed1LatestCertificate,
-                    aed2FirstCertificate, aed2SecondCertificate, aed2LatestCertificate,
-                    aed3, aed4, otherAed
+                    aed1InitialDocument, aed1SecondDocument, aed1LatestDocument,
+                    aed2InitialDocument, aed2SecondDocument, aed2LatestDocument,
+                    aed3Document, aed4Document, otherAedDocument
                 )
             )
 
-            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed3)
-            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed4)
-            val expectedSummaryRecord3 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed1LatestCertificate)
-            val expectedSummaryRecord4 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed2LatestCertificate)
-            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherAed)
+            val expectedSummaryRecord1 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed3Document)
+            val expectedSummaryRecord2 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed4Document)
+            val expectedSummaryRecord3 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed1LatestDocument)
+            val expectedSummaryRecord4 = buildAnonymousElectorDocumentSummaryViewFromAedEntity(aed2LatestDocument)
+            val otherAedSummaryRecord = buildAnonymousElectorDocumentSummaryViewFromAedEntity(otherAedDocument)
 
             // When
             val actual = anonymousElectorDocumentSummaryRepository
@@ -156,7 +156,7 @@ internal class AnonymousElectorDocumentSummaryRepositoryIntegrationTest : Integr
         }
 
         @Test
-        fun `should find AEDs for a given gssCode and source type for matching page`() {
+        fun `should find AEDs for a given gssCode and source type for a matching page`() {
             // Given
             val gssCode = aGssCode()
             val currentDate = LocalDate.now()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.dluhc.printapi.mapper.aed
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -27,69 +26,62 @@ class AnonymousSearchSummaryMapperTest {
     @InjectMocks
     private lateinit var mapper: AnonymousSearchSummaryMapperImpl
 
-    @Nested
-    inner class ToAnonymousSearchSummaryDto {
-
-        @Test
-        fun `should map AnonymousElectorDocumentSummary Entity to an AnonymousSearchSummaryDto`() {
-            // Given
-            val entity = buildAnonymousElectorDocumentSummaryEntity()
-            val expected = with(entity) {
-                buildAnonymousSearchSummaryDto(
-                    gssCode = gssCode,
-                    sourceReference = sourceReference,
-                    applicationReference = applicationReference,
-                    certificateNumber = certificateNumber,
-                    electoralRollNumber = electoralRollNumber,
-                    firstName = firstName,
-                    surname = surname,
-                    postcode = postcode,
-                    issueDate = issueDate,
-                    dateTimeCreated = dateCreated,
-                )
-            }
-
-            // When
-            val actual = mapper.toAnonymousSearchSummaryDto(entity)
-
-            // Then
-            assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
-            verifyNoInteractions(instantMapper)
+    @Test
+    fun `should map AnonymousElectorDocumentSummary Entity to an AnonymousSearchSummaryDto`() {
+        // Given
+        val entity = buildAnonymousElectorDocumentSummaryEntity()
+        val expected = with(entity) {
+            buildAnonymousSearchSummaryDto(
+                gssCode = gssCode,
+                sourceReference = sourceReference,
+                applicationReference = applicationReference,
+                certificateNumber = certificateNumber,
+                electoralRollNumber = electoralRollNumber,
+                firstName = firstName,
+                surname = surname,
+                postcode = postcode,
+                issueDate = issueDate,
+                dateTimeCreated = dateCreated,
+            )
         }
+
+        // When
+        val actual = mapper.toAnonymousSearchSummaryDto(entity)
+
+        // Then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+        verifyNoInteractions(instantMapper)
     }
 
-    @Nested
-    inner class ToAnonymousSearchSummaryApi {
-        @Test
-        fun `should map AnonymousSearchSummaryDto to an AedSearchSummary Api`() {
-            // Given
-            val dto = buildAnonymousSearchSummaryDto()
-            val expectedOffsetDateTime = OffsetDateTime.now()
+    @Test
+    fun `should map AnonymousSearchSummaryDto to an AedSearchSummary Api`() {
+        // Given
+        val dto = buildAnonymousSearchSummaryDto()
+        val expectedOffsetDateTime = OffsetDateTime.now()
 
-            given(instantMapper.toOffsetDateTime(any())).willReturn(expectedOffsetDateTime)
+        given(instantMapper.toOffsetDateTime(any())).willReturn(expectedOffsetDateTime)
 
-            val expected = with(dto) {
-                buildAedSearchSummaryApi(
-                    gssCode = gssCode,
-                    sourceReference = sourceReference,
-                    applicationReference = applicationReference,
-                    certificateNumber = certificateNumber,
-                    electoralRollNumber = electoralRollNumber,
-                    firstName = firstName,
-                    surname = surname,
-                    postcode = postcode,
-                    issueDate = issueDate,
-                    dateTimeCreated = expectedOffsetDateTime,
-                )
-            }
-
-            // When
-            val actual = mapper.toAnonymousSearchSummaryApi(dto)
-
-            // Then
-            assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
-            verify(instantMapper).toOffsetDateTime(dto.dateTimeCreated)
-            verifyNoMoreInteractions(instantMapper)
+        val expected = with(dto) {
+            buildAedSearchSummaryApi(
+                gssCode = gssCode,
+                sourceReference = sourceReference,
+                applicationReference = applicationReference,
+                certificateNumber = certificateNumber,
+                electoralRollNumber = electoralRollNumber,
+                firstName = firstName,
+                surname = surname,
+                postcode = postcode,
+                issueDate = issueDate,
+                dateTimeCreated = expectedOffsetDateTime,
+            )
         }
+
+        // When
+        val actual = mapper.toAnonymousSearchSummaryApi(dto)
+
+        // Then
+        assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+        verify(instantMapper).toOffsetDateTime(dto.dateTimeCreated)
+        verifyNoMoreInteractions(instantMapper)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousSearchSummaryMapperTest.kt
@@ -1,0 +1,95 @@
+package uk.gov.dluhc.printapi.mapper.aed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.dluhc.printapi.mapper.InstantMapper
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildAnonymousSearchSummaryDto
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocumentSummaryEntity
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildAedSearchSummaryApi
+import java.time.OffsetDateTime
+
+@ExtendWith(MockitoExtension::class)
+class AnonymousSearchSummaryMapperTest {
+
+    @Mock
+    private lateinit var instantMapper: InstantMapper
+
+    @InjectMocks
+    private lateinit var mapper: AnonymousSearchSummaryMapperImpl
+
+    @Nested
+    inner class ToAnonymousSearchSummaryDto {
+
+        @Test
+        fun `should map AnonymousElectorDocumentSummary Entity to an AnonymousSearchSummaryDto`() {
+            // Given
+            val entity = buildAnonymousElectorDocumentSummaryEntity()
+            val expected = with(entity) {
+                buildAnonymousSearchSummaryDto(
+                    gssCode = gssCode,
+                    sourceReference = sourceReference,
+                    applicationReference = applicationReference,
+                    certificateNumber = certificateNumber,
+                    electoralRollNumber = electoralRollNumber,
+                    firstName = firstName,
+                    surname = surname,
+                    postcode = postcode,
+                    issueDate = issueDate,
+                    dateTimeCreated = dateCreated,
+                )
+            }
+
+            // When
+            val actual = mapper.toAnonymousSearchSummaryDto(entity)
+
+            // Then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+            verifyNoInteractions(instantMapper)
+        }
+    }
+
+    @Nested
+    inner class ToAnonymousSearchSummaryApi {
+        @Test
+        fun `should map AnonymousSearchSummaryDto to an AedSearchSummary Api`() {
+            // Given
+            val dto = buildAnonymousSearchSummaryDto()
+            val expectedOffsetDateTime = OffsetDateTime.now()
+
+            given(instantMapper.toOffsetDateTime(any())).willReturn(expectedOffsetDateTime)
+
+            val expected = with(dto) {
+                buildAedSearchSummaryApi(
+                    gssCode = gssCode,
+                    sourceReference = sourceReference,
+                    applicationReference = applicationReference,
+                    certificateNumber = certificateNumber,
+                    electoralRollNumber = electoralRollNumber,
+                    firstName = firstName,
+                    surname = surname,
+                    postcode = postcode,
+                    issueDate = issueDate,
+                    dateTimeCreated = expectedOffsetDateTime,
+                )
+            }
+
+            // When
+            val actual = mapper.toAnonymousSearchSummaryApi(dto)
+
+            // Then
+            assertThat(actual).usingRecursiveComparison().isEqualTo(expected)
+            verify(instantMapper).toOffsetDateTime(dto.dateTimeCreated)
+            verifyNoMoreInteractions(instantMapper)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/DataBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/DataBuilder.kt
@@ -9,6 +9,8 @@ fun aValidCertificateNumber() = CertificateNumber.create()
 
 fun aGssCode() = "E99999999"
 
+fun anotherGssCode() = "E11111111"
+
 fun aValidPrintRequestsFilename() = "05372cf5339447b39f98b248c2217b9f-20221018112232123-10.psv"
 
 fun aValidZipFilename() = "05372cf5339447b39f98b248c2217b9f-20221018112232123-10.zip"

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/AnonymousSearchSummaryDtoBuilder.kt
@@ -1,0 +1,41 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.dto.aed
+
+import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryDto
+import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
+import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidElectoralRollNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidFirstName
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
+import java.time.Instant
+import java.time.LocalDate
+
+fun buildAnonymousSearchSummaryDto(
+    gssCode: String = aGssCode(),
+    sourceReference: String = aValidSourceReference(),
+    applicationReference: String = aValidApplicationReference(),
+    certificateNumber: String = aValidVacNumber(),
+    electoralRollNumber: String = aValidElectoralRollNumber(),
+    issueDate: LocalDate = aValidIssueDate(),
+    dateTimeCreated: Instant = aValidRequestDateTime(),
+    firstName: String = aValidFirstName(),
+    surname: String = aValidSurname(),
+    postcode: String = faker.address().postcode(),
+): AnonymousSearchSummaryDto {
+    return AnonymousSearchSummaryDto(
+        gssCode = gssCode,
+        sourceReference = sourceReference,
+        applicationReference = applicationReference,
+        certificateNumber = certificateNumber,
+        electoralRollNumber = electoralRollNumber,
+        issueDate = issueDate,
+        dateTimeCreated = dateTimeCreated,
+        firstName = firstName,
+        surname = surname,
+        postcode = postcode
+    )
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
@@ -1,0 +1,76 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.entity
+
+import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
+import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
+import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
+import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidElectoralRollNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidFirstName
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.anAnonymousElectorDocumentSourceType
+import java.time.Instant
+import java.time.LocalDate
+import java.util.UUID
+
+fun buildAnonymousElectorDocumentSummaryEntity(
+    id: UUID = UUID.randomUUID(),
+    gssCode: String = aGssCode(),
+    sourceType: SourceType = anAnonymousElectorDocumentSourceType(),
+    sourceReference: String = aValidSourceReference(),
+    applicationReference: String = aValidApplicationReference(),
+    certificateNumber: String = aValidVacNumber(),
+    electoralRollNumber: String = aValidElectoralRollNumber(),
+    issueDate: LocalDate = aValidIssueDate(),
+    dateCreated: Instant = aValidRequestDateTime(),
+    firstName: String = aValidFirstName(),
+    surname: String = aValidSurname(),
+    postcode: String = faker.address().postcode(),
+): AnonymousElectorDocumentSummary {
+    return AnonymousElectorDocumentSummary(
+        id = id,
+        gssCode = gssCode,
+        sourceType = sourceType,
+        sourceReference = sourceReference,
+        applicationReference = applicationReference,
+        certificateNumber = certificateNumber,
+        electoralRollNumber = electoralRollNumber,
+        sanitizedElectoralRollNumber = electoralRollNumber,
+        issueDate = issueDate,
+        dateCreated = dateCreated,
+        firstName = firstName,
+        surname = surname,
+        sanitizedSurname = surname,
+        postcode = postcode
+    )
+}
+
+fun buildAnonymousElectorDocumentSummaryViewFromAedEntity(
+    aedEntity: AnonymousElectorDocument,
+    electoralRollNumber: String = aedEntity.electoralRollNumber,
+    surname: String = aedEntity.contactDetails!!.surname
+): AnonymousElectorDocumentSummary {
+    return with(aedEntity) {
+        AnonymousElectorDocumentSummary(
+            id = id!!,
+            gssCode = gssCode,
+            sourceType = sourceType,
+            sourceReference = sourceReference,
+            applicationReference = applicationReference!!,
+            certificateNumber = certificateNumber,
+            electoralRollNumber = electoralRollNumber,
+            sanitizedElectoralRollNumber = electoralRollNumber,
+            firstName = contactDetails!!.firstName,
+            surname = surname,
+            sanitizedSurname = surname,
+            postcode = contactDetails!!.address!!.postcode!!,
+            issueDate = issueDate,
+            dateCreated = requestDateTime
+        )
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentSummaryBuilder.kt
@@ -61,7 +61,7 @@ fun buildAnonymousElectorDocumentSummaryViewFromAedEntity(
             gssCode = gssCode,
             sourceType = sourceType,
             sourceReference = sourceReference,
-            applicationReference = applicationReference!!,
+            applicationReference = applicationReference,
             certificateNumber = certificateNumber,
             electoralRollNumber = electoralRollNumber,
             sanitizedElectoralRollNumber = electoralRollNumber,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AedSummaryBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AedSummaryBuilder.kt
@@ -1,0 +1,41 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.model
+
+import uk.gov.dluhc.printapi.models.AedSearchSummary
+import uk.gov.dluhc.printapi.testsupport.testdata.DataFaker.Companion.faker
+import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidElectoralRollNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidFirstName
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidGeneratedDateTime
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+fun buildAedSearchSummaryApi(
+    gssCode: String = aGssCode(),
+    sourceReference: String = aValidSourceReference(),
+    applicationReference: String = aValidApplicationReference(),
+    certificateNumber: String = aValidVacNumber(),
+    electoralRollNumber: String = aValidElectoralRollNumber(),
+    issueDate: LocalDate = aValidIssueDate(),
+    dateTimeCreated: OffsetDateTime = aValidGeneratedDateTime(),
+    firstName: String = aValidFirstName(),
+    surname: String = aValidSurname(),
+    postcode: String = faker.address().postcode(),
+): AedSearchSummary {
+    return AedSearchSummary(
+        gssCode = gssCode,
+        sourceReference = sourceReference,
+        applicationReference = applicationReference,
+        certificateNumber = certificateNumber,
+        electoralRollNumber = electoralRollNumber,
+        issueDate = issueDate,
+        dateTimeCreated = dateTimeCreated,
+        firstName = firstName,
+        surname = surname,
+        postcode = postcode
+    )
+}


### PR DESCRIPTION
- New view updated to include `id` of `anonymous_elector_document` entity
- Added repository and it's int test
- Added mapper that will be used by service and controller in subsequent PRs