### PR TITLE
EIP1-5820 / EIP1-5836 - Swagger spec and initial controller for getting AED photo

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
@@ -1,0 +1,39 @@
+package uk.gov.dluhc.printapi.rest.aed
+
+import org.springframework.http.HttpStatus.OK
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.CrossOrigin
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
+import uk.gov.dluhc.printapi.exception.CertificateNotFoundException
+import uk.gov.dluhc.printapi.models.PreSignedUrlResourceResponse
+import uk.gov.dluhc.printapi.rest.HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY
+import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentService
+
+@RestController
+@CrossOrigin
+@RequestMapping("/eros/{eroId}/anonymous-elector-documents/photo")
+class AnonymousElectorDocumentPhotoController(
+    private val anonymousElectorDocumentService: AnonymousElectorDocumentService,
+) {
+
+    @GetMapping
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    @ResponseStatus(OK)
+    fun getAnonymousElectorDocumentsPhoto(
+        @PathVariable eroId: String,
+        @RequestParam applicationId: String,
+    ): PreSignedUrlResourceResponse {
+        val aed = anonymousElectorDocumentService
+            .getAnonymousElectorDocuments(eroId, applicationId)
+            .firstOrNull() ?: throw CertificateNotFoundException(eroId, ANONYMOUS_ELECTOR_DOCUMENT, applicationId)
+
+        // aed.photoLocationArn
+        TODO("not yet implemented")
+    }
+}

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -760,6 +760,84 @@ paths:
         connectionId: '${vpc_connection_id}'
         httpMethod: POST
 
+  '/eros/{eroId}/anonymous-elector-documents/photo':
+    parameters:
+      - name: eroId
+        description: The ID of the Electoral Registration Office responsible for the application.
+        schema:
+          type: string
+        in: path
+        required: true
+    options:
+      summary: CORS support
+      description: |
+        Enable CORS by returning correct headers
+      tags:
+        - Anonymous Elector Documents (AED)
+      responses:
+        200:
+          description: Default response for CORS method
+          headers:
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+            Access-Control-Allow-Headers:
+              schema:
+                type: string
+          content: { }
+      x-amazon-apigateway-integration:
+        type: mock
+        requestTemplates:
+          application/json: |
+            {
+              "statusCode" : 200
+            }
+        responses:
+          default:
+            statusCode: "200"
+            responseParameters:
+              method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+              method.response.header.Access-Control-Allow-Methods: '''*'''
+              method.response.header.Access-Control-Allow-Origin: '''*'''
+            responseTemplates:
+              application/json: |
+                {}
+    get:
+      summary: Returns the Anonymous Elector Document photo for an Anonymous application
+      description: Returns the Anonymous Elector Document photo for an Anonymous application
+      tags:
+        - Anonymous Elector Documents (AED)
+      parameters:
+        - name: applicationId
+          description: An identifier of an Anonymous Elector Document application
+          schema:
+            type: string
+          in: query
+          required: true
+      responses:
+        '200':
+          $ref: '#/components/responses/PreSignedUrlResource'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
+      operationId: get-anonymous-elector-documents-photo-by-application-id
+      security:
+        - eroUserCognitoUserPoolAuthorizer: [ ]
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/eros/{eroId}/anonymous-elector-documents/photo'
+        requestParameters:
+          integration.request.path.eroId: method.request.path.eroId
+        responseParameters:
+          method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+          method.response.header.Access-Control-Allow-Methods: '''*'''
+          method.response.header.Access-Control-Allow-Origin: '''*'''
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: GET
+
   #
   # Anonymous Elector Document (AED) Explainer Document
   # --------------------------------------------------------------------------------
@@ -1517,6 +1595,18 @@ components:
         - electoralRollNumber
         - deliveryAddressType
 
+    PreSignedUrlResourceResponse:
+      title: PreSignedUrlResourceResponse
+      description: An object detailing the pre-signed URL to use in order to retrieve the resource
+      properties:
+        preSignedUrl:
+          type: string
+          format: uri
+          description: AWS pre-signed URL giving time-limited access to the resource.
+          example: 'https://example.s3.eu-west-2.amazonaws.com/image.png?X-Amz-Expires=1800'
+      required:
+        - preSignedUrl
+
   #
   # Response Body Definitions
   # --------------------------------------------------------------------------------
@@ -1653,6 +1743,23 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/AedSearchSummaryResponse'
+    PreSignedUrlResource:
+      description: Response containing an object detailing the pre-signed URL for the resource
+      headers:
+        Access-Control-Allow-Origin:
+          schema:
+            type: string
+        Access-Control-Allow-Methods:
+          schema:
+            type: string
+        Access-Control-Allow-Headers:
+          schema:
+            type: string
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PreSignedUrlResourceResponse'
+
   #
   # Request Body Definitions
   # --------------------------------------------------------------------------------

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.15.3'
+  version: '1.16.0'
   description: Print APIs
   contact:
     name: Krister Bone

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
@@ -1,0 +1,75 @@
+package uk.gov.dluhc.printapi.rest.aed
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.getVCAnonymousAdminBearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
+
+internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest : IntegrationTest() {
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/anonymous-elector-documents/photo?applicationId={APPLICATION_ID}"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4bbc"
+        private const val GSS_CODE = "W06000099"
+    }
+
+    @Test
+    fun `should return bad request given request without applicationId query string parameter`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+
+        webTestClient.get()
+            .uri("/eros/{ERO_ID}/anonymous-elector-documents/photo", ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = userGroupEroId))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return not found given no AEDs exist for application ID`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        // When
+        val response = webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isNotFound
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        ErrorResponseAssert.assertThat(actual)
+            .hasStatus(404)
+            .hasError("Not Found")
+            .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = $APPLICATION_ID not found")
+    }
+}


### PR DESCRIPTION
This PR defines the openAPI spec request for getting the presigned URL for the AED photo. It also implements the basic controller method and usual 401/403/404 integration tests

![Screenshot 2023-05-02 at 08 20 31](https://user-images.githubusercontent.com/78348259/235604136-2d6cd8c3-f308-47a4-8468-21c8abd2eeed.png)
