### PR TITLE
EIP1-5615 / EIP1-5658 - Added mappings for electoralRollNumber, userId, deliveryAddressType

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
@@ -1,7 +1,9 @@
 package uk.gov.dluhc.printapi.mapper.aed
 
+import org.mapstruct.AfterMapping
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.mapstruct.MappingTarget
 import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentStatus
@@ -26,6 +28,9 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
     @Autowired
     protected lateinit var aedMappingHelper: AedMappingHelper
 
+    @Autowired
+    protected lateinit var deliveryAddressTypeMapper: DeliveryAddressTypeMapper
+
     abstract fun toReIssueAnonymousElectorDocumentDto(
         apiRequest: ReIssueAnonymousElectorDocumentRequest,
         userId: String
@@ -35,6 +40,9 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
     @Mapping(target = "issueDate", expression = "java( aedMappingHelper.issueDate() )")
     @Mapping(target = "requestDateTime", expression = "java( aedMappingHelper.requestDateTime() )")
     @Mapping(target = "statusHistory", expression = "java( aedMappingHelper.statusHistory(Status.PRINTED) )")
+    @Mapping(target = "sourceReference", source = "previousAed.sourceReference")
+    @Mapping(target = "electoralRollNumber", source = "dto.electoralRollNumber")
+    @Mapping(target = "userId", source = "dto.userId")
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "delivery.id", ignore = true)
     @Mapping(target = "delivery.address.id", ignore = true)
@@ -42,6 +50,15 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
     @Mapping(target = "contactDetails.address.id", ignore = true)
     abstract fun toNewAnonymousElectorDocument(
         previousAed: AnonymousElectorDocument,
+        dto: ReIssueAnonymousElectorDocumentDto,
         aedTemplateFilename: String
     ): AnonymousElectorDocument
+
+    @AfterMapping
+    protected fun setDeliveryAddressTypeInNewAnonymousElectorDocument(
+        @MappingTarget aed: AnonymousElectorDocument,
+        dto: ReIssueAnonymousElectorDocumentDto,
+    ) {
+        aed.delivery?.deliveryAddressType = deliveryAddressTypeMapper.mapDtoToEntity(dto.deliveryAddressType)
+    }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
@@ -50,7 +50,7 @@ class AnonymousElectorDocumentService(
             .firstOrNull() ?: throw CertificateNotFoundException(eroId, ANONYMOUS_ELECTOR_DOCUMENT, dto.sourceReference)
 
         val templateFilename = pdfTemplateDetailsFactory.getTemplateFilename(mostRecentAed.gssCode)
-        with(reIssueAnonymousElectorDocumentMapper.toNewAnonymousElectorDocument(mostRecentAed, templateFilename)) {
+        with(reIssueAnonymousElectorDocumentMapper.toNewAnonymousElectorDocument(mostRecentAed, dto, templateFilename)) {
             return generatePdf()
                 .also { anonymousElectorDocumentRepository.save(this) }
         }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapperTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentStatus
 import uk.gov.dluhc.printapi.database.entity.DeliveryAddressType
 import uk.gov.dluhc.printapi.dto.DeliveryAddressType.ERO_COLLECTION
+import uk.gov.dluhc.printapi.dto.DeliveryAddressType.REGISTERED
 import uk.gov.dluhc.printapi.dto.aed.ReIssueAnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
 import uk.gov.dluhc.printapi.models.DeliveryAddressType.ERO_MINUS_COLLECTION
@@ -23,6 +24,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildReIssueAnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildDelivery
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildReIssueAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.temporarycertificates.aTemplateFilename
 import java.time.Instant
@@ -92,6 +94,10 @@ class ReIssueAnonymousElectorDocumentMapperTest {
             sourceReference = sourceReference,
             certificateNumber = aValidVacNumber(),
             electoralRollNumber = originalElectoralRollNumber,
+            delivery = buildDelivery(
+                deliveryAddressType = DeliveryAddressType.ERO_COLLECTION,
+                collectionReason = "There is a postal strike"
+            ),
         )
         val templateFilename = aTemplateFilename()
 
@@ -112,11 +118,11 @@ class ReIssueAnonymousElectorDocumentMapperTest {
         val dto = buildReIssueAnonymousElectorDocumentDto(
             sourceReference = sourceReference,
             electoralRollNumber = newElectoralRollNumber,
-            deliveryAddressType = ERO_COLLECTION,
+            deliveryAddressType = REGISTERED,
             userId = userId
         )
 
-        given(deliveryAddressTypeMapper.mapDtoToEntity(any())).willReturn(DeliveryAddressType.ERO_COLLECTION)
+        given(deliveryAddressTypeMapper.mapDtoToEntity(any())).willReturn(DeliveryAddressType.REGISTERED)
 
         val expected = previousAed.deepCopy().apply {
             certificateNumber = newCertificateNumber
@@ -124,7 +130,8 @@ class ReIssueAnonymousElectorDocumentMapperTest {
             issueDate = FIXED_DATE
             statusHistory = expectedStatusHistory.toMutableList()
             electoralRollNumber = newElectoralRollNumber
-            delivery?.deliveryAddressType = DeliveryAddressType.ERO_COLLECTION
+            delivery?.deliveryAddressType = DeliveryAddressType.REGISTERED
+            delivery?.collectionReason = "There is a postal strike"
             this.userId = userId
         }
 
@@ -142,6 +149,6 @@ class ReIssueAnonymousElectorDocumentMapperTest {
         verify(aedMappingHelper).issueDate()
         verify(aedMappingHelper).requestDateTime()
         verify(aedMappingHelper).statusHistory(AnonymousElectorDocumentStatus.Status.PRINTED)
-        verify(deliveryAddressTypeMapper).mapDtoToEntity(ERO_COLLECTION)
+        verify(deliveryAddressTypeMapper).mapDtoToEntity(REGISTERED)
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
@@ -263,7 +263,7 @@ internal class AnonymousElectorDocumentServiceTest {
             val newlyIssuedAed = buildAnonymousElectorDocument(
                 certificateNumber = certificateNumber
             )
-            given(reIssueAnonymousElectorDocumentMapper.toNewAnonymousElectorDocument(any(), any()))
+            given(reIssueAnonymousElectorDocumentMapper.toNewAnonymousElectorDocument(any(), any(), any()))
                 .willReturn(newlyIssuedAed)
 
             val dto = buildReIssueAnonymousElectorDocumentDto(
@@ -281,7 +281,7 @@ internal class AnonymousElectorDocumentServiceTest {
             verify(pdfFactory).createPdfContents(templateDetails)
             verify(eroService).lookupGssCodesForEro(eroId)
             verify(anonymousElectorDocumentRepository).findByGssCodeInAndSourceTypeAndSourceReference(gssCodes, ANONYMOUS_ELECTOR_DOCUMENT, dto.sourceReference)
-            verify(reIssueAnonymousElectorDocumentMapper).toNewAnonymousElectorDocument(mostRecentIssueAed, templateFilename)
+            verify(reIssueAnonymousElectorDocumentMapper).toNewAnonymousElectorDocument(mostRecentIssueAed, dto, templateFilename)
             verify(anonymousElectorDocumentRepository).save(newlyIssuedAed)
         }
 


### PR DESCRIPTION
This PR adds in the mappings for `electoralRollNumber`, `userId` and `deliveryAddressType` when re-issuing an AED
(because I forgot about them in my earlier PR! 🙄 )