### PR TITLE
EIP1-5820 / EIP1-5837 - Return photoUrl instead of photoLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ The following environment variables must be set in order to run the application:
 * `SQS_PROCESS_PRINT_RESPONSE_QUEUE_NAME` - the queue name for processing individual print responses
 * `SQS_APPLICATION_REMOVED_QUEUE_NAME` - the queue name to notify this api that a source application has been removed
 * `SQS_REMOVE_CERTIFICATE_QUEUE_NAME` - the queue name for removing certificates after the final data retention period
+* `API_PRINT_API_BASE_URL` - the base URL to this print-api REST API service or its API Gateway.
 * `API_ERO_MANAGEMENT_URL` - the base URL of the ERO Management REST API service.
 * `THREAD_POOL_ZIP_CORE_SIZE` - number of core threads for the Zip producer thread pool 
 * `THREAD_POOL_ZIP_MAX_SIZE` - maximum number of threads for the Zip producer thread pool

--- a/src/main/kotlin/uk/gov/dluhc/printapi/factory/UrlFactory.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/factory/UrlFactory.kt
@@ -1,0 +1,22 @@
+package uk.gov.dluhc.printapi.factory
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.dto.SourceType
+import uk.gov.dluhc.printapi.dto.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
+import uk.gov.dluhc.printapi.dto.SourceType.VOTER_CARD
+
+/**
+ * Factory for creating absolute URLs that are configurable for AWS API Gateways.
+ */
+@Component
+class UrlFactory(
+    @Value("\${api.print-api.base.url}") private val printApiBaseUrl: String
+) {
+    fun createPhotoUrl(eroId: String, sourceType: SourceType, applicationId: String): String {
+        return when (sourceType) {
+            ANONYMOUS_ELECTOR_DOCUMENT -> "$printApiBaseUrl/eros/$eroId/anonymous-elector-documents/photo?applicationId=$applicationId"
+            VOTER_CARD -> throw UnsupportedOperationException("print-api does not currently support returning the URL of VAC or Temporary Certificate photos")
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/AnonymousElectorDocumentMapper.kt
@@ -2,10 +2,13 @@ package uk.gov.dluhc.printapi.mapper.aed
 
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
+import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.printapi.database.entity.AedContactDetails
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocument
+import uk.gov.dluhc.printapi.dto.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
 import uk.gov.dluhc.printapi.dto.aed.AnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.dto.aed.AnonymousElectorDto
+import uk.gov.dluhc.printapi.factory.UrlFactory
 import uk.gov.dluhc.printapi.mapper.CertificateLanguageMapper
 import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
 import uk.gov.dluhc.printapi.mapper.InstantMapper
@@ -21,9 +24,12 @@ import uk.gov.dluhc.printapi.models.AnonymousElectorDocument as AnonymousElector
 )
 abstract class AnonymousElectorDocumentMapper {
 
-    @Mapping(target = "dateTime", source = "requestDateTime")
-    @Mapping(target = "photoLocation", source = "photoLocationArn")
-    abstract fun mapToApiAnonymousElectorDocument(aedSummaryDto: AnonymousElectorDocumentDto): AnonymousElectorDocumentApi
+    @Autowired
+    protected lateinit var urlFactory: UrlFactory
+
+    @Mapping(target = "dateTime", source = "dto.requestDateTime")
+    @Mapping(target = "photoUrl", expression = "java(getPhotoUrl(eroId, dto))")
+    abstract fun mapToApiAnonymousElectorDocument(dto: AnonymousElectorDocumentDto, eroId: String): AnonymousElectorDocumentApi
 
     @Mapping(target = "elector", source = "aedEntity.contactDetails")
     @Mapping(target = "status", constant = "PRINTED")
@@ -44,4 +50,7 @@ abstract class AnonymousElectorDocumentMapper {
             }
         }
     }
+
+    protected fun getPhotoUrl(eroId: String, dto: AnonymousElectorDocumentDto): String =
+        urlFactory.createPhotoUrl(eroId, ANONYMOUS_ELECTOR_DOCUMENT, dto.sourceReference)
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
@@ -97,7 +97,7 @@ class AnonymousElectorDocumentController(
     ): AnonymousElectorDocumentsResponse {
         val anonymousElectorDocuments = anonymousElectorDocumentService
             .getAnonymousElectorDocuments(eroId, applicationId)
-            .map { anonymousElectorDocumentMapper.mapToApiAnonymousElectorDocument(it) }
+            .map { anonymousElectorDocumentMapper.mapToApiAnonymousElectorDocument(it, eroId) }
         return AnonymousElectorDocumentsResponse(anonymousElectorDocuments = anonymousElectorDocuments)
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,7 @@ sqs:
 
 api:
   print-api:
+    base.url: ${API_PRINT_API_BASE_URL}
     generate-temporary-certificate:
       valid-on-date:
         max-calendar-days-in-future: 30

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.16.0'
+  version: '1.17.0'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -1337,13 +1337,12 @@ components:
           $ref: '#/components/schemas/AnonymousElector'
         status:
           $ref: '#/components/schemas/AnonymousElectorDocumentStatus'
-        photoLocation:
+        photoUrl:
           type: string
           description: |
-            The location of the Elector's Certificate photo. 
-            This is the photo that has been prepared and approved for the Certificate by the `vc-anonymous-admin`, rather than the photo that the applicant uploaded as part of their original application. 
-            Typically an S3 ARN
-          maxLength: 1024
+            The URL of the Elector's Certificate photo. 
+            This is the photo that has been prepared and approved for the Certificate by the ERO, rather than the photo that the applicant uploaded as part of their original application.
+          example: 'http://localhost:8080/eros/city-council/anonymous-elector-documents/photo?applicationId=507f1f77bcf86cd799439011'
         issueDate:
           type: string
           format: date
@@ -1360,7 +1359,7 @@ components:
         - deliveryAddressType
         - elector
         - status
-        - photoLocation
+        - photoUrl
         - issueDate
 
     AnonymousElector:

--- a/src/test/kotlin/uk/gov/dluhc/printapi/factory/UrlFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/factory/UrlFactoryTest.kt
@@ -1,0 +1,44 @@
+package uk.gov.dluhc.printapi.factory
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowableOfType
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.dto.SourceType
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+
+class UrlFactoryTest {
+
+    private val factory = UrlFactory("http://localhost:8080")
+
+    @Test
+    fun `should create photo URL given source type ANONYMOUS_ELECTOR_DOCUMENTED`() {
+        // Given
+        val eroId = aValidEroId()
+        val sourceReference = aValidSourceReference()
+        val sourceType = SourceType.ANONYMOUS_ELECTOR_DOCUMENT
+
+        // When
+        val actual = factory.createPhotoUrl(eroId, sourceType, sourceReference)
+
+        // Then
+        assertThat(actual).isEqualTo("http://localhost:8080/eros/$eroId/anonymous-elector-documents/photo?applicationId=$sourceReference")
+    }
+
+    @Test
+    fun `should not create photo URL given source type VOTER_CARD`() {
+        // Given
+        val eroId = aValidEroId()
+        val sourceReference = aValidSourceReference()
+        val sourceType = SourceType.VOTER_CARD
+
+        // When
+        val exception = catchThrowableOfType(
+            { factory.createPhotoUrl(eroId, sourceType, sourceReference) },
+            UnsupportedOperationException::class.java
+        )
+
+        // Then
+        assertThat(exception).hasMessage("print-api does not currently support returning the URL of VAC or Temporary Certificate photos")
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/factory/UrlFactoryTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/factory/UrlFactoryTest.kt
@@ -12,7 +12,7 @@ class UrlFactoryTest {
     private val factory = UrlFactory("http://localhost:8080")
 
     @Test
-    fun `should create photo URL given source type ANONYMOUS_ELECTOR_DOCUMENTED`() {
+    fun `should create photo URL given source type ANONYMOUS_ELECTOR_DOCUMENT`() {
         // Given
         val eroId = aValidEroId()
         val sourceReference = aValidSourceReference()

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsByApplicationIdIntegrationTest.kt
@@ -109,6 +109,8 @@ internal class GetAnonymousElectorDocumentsByApplicationIdIntegrationTest : Inte
             )
         )
 
+        val expectedPhotoUrl = "http://localhost:8080/eros/$ERO_ID/anonymous-elector-documents/photo?applicationId=$APPLICATION_ID"
+
         val expectedFirstRecord = with(aedMatchingDocument2) {
             buildAnonymousElectorDocumentApi(
                 certificateNumber = certificateNumber, electoralRollNumber = electoralRollNumber,
@@ -130,8 +132,11 @@ internal class GetAnonymousElectorDocumentsByApplicationIdIntegrationTest : Inte
                         phoneNumber = phoneNumber
                     )
                 },
-                photoLocation = photoLocationArn, issueDate = issueDate, userId = userId,
-                dateTime = requestDateTime.atOffset(ZoneOffset.UTC), supportingInformationFormat = STANDARD
+                photoUrl = expectedPhotoUrl,
+                issueDate = issueDate,
+                userId = userId,
+                dateTime = requestDateTime.atOffset(ZoneOffset.UTC),
+                supportingInformationFormat = STANDARD
             )
         }
         val expectedSecondRecord = with(aedMatchingDocument1) {
@@ -155,8 +160,11 @@ internal class GetAnonymousElectorDocumentsByApplicationIdIntegrationTest : Inte
                         phoneNumber = phoneNumber
                     )
                 },
-                photoLocation = photoLocationArn, issueDate = issueDate, userId = userId,
-                dateTime = requestDateTime.atOffset(ZoneOffset.UTC), supportingInformationFormat = LARGE_MINUS_PRINT
+                photoUrl = expectedPhotoUrl,
+                issueDate = issueDate,
+                userId = userId,
+                dateTime = requestDateTime.atOffset(ZoneOffset.UTC),
+                supportingInformationFormat = LARGE_MINUS_PRINT
             )
         }
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AnonymousElectorDocumentBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/AnonymousElectorDocumentBuilder.kt
@@ -20,7 +20,7 @@ import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSurname
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
-import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoArn
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.anAedPhotoUrl
 import java.time.LocalDate
 import java.time.OffsetDateTime
 
