### PR TITLE
EIP1-5838 - Service to create a pre-signed URL to retrieve an AED photo

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ The following environment variables must be set in order to run the application:
 * `SFTP_PRINT_RESPONSE_DOWNLOAD_DIRECTORY` - Directory on the remote host to read print response files
 * `JOBS_BATCH_PRINT_REQUESTS_CRON` - Optional. Overrides the cron schedule for when print requests are batched and sent to the Print Provider
 * `JOBS_PROCESS_PRINT_RESPONSES_CRON` - Optional. Overrides the cron schedule for when the Print Provider's OutBound folder is polled to find and process print responses
+* `S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_NAME` - the S3 bucket name where certificate photos are stored
+* `S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_PROXY_ENDPOINT` - the URL of the custom domain file proxy for certificate photos
 
 #### MYSQL Configuration
 For local setup refer to src/main/resources/db/readme.

--- a/src/main/kotlin/uk/gov/dluhc/printapi/config/S3Configuration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/config/S3Configuration.kt
@@ -1,12 +1,27 @@
 package uk.gov.dluhc.printapi.config
 
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import java.time.Duration
 
 @Configuration
 class S3Configuration {
 
     @Bean
     fun s3Client(): S3Client = S3Client.builder().build()
+
+    @Bean
+    fun S3Presigner(): S3Presigner = S3Presigner.builder().build()
 }
