### PR TITLE
EIP1-4998 - Fix config; apply SES client endpointOverride

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/SesEmailClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/SesEmailClientConfiguration.kt
@@ -1,10 +1,12 @@
 package uk.gov.dluhc.printapi.config
 
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain
 import software.amazon.awssdk.services.ses.SesClient
 import uk.gov.dluhc.emailnotifications.SesEmailClient
+import java.net.URI
 
 /**
  * Configuration class exposing a configured email client bean to send emails via AWS's SES service.
@@ -12,9 +14,10 @@ import uk.gov.dluhc.emailnotifications.SesEmailClient
 @Configuration
 class SesEmailClientConfiguration() {
     @Bean
-    fun sesClient(): SesClient =
+    fun sesClient(@Value("\${cloud.aws.mail.endpoint}") sesVpcEndpoint: URI): SesClient =
         SesClient.builder()
             .region(DefaultAwsRegionProviderChain().region)
+            .endpointOverride(sesVpcEndpoint)
             .build()
 
     @Bean

--- a/src/test/kotlin/uk/gov/dluhc/printapi/config/LocalStackContainerConfiguration.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/config/LocalStackContainerConfiguration.kt
@@ -109,13 +109,14 @@ class LocalStackContainerConfiguration {
     fun configureEmailIdentityAndExposeSesClient(
         awsBasicCredentialsProvider: AwsCredentialsProvider,
         emailClientProperties: EmailClientProperties,
+        @Value("\${cloud.aws.mail.endpoint}") sesVpcEndpoint: URI,
     ): SesClient {
         localStackContainer.verifyEmailIdentity(emailClientProperties.sender)
 
         return SesClient.builder()
             .region(Region.of(DEFAULT_REGION))
             .credentialsProvider(awsBasicCredentialsProvider)
-            .applyMutation { builder -> builder.endpointOverride(localStackContainer.getEndpointOverride()) }
+            .endpointOverride(sesVpcEndpoint)
             .build()
     }
 
@@ -159,7 +160,7 @@ class LocalStackContainerConfiguration {
 
         TestPropertyValues.of(
             "cloud.aws.sqs.endpoint=$apiUrl",
-            "cloud.aws.email.endpoint=$apiUrl",
+            "cloud.aws.mail.endpoint=$apiUrl",
         ).applyTo(applicationContext)
 
         return LocalStackContainerSettings(

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -7,7 +7,7 @@ cloud:
       secret-key: test
     sqs:
       endpoint: http://replaced-by-localStackContainerSettings-bean
-    email:
+    mail:
       endpoint: http://replaced-by-localStackContainerSettings-bean
 
 spring:


### PR DESCRIPTION
This PR sets the endpoint override for the `SesClient`, and fixes the integration tests (which broke because of this change!) by correcting a typo in the property name (whoops!) and correcting how the `SesClient` that the integration tests use is setup