### PR TITLE
EIP1-5918 - New endpoint to update AED contact details

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/UpdateAnonymousElectorDocumentDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/UpdateAnonymousElectorDocumentDto.kt
@@ -1,0 +1,7 @@
+package uk.gov.dluhc.printapi.dto.aed
+
+data class UpdateAnonymousElectorDocumentDto(
+    val sourceReference: String,
+    val email: String?,
+    val phoneNumber: String?
+)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/GlobalExceptionHandler.kt
@@ -90,7 +90,8 @@ class GlobalExceptionHandler(
     @ExceptionHandler(
         value = [
             GenerateTemporaryCertificateValidationException::class,
-            GenerateAnonymousElectorDocumentValidationException::class
+            GenerateAnonymousElectorDocumentValidationException::class,
+            UpdateAnonymousElectorDocumentValidationException::class
         ]
     )
     protected fun handleExceptionReturnBadRequestErrorResponse(

--- a/src/main/kotlin/uk/gov/dluhc/printapi/exception/UpdateAnonymousElectorDocumentValidationException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/exception/UpdateAnonymousElectorDocumentValidationException.kt
@@ -1,0 +1,3 @@
+package uk.gov.dluhc.printapi.exception
+
+class UpdateAnonymousElectorDocumentValidationException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/UpdateAnonymousElectorDocumentMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/aed/UpdateAnonymousElectorDocumentMapper.kt
@@ -1,0 +1,11 @@
+package uk.gov.dluhc.printapi.mapper.aed
+
+import org.mapstruct.Mapper
+import uk.gov.dluhc.printapi.dto.aed.UpdateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.models.UpdateAnonymousElectorDocumentRequest
+
+@Mapper
+interface UpdateAnonymousElectorDocumentMapper {
+
+    fun toUpdateAedDto(updateAedRequest: UpdateAnonymousElectorDocumentRequest): UpdateAnonymousElectorDocumentDto
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/rest/aed/AnonymousElectorDocumentController.kt
@@ -6,6 +6,7 @@ import org.springframework.core.io.InputStreamResource
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpHeaders.CONTENT_DISPOSITION
 import org.springframework.http.HttpStatus.CREATED
+import org.springframework.http.HttpStatus.NO_CONTENT
 import org.springframework.http.HttpStatus.OK
 import org.springframework.http.MediaType.APPLICATION_PDF
 import org.springframework.http.MediaType.APPLICATION_PDF_VALUE
@@ -16,6 +17,7 @@ import org.springframework.web.bind.WebDataBinder
 import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.InitBinder
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -24,15 +26,18 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.dluhc.printapi.dto.PdfFile
+import uk.gov.dluhc.printapi.exception.UpdateAnonymousElectorDocumentValidationException
 import uk.gov.dluhc.printapi.mapper.aed.AedSearchQueryStringParametersMapper
 import uk.gov.dluhc.printapi.mapper.aed.AnonymousElectorDocumentMapper
 import uk.gov.dluhc.printapi.mapper.aed.AnonymousSearchSummaryMapper
 import uk.gov.dluhc.printapi.mapper.aed.GenerateAnonymousElectorDocumentMapper
 import uk.gov.dluhc.printapi.mapper.aed.ReIssueAnonymousElectorDocumentMapper
+import uk.gov.dluhc.printapi.mapper.aed.UpdateAnonymousElectorDocumentMapper
 import uk.gov.dluhc.printapi.models.AedSearchSummaryResponse
 import uk.gov.dluhc.printapi.models.AnonymousElectorDocumentsResponse
 import uk.gov.dluhc.printapi.models.GenerateAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.models.ReIssueAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.models.UpdateAnonymousElectorDocumentRequest
 import uk.gov.dluhc.printapi.rest.HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY
 import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentSearchService
 import uk.gov.dluhc.printapi.service.aed.AnonymousElectorDocumentService
@@ -58,6 +63,7 @@ class AnonymousElectorDocumentController(
     private val anonymousElectorDocumentMapper: AnonymousElectorDocumentMapper,
     private val anonymousSearchSummaryMapper: AnonymousSearchSummaryMapper,
     private val aedSearchQueryStringParametersMapper: AedSearchQueryStringParametersMapper,
+    private val updateAnonymousElectorDocumentMapper: UpdateAnonymousElectorDocumentMapper
 ) {
 
     @InitBinder
@@ -99,6 +105,20 @@ class AnonymousElectorDocumentController(
                 .headers(createPdfHttpHeaders(pdfFile))
                 .body(InputStreamResource(ByteArrayInputStream(pdfFile.contents)))
         }
+    }
+
+    @PatchMapping
+    @PreAuthorize(HAS_ERO_VC_ANONYMOUS_ADMIN_AUTHORITY)
+    @ResponseStatus(NO_CONTENT)
+    fun updateAnonymousElectorDocumentByApplicationId(
+        @PathVariable eroId: String,
+        @RequestBody @Valid updateRequest: UpdateAnonymousElectorDocumentRequest,
+        authentication: Authentication
+    ) {
+        updateRequest.validate()
+        anonymousElectorDocumentService.updateAnonymousElectorDocument(
+            eroId, updateAnonymousElectorDocumentMapper.toUpdateAedDto(updateRequest)
+        )
     }
 
     @GetMapping
@@ -161,5 +181,11 @@ class QueryStringParameterPropertyEditor : PropertyEditorSupport() {
         value = text
             ?.let { URLDecoder.decode(it, StandardCharsets.UTF_8.name()) }?.trim()
             ?.let { it.ifEmpty { null } }
+    }
+}
+
+private fun UpdateAnonymousElectorDocumentRequest.validate() {
+    if (email.isNullOrBlank() && phoneNumber.isNullOrBlank()) {
+        throw UpdateAnonymousElectorDocumentValidationException("Either email or phoneNumber must be provided")
     }
 }

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.18.0'
+  version: '1.19.0'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -659,7 +659,35 @@ paths:
         connectionType: VPC_LINK
         connectionId: '${vpc_connection_id}'
         httpMethod: POST
-
+    patch:
+      summary: Updates specific details within an Anonymous Elector Document (AED).
+      description: Updates specific details (e.g. the elector's phone number) within an Anonymous Elector Document (AED). Note that if more than one AED has been issued for an application, then all of them will be updated.
+      tags:
+        - Anonymous Elector Documents (AED)
+      requestBody:
+        $ref: '#/components/requestBodies/UpdateAnonymousElectorDocument'
+      responses:
+        '204':
+          description: AED updated successfully
+        '400':
+          $ref: '#/components/responses/400ErrorResponse'
+        '404':
+          $ref: '#/components/responses/404ErrorResponse'
+      operationId: update-anonymous-elector-document-details
+      security:
+        - eroUserCognitoUserPoolAuthorizer: [ ]
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/eros/{eroId}/anonymous-elector-documents'
+        requestParameters:
+          integration.request.path.eroId: method.request.path.eroId
+        responseParameters:
+          method.response.header.Access-Control-Allow-Headers: '''Content-Type,X-Amz-Date,Authorization,X-Api-Key'''
+          method.response.header.Access-Control-Allow-Methods: '''*'''
+          method.response.header.Access-Control-Allow-Origin: '''*'''
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: PATCH
     get:
       summary: Returns the Anonymous Elector Documents for an Anonymous application
       description: Returns the Anonymous Elector Documents for an Anonymous application
@@ -1631,6 +1659,29 @@ components:
         - electoralRollNumber
         - deliveryAddressType
 
+    UpdateAnonymousElectorDocumentRequest:
+      title: UpdateAnonymousElectorDocumentRequest
+      description: Request body to update specific details of an Anonymous Elector Document (AED).
+      type: object
+      properties:
+        sourceReference:
+          type: string
+          example: 1f0f76a9a66f438b9bb33070
+          description: Reference in the source application that this Anonymous Elector Document is for.
+        email:
+          type: string
+          maxLength: 1024
+          format: email
+          description: The applicant's email address. This will only be updated if a non-null value is provided.
+          example: fred.blogs@some-domain.co.uk
+        phoneNumber:
+          type: string
+          maxLength: 50
+          description: The applicant's phone number. This will only be updated if a non-null value is provided.
+          example: 01234 567890
+      required:
+        - sourceReference
+
     PreSignedUrlResourceResponse:
       title: PreSignedUrlResourceResponse
       description: An object detailing the pre-signed URL to use in order to retrieve the resource
@@ -1818,6 +1869,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ReIssueAnonymousElectorDocumentRequest'
+    UpdateAnonymousElectorDocument:
+      description: Request body to update specific details belonging to one or more Anonymous Elector Documents (AEDs)
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateAnonymousElectorDocumentRequest'
 
   securitySchemes:
     eroUserCognitoUserPoolAuthorizer:

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -668,7 +668,7 @@ paths:
         $ref: '#/components/requestBodies/UpdateAnonymousElectorDocument'
       responses:
         '204':
-          description: AED updated successfully
+          description: Updated successfully
         '400':
           $ref: '#/components/responses/400ErrorResponse'
         '404':

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/UpdateAnonymousElectorDocumentMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/UpdateAnonymousElectorDocumentMapperTest.kt
@@ -1,0 +1,23 @@
+package uk.gov.dluhc.printapi.mapper.aed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.dluhc.printapi.dto.aed.UpdateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildUpdateAnonymousElectorDocumentRequest
+
+class UpdateAnonymousElectorDocumentMapperTest {
+    private val mapper = UpdateAnonymousElectorDocumentMapperImpl()
+
+    @Test
+    fun `should map to UpdateAnonymousElectorDocumentDto`() {
+        // Given
+        val request = buildUpdateAnonymousElectorDocumentRequest()
+        val expected = UpdateAnonymousElectorDocumentDto(request.sourceReference, request.email, request.phoneNumber)
+
+        // When
+        val actual = mapper.toUpdateAedDto(request)
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/UpdateAnonymousElectorDocumentByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/UpdateAnonymousElectorDocumentByApplicationIdIntegrationTest.kt
@@ -1,0 +1,252 @@
+package uk.gov.dluhc.printapi.rest.aed
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType.APPLICATION_JSON
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.models.ErrorResponse
+import uk.gov.dluhc.printapi.testsupport.assertj.assertions.models.ErrorResponseAssert
+import uk.gov.dluhc.printapi.testsupport.bearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEroId
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidPhoneNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAedContactDetails
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
+import uk.gov.dluhc.printapi.testsupport.testdata.getVCAnonymousAdminBearerToken
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildElectoralRegistrationOfficeResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildLocalAuthorityResponse
+import uk.gov.dluhc.printapi.testsupport.testdata.model.buildUpdateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.testsupport.withBody
+import java.time.temporal.ChronoUnit
+
+internal class UpdateAnonymousElectorDocumentByApplicationIdIntegrationTest : IntegrationTest() {
+    companion object {
+        private const val URI_TEMPLATE = "/eros/{ERO_ID}/anonymous-elector-documents"
+        private const val GSS_CODE = "W06000099"
+        private const val APPLICATION_ID = "7762ccac7c056046b75d4bbc"
+    }
+
+    @Test
+    fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val userGroupEroId = anotherValidEroId(ERO_ID)
+
+        webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = userGroupEroId))
+            .contentType(APPLICATION_JSON)
+            .withBody(buildUpdateAnonymousElectorDocumentRequest())
+            .exchange()
+            .expectStatus()
+            .isForbidden
+    }
+
+    @Test
+    fun `should return bad request given invalid request body`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val invalidRequestBody = buildUpdateAnonymousElectorDocumentRequest(
+            email = null,
+            phoneNumber = null
+        )
+
+        // When
+        val response = webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(invalidRequestBody)
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        ErrorResponseAssert.assertThat(actual)
+            .hasStatus(400)
+            .hasError("Bad Request")
+            .hasMessageContaining("Either email or phoneNumber must be provided")
+    }
+
+    @Test
+    fun `should return not found given no AEDs exist for application`() {
+        // Given
+        wireMockService.stubCognitoJwtIssuerResponse()
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE))
+        )
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+        val unknownSourceReference = aValidSourceReference()
+
+        // When
+        val response = webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(buildUpdateAnonymousElectorDocumentRequest(sourceReference = unknownSourceReference))
+            .exchange()
+            .expectStatus()
+            .isNotFound
+            .returnResult(ErrorResponse::class.java)
+
+        // Then
+        val actual = response.responseBody.blockFirst()
+        ErrorResponseAssert.assertThat(actual)
+            .hasStatus(404)
+            .hasError("Not Found")
+            .hasMessage("Certificate for eroId = $ERO_ID with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = $unknownSourceReference not found")
+    }
+
+    @Test
+    fun `should update elector's email and phone number`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+        val originalEmailAddress = aValidEmailAddress()
+        val originalPhoneNumber = aValidPhoneNumber()
+        val aed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = APPLICATION_ID,
+            contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+        )
+        anonymousElectorDocumentRepository.save(aed)
+        Thread.sleep(1000)
+
+        val dateCreated = aed.contactDetails!!.dateCreated!!
+        val createdBy = aed.contactDetails!!.createdBy!!
+        val dateUpdated = aed.contactDetails!!.dateUpdated!!
+        val expectedUpdatedBy = "an-ero-user1@$ERO_ID.gov.uk"
+        val newEmailAddress = anotherValidEmailAddress()
+        val newPhoneNumber = anotherValidPhoneNumber()
+        val updateAedRequest = buildUpdateAnonymousElectorDocumentRequest(
+            sourceReference = APPLICATION_ID,
+            email = newEmailAddress,
+            phoneNumber = newPhoneNumber
+        )
+
+        // When
+        webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(updateAedRequest)
+            .exchange()
+            .expectStatus().isNoContent
+
+        // Then
+        val updated = anonymousElectorDocumentRepository.findById(aed.id!!).get()
+        assertThat(updated.contactDetails!!.email).isEqualTo(newEmailAddress)
+        assertThat(updated.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+        assertThat(updated.contactDetails!!.dateCreated).isCloseTo(dateCreated, within(1, ChronoUnit.SECONDS))
+        assertThat(updated.contactDetails!!.createdBy).isEqualTo(createdBy)
+        assertThat(updated.contactDetails!!.dateUpdated).isAfter(dateUpdated)
+        assertThat(updated.contactDetails!!.updatedBy).isEqualTo(expectedUpdatedBy)
+    }
+
+    @Test
+    fun `should not update elector's email and phone number given same existing values`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+        val originalEmailAddress = aValidEmailAddress()
+        val originalPhoneNumber = aValidPhoneNumber()
+        val aed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = APPLICATION_ID,
+            contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+        )
+        anonymousElectorDocumentRepository.save(aed)
+        Thread.sleep(1000)
+
+        val dateCreated = aed.contactDetails!!.dateCreated!!
+        val createdBy = aed.contactDetails!!.createdBy!!
+        val dateUpdated = aed.contactDetails!!.dateUpdated!!
+        val updatedBy = aed.contactDetails!!.updatedBy!!
+        val updateAedRequest = buildUpdateAnonymousElectorDocumentRequest(
+            sourceReference = APPLICATION_ID,
+            email = originalEmailAddress,
+            phoneNumber = originalPhoneNumber
+        )
+
+        // When
+        webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(updateAedRequest)
+            .exchange()
+            .expectStatus().isNoContent
+
+        // Then
+        val updated = anonymousElectorDocumentRepository.findById(aed.id!!).get()
+        assertThat(updated.contactDetails!!.email).isEqualTo(originalEmailAddress)
+        assertThat(updated.contactDetails!!.phoneNumber).isEqualTo(originalPhoneNumber)
+        assertThat(updated.contactDetails!!.dateCreated).isCloseTo(dateCreated, within(1, ChronoUnit.SECONDS))
+        assertThat(updated.contactDetails!!.createdBy).isEqualTo(createdBy)
+        assertThat(updated.contactDetails!!.dateUpdated).isCloseTo(dateUpdated, within(1, ChronoUnit.SECONDS))
+        assertThat(updated.contactDetails!!.updatedBy).isEqualTo(updatedBy)
+    }
+
+    @Test
+    fun `should update elector's email and phone number on multiple AEDs`() {
+        // Given
+        val eroResponse = buildElectoralRegistrationOfficeResponse(
+            id = ERO_ID,
+            localAuthorities = listOf(buildLocalAuthorityResponse(gssCode = GSS_CODE), buildLocalAuthorityResponse())
+        )
+        wireMockService.stubCognitoJwtIssuerResponse()
+        wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
+        val originalEmailAddress = aValidEmailAddress()
+        val originalPhoneNumber = aValidPhoneNumber()
+        val aed1 = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = APPLICATION_ID,
+            contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+        )
+        val aed2 = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = APPLICATION_ID,
+            contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+        )
+        anonymousElectorDocumentRepository.saveAll(listOf(aed1, aed2))
+
+        val newEmailAddress = anotherValidEmailAddress()
+        val newPhoneNumber = anotherValidPhoneNumber()
+        val updateAedRequest = buildUpdateAnonymousElectorDocumentRequest(
+            sourceReference = APPLICATION_ID,
+            email = newEmailAddress,
+            phoneNumber = newPhoneNumber
+        )
+
+        // When
+        webTestClient.patch()
+            .uri(URI_TEMPLATE, ERO_ID, APPLICATION_ID)
+            .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
+            .contentType(APPLICATION_JSON)
+            .withBody(updateAedRequest)
+            .exchange()
+            .expectStatus().isNoContent
+
+        // Then
+        val updated1 = anonymousElectorDocumentRepository.findById(aed1.id!!).get()
+        val updated2 = anonymousElectorDocumentRepository.findById(aed2.id!!).get()
+        assertThat(updated1.contactDetails!!.email).isEqualTo(newEmailAddress)
+        assertThat(updated1.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+        assertThat(updated2.contactDetails!!.email).isEqualTo(newEmailAddress)
+        assertThat(updated2.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentServiceTest.kt
@@ -27,11 +27,17 @@ import uk.gov.dluhc.printapi.mapper.aed.ReIssueAnonymousElectorDocumentMapper
 import uk.gov.dluhc.printapi.service.EroService
 import uk.gov.dluhc.printapi.service.pdf.PdfFactory
 import uk.gov.dluhc.printapi.testsupport.testdata.aGssCode
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRandomEroId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.anotherValidPhoneNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildAnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildGenerateAnonymousElectorDocumentDto
 import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildReIssueAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildUpdateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAedContactDetails
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildDelivery
 import uk.gov.dluhc.printapi.testsupport.testdata.temporarycertificates.aTemplateFilename
@@ -309,6 +315,132 @@ internal class AnonymousElectorDocumentServiceTest {
                 .hasMessage("Certificate for eroId = $eroId with sourceType = ANONYMOUS_ELECTOR_DOCUMENT and sourceReference = ${dto.sourceReference} not found")
             verify(eroService).lookupGssCodesForEro(eroId)
             verify(anonymousElectorDocumentRepository).findByGssCodeInAndSourceTypeAndSourceReference(gssCodes, ANONYMOUS_ELECTOR_DOCUMENT, dto.sourceReference)
+        }
+    }
+
+    @Nested
+    inner class UpdateAnonymousElectorDocument {
+        @Test
+        fun `should update elector's email address on single AED`() {
+            // Given
+            val eroId = aValidRandomEroId()
+            val gssCodes = listOf(aGssCode(), aGssCode())
+            val originalEmailAddress = aValidEmailAddress()
+            val originalPhoneNumber = aValidPhoneNumber()
+            val aed = buildAnonymousElectorDocument(
+                gssCode = gssCodes.first(),
+                contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+            )
+            val newEmailAddress = anotherValidEmailAddress()
+            val updateAedDto = buildUpdateAnonymousElectorDocumentDto(
+                sourceReference = aed.sourceReference,
+                email = newEmailAddress,
+                phoneNumber = null
+            )
+            given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
+            given(anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(aed))
+
+            // When
+            anonymousElectorDocumentService.updateAnonymousElectorDocument(eroId, updateAedDto)
+
+            // Then
+            assertThat(aed.contactDetails!!.email).isEqualTo(newEmailAddress)
+            assertThat(aed.contactDetails!!.phoneNumber).isEqualTo(originalPhoneNumber)
+        }
+
+        @Test
+        fun `should update elector's phone number on single AED`() {
+            // Given
+            val eroId = aValidRandomEroId()
+            val gssCodes = listOf(aGssCode(), aGssCode())
+            val originalEmailAddress = aValidEmailAddress()
+            val originalPhoneNumber = aValidPhoneNumber()
+            val aed = buildAnonymousElectorDocument(
+                gssCode = gssCodes.first(),
+                contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+            )
+            val newPhoneNumber = anotherValidPhoneNumber()
+            val updateAedDto = buildUpdateAnonymousElectorDocumentDto(
+                sourceReference = aed.sourceReference,
+                email = null,
+                phoneNumber = newPhoneNumber
+            )
+            given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
+            given(anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(aed))
+
+            // When
+            anonymousElectorDocumentService.updateAnonymousElectorDocument(eroId, updateAedDto)
+
+            // Then
+            assertThat(aed.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+            assertThat(aed.contactDetails!!.email).isEqualTo(originalEmailAddress)
+        }
+
+        @Test
+        fun `should update elector's email address and phone number on single AED`() {
+            // Given
+            val eroId = aValidRandomEroId()
+            val gssCodes = listOf(aGssCode(), aGssCode())
+            val originalEmailAddress = aValidEmailAddress()
+            val originalPhoneNumber = aValidPhoneNumber()
+            val aed = buildAnonymousElectorDocument(
+                gssCode = gssCodes.first(),
+                contactDetails = buildAedContactDetails(email = originalEmailAddress, phoneNumber = originalPhoneNumber)
+            )
+            val newEmailAddress = anotherValidEmailAddress()
+            val newPhoneNumber = anotherValidPhoneNumber()
+            val updateAedDto = buildUpdateAnonymousElectorDocumentDto(
+                sourceReference = aed.sourceReference,
+                email = newEmailAddress,
+                phoneNumber = newPhoneNumber
+            )
+            given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
+            given(anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(aed))
+
+            // When
+            anonymousElectorDocumentService.updateAnonymousElectorDocument(eroId, updateAedDto)
+
+            // Then
+            assertThat(aed.contactDetails!!.email).isEqualTo(newEmailAddress)
+            assertThat(aed.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+        }
+
+        @Test
+        fun `should update elector's email address and phone number on multiple AEDs`() {
+            // Given
+            val eroId = aValidRandomEroId()
+            val gssCodes = listOf(aGssCode(), aGssCode())
+            val sourceReference = aValidSourceReference()
+            val originalEmail = aValidEmailAddress()
+            val originalPhoneNumber = aValidPhoneNumber()
+            val aed1 = buildAnonymousElectorDocument(
+                sourceReference = sourceReference,
+                gssCode = gssCodes.first(),
+                contactDetails = buildAedContactDetails(email = originalEmail, phoneNumber = originalPhoneNumber)
+            )
+            val aed2 = buildAnonymousElectorDocument(
+                sourceReference = sourceReference,
+                gssCode = gssCodes.first(),
+                contactDetails = buildAedContactDetails(email = originalEmail, phoneNumber = originalPhoneNumber)
+            )
+            val newEmailAddress = anotherValidEmailAddress()
+            val newPhoneNumber = anotherValidPhoneNumber()
+            val updateAedDto = buildUpdateAnonymousElectorDocumentDto(
+                sourceReference = sourceReference,
+                email = newEmailAddress,
+                phoneNumber = newPhoneNumber
+            )
+            given(eroService.lookupGssCodesForEro(any())).willReturn(gssCodes)
+            given(anonymousElectorDocumentRepository.findByGssCodeInAndSourceTypeAndSourceReference(any(), any(), any())).willReturn(listOf(aed1, aed2))
+
+            // When
+            anonymousElectorDocumentService.updateAnonymousElectorDocument(eroId, updateAedDto)
+
+            // Then
+            assertThat(aed1.contactDetails!!.email).isEqualTo(newEmailAddress)
+            assertThat(aed1.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
+            assertThat(aed2.contactDetails!!.email).isEqualTo(newEmailAddress)
+            assertThat(aed2.contactDetails!!.phoneNumber).isEqualTo(newPhoneNumber)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/RandomUtils.kt
@@ -75,7 +75,11 @@ fun aValidAddressPostcode(): String = faker.address().postcode()
 
 fun aValidPhoneNumber(): String = faker.phoneNumber().cellPhone()
 
+fun anotherValidPhoneNumber(): String = faker.phoneNumber().phoneNumber()
+
 fun aValidEmailAddress(): String = "contact@${aValidEroName().replaceSpacesWith("-")}.gov.uk"
+
+fun anotherValidEmailAddress(): String = "info@${aValidEroName().replaceSpacesWith("-")}.gov.uk"
 
 fun aValidWebsite(): String = "https://${aValidEroName().replaceSpacesWith("-")}.gov.uk"
 

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/UpdateAnonymousElectorDocumentDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/aed/UpdateAnonymousElectorDocumentDtoBuilder.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.dto.aed
+
+import uk.gov.dluhc.printapi.dto.aed.UpdateAnonymousElectorDocumentDto
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+
+fun buildUpdateAnonymousElectorDocumentDto(
+    sourceReference: String = aValidSourceReference(),
+    email: String? = aValidEmailAddress(),
+    phoneNumber: String? = aValidPhoneNumber()
+): UpdateAnonymousElectorDocumentDto =
+    UpdateAnonymousElectorDocumentDto(
+        sourceReference = sourceReference,
+        email = email,
+        phoneNumber = phoneNumber,
+    )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/UpdateAnonymousElectorDocumentRequestBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/model/UpdateAnonymousElectorDocumentRequestBuilder.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.printapi.testsupport.testdata.model
+
+import uk.gov.dluhc.printapi.models.UpdateAnonymousElectorDocumentRequest
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidEmailAddress
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidPhoneNumber
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+
+fun buildUpdateAnonymousElectorDocumentRequest(
+    sourceReference: String = aValidSourceReference(),
+    email: String? = aValidEmailAddress(),
+    phoneNumber: String? = aValidPhoneNumber()
+): UpdateAnonymousElectorDocumentRequest =
+    UpdateAnonymousElectorDocumentRequest(
+        sourceReference = sourceReference,
+        email = email,
+        phoneNumber = phoneNumber,
+    )


### PR DESCRIPTION
This PR introduces a new endpoint to update the contact details of one or more AEDs, belonging to an application.

I've merged these PRs into this one:

* https://github.com/cabinetoffice/eip-ero-print-api/pull/276
* https://github.com/cabinetoffice/eip-ero-print-api/pull/273


**Endpoint definition**
![image](https://user-images.githubusercontent.com/107410075/236439943-c007930b-8ce3-4af0-9a54-4e4de3caaa6a.png)

**Schema**
![image](https://user-images.githubusercontent.com/107410075/236440066-2af4c59b-0277-4660-9374-8400d6dc9cb6.png)