@@ -36,7 +36,7 @@ fun buildAnonymousElectorDocumentApi(
     collectionReason: String? = null,
     elector: AnonymousElector = buildAnonymousElectorApi(),
     status: AnonymousElectorDocumentStatus = AnonymousElectorDocumentStatus.PRINTED,
-    photoLocation: String = aPhotoArn(),
+    photoUrl: String = anAedPhotoUrl(),
     issueDate: LocalDate = aValidIssueDate(),
     userId: String = aValidUserId(),
     dateTime: OffsetDateTime = aValidGeneratedDateTime()
@@ -52,7 +52,7 @@ fun buildAnonymousElectorDocumentApi(
     collectionReason = collectionReason,
     elector = elector,
     status = status,
-    photoLocation = photoLocation,
+    photoUrl = photoUrl,
     issueDate = issueDate,
     userId = userId,
     dateTime = dateTime,

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/zip/PhotoLocationBuilder.kt
@@ -2,6 +2,8 @@ package uk.gov.dluhc.printapi.testsupport.testdata.zip
 
 import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration.Companion.S3_BUCKET_CONTAINING_PHOTOS
 import uk.gov.dluhc.printapi.service.PhotoLocation
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
 
 fun buildPhotoLocation(
     zipPath: String = aPhotoZipPath(),
@@ -28,3 +30,8 @@ fun aPhotoBucketPath() = "E99999999/6407b6158f529a11713a1e5c/certificate-photos/
 fun anotherPhotoBucketPath() = "E99999999/2304v5134f529a11713a1e6a/certificate-photos/0d21c6de-72d4-5aa2-c4da-c33456252922_certificate-photo-1.png"
 
 fun aPhotoZipPath() = "05372cf5339447b39f98b248c2217b9f-635abede7c432c0aaeeeba47.png"
+
+fun anAedPhotoUrl(
+    eroId: String = aValidEroId(),
+    sourceReference: String = aValidSourceReference()
+) = "http://localhost:8080/eros/$eroId/anonymous-elector-documents/photo?applicationId=$sourceReference"

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -33,6 +33,8 @@ sqs:
   remove-certificate-queue-name: remove-certificate
 
 api:
+  print-api:
+    base.url: http://localhost:8080
   ero-management:
     url: http://will-be-replaced-by-wireMockServer-bean
 


### PR DESCRIPTION
This PR changes the `AnonymousElectorDocument` response changing the field `photoLocation` to `photoUrl`, with the value being the print-api REST API endpoint to get the photo's presigned URL

This approach, terminology etc is in keeping with how we do it in VCA