### PR TITLE
EIP1-5616 / EIP1-5761 - Add updatedDate and updatedBy to AED Contact Details

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AedContactDetails.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/entity/AedContactDetails.kt
@@ -4,6 +4,8 @@ import org.hibernate.Hibernate
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.GenericGenerator
 import org.hibernate.annotations.Type
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.annotation.CreatedBy
 import org.springframework.data.annotation.LastModifiedBy
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import uk.gov.dluhc.printapi.database.repository.UUIDCharType
@@ -57,8 +59,15 @@ class AedContactDetails(
     var dateCreated: Instant? = null,
 
     @field:Size(max = 255)
-    @LastModifiedBy
+    @CreatedBy
     var createdBy: String? = null,
+
+    @UpdateTimestamp
+    var dateUpdated: Instant? = null,
+
+    @field:Size(max = 255)
+    @LastModifiedBy
+    var updatedBy: String? = null,
 
     @Version
     var version: Long? = null

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapper.kt
@@ -58,6 +58,8 @@ abstract class ReIssueAnonymousElectorDocumentMapper {
     @Mapping(target = "contactDetails.id", ignore = true)
     @Mapping(target = "contactDetails.dateCreated", ignore = true)
     @Mapping(target = "contactDetails.createdBy", ignore = true)
+    @Mapping(target = "contactDetails.dateUpdated", ignore = true)
+    @Mapping(target = "contactDetails.updatedBy", ignore = true)
     @Mapping(target = "contactDetails.version", ignore = true)
     @Mapping(target = "contactDetails.address.id", ignore = true)
     @Mapping(target = "contactDetails.address.dateCreated", ignore = true)

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -35,4 +35,5 @@
     <include relativeToChangelogFile="true" file="ddl/0025_alter_aed_application_ref_not_null.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0026_alter_delivery_add_collection_reason.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0027_update_aed_summary_view.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0028_alter_aed_contact_details_add_last_updated.xml"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0028_alter_aed_contact_details_add_last_updated.xml
+++ b/src/main/resources/db/changelog/ddl/0028_alter_aed_contact_details_add_last_updated.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="nathan.russell@valtech.com" id="0028_EIP-5761_aed_contact_details add updated_by and date_updated" context="ddl">
+
+        <addColumn tableName="aed_contact_details">
+            <column name="date_updated" type="timestamp" beforeColumn="version">
+                <constraints nullable="true"/>
+            </column>
+            <column name="updated_by" type="varchar(255)" beforeColumn="version">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <sql>
+            UPDATE aed_contact_details SET date_updated = date_created;
+            UPDATE aed_contact_details SET updated_by = created_by;
+        </sql>
+
+        <addNotNullConstraint tableName="aed_contact_details" columnName="date_updated" columnDataType="timestamp"/>
+        <addNotNullConstraint tableName="aed_contact_details" columnName="updated_by" columnDataType="varchar(255)"/>
+
+        <rollback>
+            <dropColumn tableName="aed_contact_details" columnName="date_updated"/>
+            <dropColumn tableName="aed_contact_details" columnName="updated_by"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0028_alter_aed_contact_details_add_last_updated.xml
+++ b/src/main/resources/db/changelog/ddl/0028_alter_aed_contact_details_add_last_updated.xml
@@ -8,10 +8,10 @@
     <changeSet author="nathan.russell@valtech.com" id="0028_EIP-5761_aed_contact_details add updated_by and date_updated" context="ddl">
 
         <addColumn tableName="aed_contact_details">
-            <column name="date_updated" type="timestamp" beforeColumn="version">
+            <column name="date_updated" type="timestamp" afterColumn="created_by">
                 <constraints nullable="true"/>
             </column>
-            <column name="updated_by" type="varchar(255)" beforeColumn="version">
+            <column name="updated_by" type="varchar(255)" afterColumn="date_updated">
                 <constraints nullable="true"/>
             </column>
         </addColumn>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepositoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentRepositoryIntegrationTest.kt
@@ -3,12 +3,18 @@ package uk.gov.dluhc.printapi.database.repository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.context.transaction.TestTransaction
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
 import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepositoryExtensions.findPendingRemovalOfFinalRetentionData
 import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentRepositoryExtensions.findPendingRemovalOfInitialRetentionData
+import uk.gov.dluhc.printapi.testsupport.testdata.anAuthenticatedJwtAuthenticationToken
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAedContactDetails
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
 import java.time.LocalDate
+import javax.transaction.Transactional
 
 internal class AnonymousElectorDocumentRepositoryIntegrationTest : IntegrationTest() {
 
@@ -65,6 +71,60 @@ internal class AnonymousElectorDocumentRepositoryIntegrationTest : IntegrationTe
 
             // Then
             assertThat(actual).containsExactlyInAnyOrder(expected1, expected2)
+        }
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    open inner class UpdateContactDetails {
+        @Test
+        @Transactional
+        open fun `should maintain updatedBy and dateUpdated fields when AED contact details are updated`() {
+            // Given
+            SecurityContextHolder.getContext().authentication = anAuthenticatedJwtAuthenticationToken("a-user@some-ero.gov.uk")
+
+            val aed = buildAnonymousElectorDocument(
+                contactDetails = buildAedContactDetails(
+                    email = "initial-email@somewhere.com",
+                    phoneNumber = "01111 111111"
+                )
+            )
+            anonymousElectorDocumentRepository.save(aed)
+            TestTransaction.flagForCommit()
+            TestTransaction.end()
+
+            val retrievedAed = anonymousElectorDocumentRepository.findById(aed.id!!).get()
+            with(retrievedAed.contactDetails!!) {
+                // Assert initial AED Contact Details are saved with expected JPA field values
+                assertThat(createdBy).isEqualTo("a-user@some-ero.gov.uk")
+                assertThat(updatedBy).isEqualTo("a-user@some-ero.gov.uk")
+                assertThat(dateCreated).isEqualTo(dateUpdated)
+                assertThat(version).isEqualTo(0)
+            }
+
+            Thread.sleep(1000) // Sleep for a second to be able to assert a difference between dateCreated and dateUpdated
+
+            // When
+            TestTransaction.start()
+            SecurityContextHolder.getContext().authentication = anAuthenticatedJwtAuthenticationToken("another-user@some-ero.gov.uk")
+            with(retrievedAed.contactDetails!!) {
+                email = "an-updated-email@somewhere.com"
+                phoneNumber = "02222 222222"
+            }
+            anonymousElectorDocumentRepository.save(retrievedAed) // save the updated AED
+            TestTransaction.flagForCommit()
+            TestTransaction.end()
+
+            // Then
+            SecurityContextHolder.clearContext()
+            val updatedAed = anonymousElectorDocumentRepository.findById(aed.id!!).get()
+            with(updatedAed.contactDetails!!) {
+                // Assert updated AED Contact Details have expected updated JPA field values
+                assertThat(createdBy).isEqualTo("a-user@some-ero.gov.uk")
+                assertThat(updatedBy).isEqualTo("another-user@some-ero.gov.uk")
+                assertThat(dateUpdated).isAfter(dateCreated)
+                assertThat(version).isEqualTo(1)
+            }
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/ReIssueAnonymousElectorDocumentMapperTest.kt
@@ -29,6 +29,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.model.buildReIssueAnonymousEle
 import uk.gov.dluhc.printapi.testsupport.testdata.temporarycertificates.aTemplateFilename
 import java.time.Instant
 import java.time.LocalDate
+import java.time.temporal.ChronoUnit
 import java.util.UUID
 
 @ExtendWith(MockitoExtension::class)
@@ -38,7 +39,8 @@ class ReIssueAnonymousElectorDocumentMapperTest {
         private const val FIXED_DATE_STRING = "2022-10-18"
         private val FIXED_DATE = LocalDate.parse(FIXED_DATE_STRING)
         private val FIXED_TIME = Instant.parse("${FIXED_DATE_STRING}T11:22:32.123Z")
-        private val IGNORED_FIELDS = arrayOf(".*id", ".*dateCreated", ".*createdBy", ".*version")
+        private val IGNORED_FIELDS =
+            arrayOf(".*id", ".*dateCreated", ".*createdBy", ".*dateUpdated", ".*updatedBy", ".*version")
     }
 
     @InjectMocks
@@ -98,7 +100,19 @@ class ReIssueAnonymousElectorDocumentMapperTest {
                 deliveryAddressType = DeliveryAddressType.ERO_COLLECTION,
                 collectionReason = "There is a postal strike"
             ),
-        )
+        ).apply {
+            createdBy = "some-user"
+            dateCreated = Instant.now().minus(1, ChronoUnit.DAYS)
+            version = 0
+            with(contactDetails!!) {
+                id = UUID.randomUUID()
+                createdBy = "some-user"
+                dateCreated = Instant.now().minus(1, ChronoUnit.DAYS)
+                updatedBy = "some-other-user"
+                dateUpdated = Instant.now()
+                version = 1
+            }
+        }
         val templateFilename = aTemplateFilename()
 
         val newCertificateNumber = aValidVacNumber()
@@ -152,6 +166,8 @@ class ReIssueAnonymousElectorDocumentMapperTest {
         assertThat(actual.contactDetails!!.id).isNull()
         assertThat(actual.contactDetails!!.dateCreated).isNull()
         assertThat(actual.contactDetails!!.createdBy).isNull()
+        assertThat(actual.contactDetails!!.dateUpdated).isNull()
+        assertThat(actual.contactDetails!!.updatedBy).isNull()
         assertThat(actual.contactDetails!!.version).isNull()
         assertThat(actual.contactDetails!!.address!!.id).isNull()
         assertThat(actual.contactDetails!!.address!!.dateCreated).isNull()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/JwtAuthenticationTokenBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/JwtAuthenticationTokenBuilder.kt
@@ -1,0 +1,15 @@
+package uk.gov.dluhc.printapi.testsupport.testdata
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+
+fun anAuthenticatedJwtAuthenticationToken(username: String): JwtAuthenticationToken {
+    val jwt = Jwt
+        .withTokenValue("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyQHdpbHRzaGlyZS5nb3YudWsiLCJpYXQiOjE1MTYyMzkwMjIsImF1dGhvcml0aWVzIjpbImVyby1hZG1pbiJdfQ.-pxW8z2xb-AzNLTRP_YRnm9fQDcK6CLt6HimtS8VcDY")
+        .header("alg", "HS256").header("typ", "JWT")
+        .claim("sub", username)
+        .build()
+    val authorities = setOf(SimpleGrantedAuthority("ero-admin-1234"))
+    return JwtAuthenticationToken(jwt, authorities)
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/entity/AnonymousElectorDocumentBuilder.kt
@@ -13,8 +13,10 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidAnonymousElectorDocument
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidAnonymousElectorDocumentTemplateFilename
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidApplicationReference
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidElectoralRollNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidFirstName
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidIssueDate
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidPrintRequestStatusEventDateTime
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestDateTime
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
@@ -89,9 +91,13 @@ fun buildAedContactDetails(
     middleNames: String? = null,
     surname: String = aValidSurname(),
     address: Address = buildAddress(),
+    email: String = aValidEmailAddress(),
+    phoneNumber: String = aValidPhoneNumber(),
 ): AedContactDetails = AedContactDetails(
     firstName = firstName,
     middleNames = middleNames,
     surname = surname,
     address = address,
+    email = email,
+    phoneNumber = phoneNumber,
 )


### PR DESCRIPTION
This PR adds updatedDate and updatedBy to the AED Contact Details table.

This is to support EIP1-5616 which is to allow the ERO to update the email and/or phoneNumber of an AED (which is the AED Contact Details table).
Without this change it would mean we would lose (overwrite) the createdDate and createdBy fields, thereby losing the history of change

The `print-api` database does not use envers audit tables as it was never intended that database records would ever be updated (by an ERO)
This is a better/faster/pragmatic solution over and above introducing envers at this stage.