### PR TITLE
Feature/EIP1-5685 Persist collection reason

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/CertificateDelivery.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/CertificateDelivery.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.printapi.dto
 data class CertificateDelivery(
     val deliveryClass: DeliveryClass,
     val deliveryAddressType: DeliveryAddressType,
+    val collectionReason: String?,
     val addressee: String,
     val deliveryAddress: AddressDto,
     val addressFormat: AddressFormat,

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.15.0'
+  version: '1.15.1'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -994,6 +994,10 @@ components:
           $ref: '#/components/schemas/DeliveryClass'
         deliveryAddressType:
           $ref: '#/components/schemas/DeliveryAddressType'
+        collectionReason:
+          type: string
+          maxLength: 1024
+          description: The reason the elector gave for having to collect their voter ID (if applicable).
         addressee:
           type: string
           maxLength: 255

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/CertificateDeliveryDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/CertificateDeliveryDtoBuilder.kt
@@ -13,11 +13,13 @@ fun buildDtoCertificateDelivery(
     deliveryAddress: AddressDto = buildValidAddressDto(),
     deliveryClass: DeliveryClass = DeliveryClass.STANDARD,
     deliveryAddressType: DeliveryAddressType = DeliveryAddressType.REGISTERED,
+    collectionReason: String? = null,
     addressFormat: AddressFormat = AddressFormat.UK,
 ): CertificateDelivery = CertificateDelivery(
     addressee = addressee,
     deliveryAddress = deliveryAddress,
     deliveryClass = deliveryClass,
     deliveryAddressType = deliveryAddressType,
+    collectionReason = collectionReason,
     addressFormat = addressFormat,
 )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/CertificateDeliveryApiBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/CertificateDeliveryApiBuilder.kt
@@ -12,11 +12,13 @@ fun buildApiCertificateDelivery(
     deliveryAddress: Address = buildValidAddress(),
     deliveryClass: DeliveryClass = DeliveryClass.STANDARD,
     deliveryAddressType: DeliveryAddressType = DeliveryAddressType.REGISTERED,
+    collectionReason: String? = null,
     addressFormat: AddressFormat = AddressFormat.UK,
 ): CertificateDelivery = CertificateDelivery(
     addressee = addressee,
     deliveryAddress = deliveryAddress,
     deliveryClass = deliveryClass,
     deliveryAddressType = deliveryAddressType,
+    collectionReason = collectionReason,
     addressFormat = addressFormat,
 )


### PR DESCRIPTION
This PR persists the reason the elector gave for having to collect their AED (if applicable).