+
+@ConfigurationProperties(prefix = "s3")
+@ConstructorBinding
+data class S3Properties(
+    val certificatePhotosTargetBucket: String,
+    val certificatePhotosTargetBucketProxyEndpoint: String,
+    val certificatePhotoAccessDuration: Duration
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentPhotoController.kt
@@ -13,6 +13,7 @@ import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUME
 import uk.gov.dluhc.printapi.exception.CertificateNotFoundException
 import uk.gov.dluhc.printapi.models.PreSignedUrlResourceResponse
 import uk.gov.dluhc.printapi.rest.HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY
+import uk.gov.dluhc.printapi.service.S3PhotoService
 import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentService
 
 @RestController
@@ -20,6 +21,7 @@ import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentService
 @RequestMapping("/eros/{eroId}/anonymous-elector-documents/photo")
 class AnonymousElectorDocumentPhotoController(
     private val anonymousElectorDocumentService: AnonymousElectorDocumentService,
+    private val s3PhotoService: S3PhotoService
 ) {
 
     @GetMapping
@@ -33,7 +35,7 @@ class AnonymousElectorDocumentPhotoController(
             .getAnonymousElectorDocuments(eroId, applicationId)
             .firstOrNull() ?: throw CertificateNotFoundException(eroId, ANONYMOUS_ELECTOR_DOCUMENT, applicationId)
 
-        // aed.photoLocationArn
-        TODO("not yet implemented")
+        val preSignedUrl = s3PhotoService.generatePresignedGetCertificatePhotoUrl(aed.photoLocationArn)
+        return PreSignedUrlResourceResponse(preSignedUrl = preSignedUrl)
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/S3PhotoService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/S3PhotoService.kt
@@ -2,16 +2,38 @@ package uk.gov.dluhc.printapi.service
 
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
 import software.amazon.awssdk.core.exception.SdkException
 import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest
+import uk.gov.dluhc.printapi.config.S3Properties
+import java.net.URI
+import java.time.Duration
 
 private val logger = KotlinLogging.logger {}
 
 @Service
 class S3PhotoService(
-    private val s3Client: S3Client
+    private val s3Client: S3Client,
+    private val s3Presigner: S3Presigner,
+    private val s3Properties: S3Properties
 ) {
+
+    private val bucketsToProxyEndpoints = mapOf(
+        s3Properties.certificatePhotosTargetBucket to s3Properties.certificatePhotosTargetBucketProxyEndpoint
+    )
+
+    /**
+     * Generates a pre-signed URL to the certificate photo in S3 (via a proxy) based on the provided S3 arn.
+     */
+    fun generatePresignedGetCertificatePhotoUrl(s3arn: String): URI {
+        return generateGetResourceUrl(s3arn, s3Properties.certificatePhotoAccessDuration)
+    }
+
     /**
      * Removes the photo that is on the printed "Elector Document" (i.e. Certificate/AED) from S3.
      */
@@ -24,6 +46,34 @@ class S3PhotoService(
         } catch (e: SdkException) {
             logger.warn { "Unable to delete photo with S3 arn [$photoS3Arn] due to error [${e.cause?.message ?: e.cause}]" }
             throw e
+        }
+    }
+
+    private fun generateGetResourceUrl(s3arn: String, accessDuration: Duration): URI {
+        val s3Resource = parseS3Arn(s3arn)
+        val getObjectRequest: GetObjectRequest = GetObjectRequest.builder()
+            .bucket(s3Resource.bucket)
+            .key(s3Resource.path)
+            .build()
+
+        val presignRequest: GetObjectPresignRequest = GetObjectPresignRequest.builder()
+            .signatureDuration(accessDuration)
+            .getObjectRequest(getObjectRequest)
+            .build()
+        val req = s3Presigner.presignGetObject(presignRequest)
+        return transformS3ResourceUrl(req, s3Resource.bucket)
+    }
+
+    private fun transformS3ResourceUrl(request: PresignedGetObjectRequest, bucketName: String): URI {
+        with(request) {
+            val preSignedS3Url = this.url()
+            return UriComponentsBuilder.newInstance()
+                .scheme("https")
+                .host(bucketsToProxyEndpoints[bucketName])
+                .path(preSignedS3Url.path)
+                .query(preSignedS3Url.query)
+                .build(true)
+                .toUri()
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
@@ -63,7 +63,6 @@ class AnonymousElectorDocumentService(
     ): List<AnonymousElectorDocumentDto> {
         val gssCodes = eroService.lookupGssCodesForEro(eroId)
         return getAnonymousElectorDocumentsSortedByDate(gssCodes, applicationId)
-            // TODO EIP1-5837 - populate photoLocation with URL to endpoint to get the certificate's pre-signed URL (instead of the arn)
             .map { anonymousElectorDocumentMapper.mapToAnonymousElectorDocumentDto(it) }
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentService.kt
@@ -63,6 +63,7 @@ class AnonymousElectorDocumentService(
     ): List<AnonymousElectorDocumentDto> {
         val gssCodes = eroService.lookupGssCodesForEro(eroId)
         return getAnonymousElectorDocumentsSortedByDate(gssCodes, applicationId)
+            // TODO EIP1-5837 - populate photoLocation with URL to endpoint to get the certificate's pre-signed URL (instead of the arn)
             .map { anonymousElectorDocumentMapper.mapToAnonymousElectorDocumentDto(it) }
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,8 +29,6 @@ sqs:
   remove-certificate-queue-name: ${SQS_REMOVE_CERTIFICATE_QUEUE_NAME}
 
 s3:
-  # TODO - EIP1-5839 - infra PR (including S3 permissions)
-  # TODO - add properties to README
   certificate-photo-access-duration: 1M
   certificate-photos-target-bucket: ${S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_NAME}
   certificate-photos-target-bucket-proxy-endpoint: ${S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_PROXY_ENDPOINT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,13 @@ sqs:
   application-removed-queue-name: ${SQS_APPLICATION_REMOVED_QUEUE_NAME}
   remove-certificate-queue-name: ${SQS_REMOVE_CERTIFICATE_QUEUE_NAME}
 
+s3:
+  # TODO - EIP1-5839 - infra PR (including S3 permissions)
+  # TODO - add properties to README
+  certificate-photo-access-duration: 1M
+  certificate-photos-target-bucket: ${S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_NAME}
+  certificate-photos-target-bucket-proxy-endpoint: ${S3_CERTIFICATE_PHOTOS_TARGET_BUCKET_PROXY_ENDPOINT}
+
 api:
   print-api:
     base.url: ${API_PRINT_API_BASE_URL}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest.kt
@@ -1,20 +1,28 @@
 package uk.gov.dluhc.printapi.rest.aed
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType.APPLICATION_JSON
 import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.config.LocalStackContainerConfiguration
 import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.models.PreSignedUrlResourceResponse
+import uk.gov.dluhc.printapi.testsupport.addCertificatePhotoToS3
 import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert
 import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.buildS3Arn
+import uk.gov.dluhc.printapi.testsupport.matchingPreSignedAwsS3GetUrl
 import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
 import uk.gov.dluhc.printapi.testsupport.testdata.getVCAnonymousAdminBearerToken
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
 import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.zip.aPhotoBucketPath
 
 internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest : IntegrationTest() {
     companion object {
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/anonymous-elector-documents/photo?applicationId={APPLICATION_ID}"
-        private const val APPLICATION_ID = "7762ccac7c056046b75d4bbc"
+        private const val APPLICATION_ID = "6407b6158f529a11713a1e5c"
         private const val GSS_CODE = "W06000099"
     }
 
@@ -71,5 +79,44 @@ internal class GetAnonymousElectorDocumentsPhotoByApplicationIdIntegrationTest :
             .hasStatus(404)
             .hasError("Not Found")
             .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = $APPLICATION_ID not found")
+    }
+
+    @Test
+    fun `should return a presigned url for the AED photo`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+
+        val s3Bucket = LocalStackContainerConfiguration.S3_BUCKET_CONTAINING_PHOTOS
+        val s3PathAedPhoto1 = aPhotoBucketPath()
+        val anonymousElectorDocument1 = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = APPLICATION_ID,
+            photoLocationArn = buildS3Arn(s3Bucket, s3PathAedPhoto1)
+        )
+        anonymousElectorDocumentRepository.save(anonymousElectorDocument1)
+        s3Client.addCertificatePhotoToS3(s3Bucket, s3PathAedPhoto1)
+
+        // When
+        val response = webTestClient.get()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .exchange()
+            .expectStatus()
+            .isOk
+            .returnResult(PreSignedUrlResourceResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        val expectedUrl = matchingPreSignedAwsS3GetUrl(s3PathAedPhoto1)
+        assertThat(actual!!.preSignedUrl).matches {
+            it.toString()
+                .matches(expectedUrl)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/S3PhotoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/S3PhotoServiceTest.kt
@@ -1,0 +1,88 @@
+package uk.gov.dluhc.printapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest
+import uk.gov.dluhc.printapi.config.S3Properties
+import java.net.URI
+import java.net.URL
+import java.time.Duration
+
+@ExtendWith(MockitoExtension::class)
+internal class S3PhotoServiceTest {
+
+    @Mock
+    private lateinit var s3Client: S3Client
+
+    @Mock
+    private lateinit var s3Presigner: S3Presigner
+
+    @Mock
+    private lateinit var s3Properties: S3Properties
+
+    private lateinit var s3PhotoService: S3PhotoService
+
+    companion object {
+        private const val S3_CERTIFICATE_PHOTO_TARGET_BUCKET = "secure-certificate-photos"
+        private const val CERTIFICATE_PHOTO_ACCESS_TIME_IN_SECONDS = 70L
+        private const val CUSTOM_DOMAIN_FILE_PROXY_URL = "customurl.testing.erop.ierds.uk"
+        private const val S3_QUERY_PARAMS = "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20230313T143807Z&X-Amz-SignedHeaders=host&X-Amz-Expires=215000&X-Amz-Credential=AKIAA5AAAAA1AAA1AAAA%2F20230313%2Feu-west-2%2Fs3%2Faws4_request&X-Amz-Signature=aaa000aa0a0000000a0a000a0a0aa000aa00000000aaa00000000000a000aa00"
+    }
+
+    @BeforeEach
+    fun setupService() {
+        given(s3Properties.certificatePhotoAccessDuration).willReturn(Duration.ofSeconds(CERTIFICATE_PHOTO_ACCESS_TIME_IN_SECONDS))
+        given(s3Properties.certificatePhotosTargetBucket).willReturn(S3_CERTIFICATE_PHOTO_TARGET_BUCKET)
+        given(s3Properties.certificatePhotosTargetBucketProxyEndpoint).willReturn(CUSTOM_DOMAIN_FILE_PROXY_URL)
+
+        s3PhotoService = S3PhotoService(
+            s3Client,
+            s3Presigner,
+            s3Properties,
+        )
+    }
+
+    @Test
+    fun `should generate pre-signed URL to get certificate photo`() {
+        // Given
+        val bucketName = s3Properties.certificatePhotosTargetBucket
+        val key = "gssCode/key"
+        val s3Arn = "arn:aws:s3:::$bucketName/$key"
+        val presignedUrl = "https://${s3Properties.certificatePhotosTargetBucket}/$key?$S3_QUERY_PARAMS"
+        val transformedUrl = "https://${s3Properties.certificatePhotosTargetBucketProxyEndpoint}/$key?$S3_QUERY_PARAMS"
+
+        val expectedPresignRequest: GetObjectPresignRequest = GetObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofSeconds(CERTIFICATE_PHOTO_ACCESS_TIME_IN_SECONDS))
+            .getObjectRequest(
+                GetObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build()
+            )
+            .build()
+
+        val presignedGetObjectRequest = mock<PresignedGetObjectRequest>()
+        given(presignedGetObjectRequest.url()).willReturn(URL(presignedUrl))
+        given(s3Presigner.presignGetObject(any<GetObjectPresignRequest>())).willReturn(presignedGetObjectRequest)
+        val expectedUri = URI.create(transformedUrl)
+
+        // When
+        val location = s3PhotoService.generatePresignedGetCertificatePhotoUrl(s3Arn)
+
+        // Then
+        assertThat(location).isEqualTo(expectedUri)
+        verify(s3Presigner).presignGetObject(expectedPresignRequest)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/S3PhotoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/S3PhotoServiceTest.kt
@@ -62,17 +62,10 @@ internal class S3PhotoServiceTest {
         val s3Arn = "arn:aws:s3:::$bucketName/$key"
         val presignedUrl = "https://${s3Properties.certificatePhotosTargetBucket}/$key?$S3_QUERY_PARAMS"
         val transformedUrl = "https://${s3Properties.certificatePhotosTargetBucketProxyEndpoint}/$key?$S3_QUERY_PARAMS"
-
         val expectedPresignRequest: GetObjectPresignRequest = GetObjectPresignRequest.builder()
             .signatureDuration(Duration.ofSeconds(CERTIFICATE_PHOTO_ACCESS_TIME_IN_SECONDS))
-            .getObjectRequest(
-                GetObjectRequest.builder()
-                    .bucket(bucketName)
-                    .key(key)
-                    .build()
-            )
+            .getObjectRequest(GetObjectRequest.builder().bucket(bucketName).key(key).build())
             .build()
-
         val presignedGetObjectRequest = mock<PresignedGetObjectRequest>()
         given(presignedGetObjectRequest.url()).willReturn(URL(presignedUrl))
         given(s3Presigner.presignGetObject(any<GetObjectPresignRequest>())).willReturn(presignedGetObjectRequest)

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/S3Utils.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/S3Utils.kt
@@ -1,0 +1,29 @@
+package uk.gov.dluhc.printapi.testsupport
+
+/**
+ * Generated pre-signed GET S3 url in tests would look something like this
+ * [X-Amz-Expires=120] is derived from property [`s3: *-upload-expiry-duration`] in seconds.
+ * <pre>
+ http://{hostname}:{port}/{source_bucket_name}/E59733855_63778af635c4d92d1b1a7163_HappyFace.png?
+ X-Amz-Algorithm=AWS4-HMAC-SHA256
+ &X-Amz-Date=20221118T133906Z
+ &X-Amz-SignedHeaders=content-type;host
+ &X-Amz-Expires=119
+ &X-Amz-Credential=test%2F20221118%2Fus-east-1%2Fs3%2Faws4_request
+ &X-Amz-Signature=b781de7ca0ccdb013e6d1da81406d19bbdca2cccdb0570b5c73603781b930904)
+ * </pre>
+ */
+fun matchingPreSignedAwsS3GetUrl(key: String): Regex =
+    Regex(
+        ".*/$key" +
+            "\\?X-Amz-Algorithm=AWS4-HMAC-SHA256" +
+            "&X-Amz-Date=.*" +
+            "&X-Amz-SignedHeaders=host" +
+            "&X-Amz-Expires=.*" +
+            "&X-Amz-Credential=.*" +
+            "&X-Amz-Signature=.*"
+    )
+
+fun buildS3Arn(bucketName: String, s3ObjectKey: String): String {
+    return "arn:aws:s3:::$bucketName/$s3ObjectKey"
+}

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -30,6 +30,10 @@ sqs:
   application-removed-queue-name: application-removed
   remove-certificate-queue-name: remove-certificate
 
+s3:
+  certificate-photos-target-bucket: localstack-vca-api-vca-target-bucket
+  certificate-photos-target-bucket-proxy-endpoint: localhost
+
 api:
   print-api:
     base.url: http://localhost:8080


### PR DESCRIPTION
This PR completes the endpoint to generate a pre-signed URL to an AED's photo in S3.

I'm not completely sure about the path to retrieve the URL (personally I'm leaning towards `/eros/{eroId}/anonymous-elector-documents/{certificateNumber}/photo`), but this is something @NathanRussellValtech and I have agreed to put aside for the time being and first make sure this works.