### PR TITLE
EIP1-5612 / EIP1-5856 - Introduced AnonymousElectorDocumentSummarySpecificationBuilder

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummaryRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.dluhc.printapi.database.repository
 
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.repository.PagingAndSortingRepository
 import org.springframework.stereotype.Repository
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
@@ -10,7 +11,8 @@ import java.util.UUID
 
 @Repository
 interface AnonymousElectorDocumentSummaryRepository :
-    PagingAndSortingRepository<AnonymousElectorDocumentSummary, UUID> {
+    PagingAndSortingRepository<AnonymousElectorDocumentSummary, UUID>,
+    JpaSpecificationExecutor<AnonymousElectorDocumentSummary> {
 
     fun findAllByGssCodeInAndSourceType(
         gssCodes: List<String>,

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilder.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilder.kt
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Component
 import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
 import uk.gov.dluhc.printapi.dto.aed.AedSearchBy
 import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchCriteriaDto
+import uk.gov.dluhc.printapi.service.aed.sanitizeApplicationReference
+import uk.gov.dluhc.printapi.service.aed.sanitizeSurname
 import javax.persistence.criteria.CriteriaBuilder
 import javax.persistence.criteria.CriteriaQuery
 import javax.persistence.criteria.Root
@@ -62,14 +64,5 @@ class AnonymousElectorDocumentSummarySpecificationBuilder {
         return Specification<AnonymousElectorDocumentSummary> { root: Root<AnonymousElectorDocumentSummary?>, _: CriteriaQuery<*>?, criteriaBuilder: CriteriaBuilder ->
             criteriaBuilder.equal(root.get<Any>(SANITIZED_SURNAME), sanitizedSurname)
         }
-    }
-
-    private fun sanitizeSurname(surname: String): String {
-        return surname.uppercase().replace(Regex("-"), " ").replace(Regex("'"), "").replace(Regex("[ ]{2,}"), " ")
-            .trim()
-    }
-
-    private fun sanitizeApplicationReference(applicationReference: String): String {
-        return applicationReference.uppercase().replace(Regex("[ ]+"), "")
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilder.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilder.kt
@@ -1,0 +1,75 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.springframework.data.jpa.domain.Specification
+import org.springframework.stereotype.Component
+import uk.gov.dluhc.printapi.database.entity.AnonymousElectorDocumentSummary
+import uk.gov.dluhc.printapi.dto.aed.AedSearchBy
+import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchCriteriaDto
+import javax.persistence.criteria.CriteriaBuilder
+import javax.persistence.criteria.CriteriaQuery
+import javax.persistence.criteria.Root
+
+@Component
+class AnonymousElectorDocumentSummarySpecificationBuilder {
+
+    companion object {
+        private const val GSS_CODE: String = "gssCode"
+        private const val APPLICATION_REFERENCE: String = "applicationReference"
+        private const val SANITIZED_SURNAME: String = "sanitizedSurname"
+    }
+
+    fun buildSpecification(
+        gssCodes: List<String>,
+        criteria: AnonymousSearchCriteriaDto
+    ): Specification<AnonymousElectorDocumentSummary> {
+        return buildSpecificationForGssCodes(gssCodes)
+            .and(buildSpecificationForSearchBy(criteria.searchBy, criteria.searchValue))
+    }
+
+    private fun buildSpecificationForGssCodes(gssCodes: List<String>) =
+        hasGssCodeIn(gssCodes)
+
+    private fun buildSpecificationForSearchBy(
+        searchBy: AedSearchBy?,
+        searchValue: String?
+    ): Specification<AnonymousElectorDocumentSummary>? {
+        if (searchBy == null || searchValue == null) {
+            return null
+        }
+
+        return when (searchBy) {
+            AedSearchBy.SURNAME -> hasSanitizedSurname(sanitizeSurname(searchValue))
+            AedSearchBy.APPLICATION_REFERENCE -> hasApplicationReference(sanitizeApplicationReference(searchValue))
+        }
+    }
+
+    private fun hasGssCodeIn(gssCodes: List<String>): Specification<AnonymousElectorDocumentSummary> {
+        return Specification { root: Root<AnonymousElectorDocumentSummary>, _: CriteriaQuery<*>?, criteriaBuilder: CriteriaBuilder ->
+            val query: CriteriaQuery<AnonymousElectorDocumentSummary> = criteriaBuilder.createQuery(
+                AnonymousElectorDocumentSummary::class.java
+            )
+            query.select(root).where(root.get<Any>(GSS_CODE).`in`(gssCodes)).restriction
+        }
+    }
+
+    private fun hasApplicationReference(applicationReference: String): Specification<AnonymousElectorDocumentSummary> {
+        return Specification<AnonymousElectorDocumentSummary> { root: Root<AnonymousElectorDocumentSummary?>, _: CriteriaQuery<*>?, criteriaBuilder: CriteriaBuilder ->
+            criteriaBuilder.equal(root.get<Any>(APPLICATION_REFERENCE), applicationReference)
+        }
+    }
+
+    private fun hasSanitizedSurname(sanitizedSurname: String): Specification<AnonymousElectorDocumentSummary> {
+        return Specification<AnonymousElectorDocumentSummary> { root: Root<AnonymousElectorDocumentSummary?>, _: CriteriaQuery<*>?, criteriaBuilder: CriteriaBuilder ->
+            criteriaBuilder.equal(root.get<Any>(SANITIZED_SURNAME), sanitizedSurname)
+        }
+    }
+
+    private fun sanitizeSurname(surname: String): String {
+        return surname.uppercase().replace(Regex("-"), " ").replace(Regex("'"), "").replace(Regex("[ ]{2,}"), " ")
+            .trim()
+    }
+
+    private fun sanitizeApplicationReference(applicationReference: String): String {
+        return applicationReference.uppercase().replace(Regex("[ ]+"), "")
+    }
+}

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchCriteriaDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/aed/AnonymousSearchCriteriaDto.kt
@@ -10,4 +10,5 @@ data class AnonymousSearchCriteriaDto(
 
 enum class AedSearchBy {
     SURNAME,
+    APPLICATION_REFERENCE,
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentSearchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/AnonymousElectorDocumentSearchService.kt
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort.Direction.DESC
 import org.springframework.stereotype.Service
 import uk.gov.dluhc.printapi.database.entity.SourceType.ANONYMOUS_ELECTOR_DOCUMENT
 import uk.gov.dluhc.printapi.database.repository.AnonymousElectorDocumentSummaryRepository
+import uk.gov.dluhc.printapi.dto.aed.AedSearchBy.APPLICATION_REFERENCE
 import uk.gov.dluhc.printapi.dto.aed.AedSearchBy.SURNAME
 import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchCriteriaDto
 import uk.gov.dluhc.printapi.dto.aed.AnonymousSearchSummaryDto
@@ -59,6 +60,9 @@ class AnonymousElectorDocumentSearchService(
                         sanitizedSurname = sanitizeSurname(searchValue!!),
                         pageRequest = pageRequest
                     )
+
+                APPLICATION_REFERENCE ->
+                    throw UnsupportedOperationException("Searching AEDs by APPLICATION_REFERENCE is not yet supported")
             }.map { anonymousSearchSummaryMapper.toAnonymousSearchSummaryDto(entity = it) }
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/SearchDataSanitization.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/service/aed/SearchDataSanitization.kt
@@ -10,3 +10,8 @@ fun sanitizeSurname(surname: String): String =
         .replace(Regex("'"), EMPTY) // remove apostrophe
         .replace(Regex(" {2,}"), SPACE) // multiple spaces to single space
         .trim()
+
+fun sanitizeApplicationReference(applicationReference: String): String =
+    applicationReference
+        .uppercase()
+        .replace(Regex(" +"), EMPTY) // any number of spaces to empty

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilderIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/repository/AnonymousElectorDocumentSummarySpecificationBuilderIntegrationTest.kt
@@ -1,0 +1,238 @@
+package uk.gov.dluhc.printapi.database.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import uk.gov.dluhc.printapi.config.IntegrationTest
+import uk.gov.dluhc.printapi.dto.aed.AedSearchBy
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidSourceReference
+import uk.gov.dluhc.printapi.testsupport.testdata.dto.aed.buildAnonymousSearchCriteriaDto
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildAnonymousElectorDocument
+import java.time.Instant
+import java.time.LocalDate
+
+@Deprecated("This is a temporary test, and will be removed when EIP1-5612 uses the specification builder in the search service")
+internal class AnonymousElectorDocumentSummarySpecificationBuilderIntegrationTest : IntegrationTest() {
+
+    companion object {
+        private const val GSS_CODE = "W06000099"
+        private const val ANOTHER_GSS_CODE = "E06000123"
+    }
+
+    @Autowired
+    private lateinit var specificationBuilder: AnonymousElectorDocumentSummarySpecificationBuilder
+
+    @Test
+    fun `should return all AEDs for gsscode given no search by criteria`() {
+        // Given
+        createAndSaveSomeAeds()
+
+        val criteria = buildAnonymousSearchCriteriaDto(
+            page = 1,
+            pageSize = 100,
+            searchBy = null,
+            searchValue = null
+        )
+
+        val specification = specificationBuilder.buildSpecification(listOf(GSS_CODE), criteria)
+        val pageRequest = PageRequest.of(
+            criteria.page - 1, // pages are zero indexed
+            criteria.pageSize,
+            Sort.by(Sort.Direction.DESC, "issueDate").and(Sort.by(Sort.Direction.ASC, "surname"))
+        )
+
+        // When
+        val actual = anonymousElectorDocumentSummaryRepository.findAll(specification, pageRequest)
+
+        // Then
+        assertThat(actual.content.map { it.applicationReference }).containsExactly(
+            "V_APP_REF3", // AED3 first because it's the most recent (today)
+            "V_APP_REF1", // AED1 2nd because it has the same date as AED2 but the surname is AAA (9 days old)
+            "V_APP_REF2", // AED2 3rd because it has the same date as AED1 but the surname is ZZZ (9 days old)
+            "V_APP_REF4", // AED4 last because it's the oldest (10 days old)
+        )
+    }
+
+    @Test
+    fun `should return all AEDs for gsscode given surname search by criteria`() {
+        // Given
+        createAndSaveSomeAeds()
+
+        val criteria = buildAnonymousSearchCriteriaDto(
+            page = 1,
+            pageSize = 100,
+            searchBy = AedSearchBy.SURNAME,
+            searchValue = "zZz"
+        )
+
+        val specification = specificationBuilder.buildSpecification(listOf(GSS_CODE), criteria)
+        val pageRequest = PageRequest.of(
+            criteria.page - 1, // pages are zero indexed
+            criteria.pageSize,
+            Sort.by(Sort.Direction.DESC, "issueDate").and(Sort.by(Sort.Direction.ASC, "surname"))
+        )
+
+        // When
+        val actual = anonymousElectorDocumentSummaryRepository.findAll(specification, pageRequest)
+
+        // Then
+        assertThat(actual.content.map { it.applicationReference }).containsExactly(
+            "V_APP_REF2", // AED2 because it has the surname ZZZ
+        )
+    }
+
+    @Test
+    fun `should return all AEDs for gsscode given surname with spaces and mixed case search by criteria`() {
+        // Given
+        createAndSaveSomeAeds()
+
+        val criteria = buildAnonymousSearchCriteriaDto(
+            page = 1,
+            pageSize = 100,
+            searchBy = AedSearchBy.SURNAME,
+            searchValue = "  o'LeaRY  "
+        )
+
+        val specification = specificationBuilder.buildSpecification(listOf(ANOTHER_GSS_CODE), criteria)
+        val pageRequest = PageRequest.of(
+            criteria.page - 1, // pages are zero indexed
+            criteria.pageSize,
+            Sort.by(Sort.Direction.DESC, "issueDate").and(Sort.by(Sort.Direction.ASC, "surname"))
+        )
+
+        // When
+        val actual = anonymousElectorDocumentSummaryRepository.findAll(specification, pageRequest)
+
+        // Then
+        assertThat(actual.content.map { it.applicationReference }).containsExactly(
+            "V_APP_REF5", // AED5 because it has the surname O'Leary and is for gssCode ANOTHER_GSS_CODE
+        )
+    }
+
+    @Test
+    fun `should return all AEDs for gsscode given application_reference search by criteria`() {
+        // Given
+        createAndSaveSomeAeds()
+
+        val criteria = buildAnonymousSearchCriteriaDto(
+            page = 1,
+            pageSize = 100,
+            searchBy = AedSearchBy.APPLICATION_REFERENCE,
+            searchValue = "V_APP_REF3"
+        )
+
+        val specification = specificationBuilder.buildSpecification(listOf(GSS_CODE), criteria)
+        val pageRequest = PageRequest.of(
+            criteria.page - 1, // pages are zero indexed
+            criteria.pageSize,
+            Sort.by(Sort.Direction.DESC, "issueDate").and(Sort.by(Sort.Direction.ASC, "surname"))
+        )
+
+        // When
+        val actual = anonymousElectorDocumentSummaryRepository.findAll(specification, pageRequest)
+
+        // Then
+        assertThat(actual.content.map { it.applicationReference }).containsExactly(
+            "V_APP_REF3", // AED3 because it has the application reference V_APP_REF3
+        )
+    }
+
+    @Test
+    fun `should return no AEDs for gsscode given search by criteria that matches nothing`() {
+        // Given
+        createAndSaveSomeAeds()
+
+        val criteria = buildAnonymousSearchCriteriaDto(
+            page = 1,
+            pageSize = 100,
+            searchBy = AedSearchBy.SURNAME,
+            searchValue = "Bloggs"
+        )
+
+        val specification = specificationBuilder.buildSpecification(listOf(GSS_CODE), criteria)
+        val pageRequest = PageRequest.of(
+            criteria.page - 1, // pages are zero indexed
+            criteria.pageSize,
+            Sort.by(Sort.Direction.DESC, "issueDate").and(Sort.by(Sort.Direction.ASC, "surname"))
+        )
+
+        // When
+        val actual = anonymousElectorDocumentSummaryRepository.findAll(specification, pageRequest)
+
+        // Then
+        assertThat(actual.content).isEmpty()
+    }
+
+    private fun createAndSaveSomeAeds() {
+        val currentDate = LocalDate.now(clock)
+        val currentDateTimeInstant = Instant.now(clock)
+
+        val aed1SourceReference = aValidSourceReference()
+        val aed1ApplicationReference = "V_APP_REF1"
+        val application1InitialAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed1SourceReference,
+            applicationReference = aed1ApplicationReference,
+            issueDate = currentDate.minusDays(10),
+            requestDateTime = currentDateTimeInstant.minusSeconds(10),
+            surname = "AAA",
+        )
+        val application1SecondAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed1SourceReference,
+            applicationReference = aed1ApplicationReference,
+            issueDate = currentDate.minusDays(10),
+            requestDateTime = currentDateTimeInstant.minusSeconds(9),
+            contactDetails = application1InitialAed.contactDetails!!
+        )
+        val application1LatestAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed1SourceReference,
+            applicationReference = aed1ApplicationReference,
+            issueDate = currentDate.minusDays(9),
+            requestDateTime = currentDateTimeInstant, // View will return this latest record as it has latest requestDateTime
+            contactDetails = application1InitialAed.contactDetails!!
+        )
+
+        val aed2SourceReference = aValidSourceReference()
+        val aed2ApplicationReference = "V_APP_REF2"
+        val application2InitialAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed2SourceReference,
+            applicationReference = aed2ApplicationReference,
+            issueDate = currentDate.minusDays(10),
+            requestDateTime = currentDateTimeInstant.minusSeconds(10),
+            surname = "ZZZ",
+        )
+        val application2SecondAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed2SourceReference,
+            applicationReference = aed2ApplicationReference,
+            issueDate = currentDate.minusDays(9),
+            requestDateTime = currentDateTimeInstant.minusSeconds(8),
+            contactDetails = application2InitialAed.contactDetails!!
+        )
+        val application2LatestAed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            sourceReference = aed2SourceReference,
+            applicationReference = aed2ApplicationReference,
+            issueDate = currentDate.minusDays(9),
+            requestDateTime = currentDateTimeInstant, // View will return this latest record as it has latest requestDateTime
+            contactDetails = application2InitialAed.contactDetails!!
+        )
+
+        val application3AedDocument = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate, applicationReference = "V_APP_REF3")
+        val application4AedDocument = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate.minusDays(10), applicationReference = "V_APP_REF4")
+        val application5AedDocument = buildAnonymousElectorDocument(gssCode = ANOTHER_GSS_CODE, surname = "O'Leary", applicationReference = "V_APP_REF5")
+
+        anonymousElectorDocumentRepository.saveAll(
+            listOf(
+                application1InitialAed, application1SecondAed, application1LatestAed,
+                application2InitialAed, application2SecondAed, application2LatestAed,
+                application3AedDocument, application4AedDocument, application5AedDocument
+            )
+        )
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/SearchDataSanitizationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/aed/SearchDataSanitizationTest.kt
@@ -9,77 +9,39 @@ internal class SearchDataSanitizationTest {
     @CsvSource(
         value = [
             "doe,DOE",
-            "Doe,DOE",
-            "DoE,DOE",
-        ]
-    )
-    @ParameterizedTest
-    fun `should uppercase surname in sanitized form`(surname: String, expected: String) {
-
-        val actual = sanitizeSurname(surname)
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @CsvSource(
-        value = [
-            "doe ,DOE",
-            " doe,DOE",
             " doe ,DOE",
-        ]
-    )
-    @ParameterizedTest
-    fun `should trim surname in sanitized form`(surname: String, expected: String) {
-
-        val actual = sanitizeSurname(surname)
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @CsvSource(
-        value = [
             "o'leary,OLEARY",
-            "de'Medici,DEMEDICI",
-            "Nyong'o,NYONGO",
-            "Prud'hon,PRUDHON",
-        ]
-    )
-    @ParameterizedTest
-    fun `should remove apostrophe from surname in sanitized form`(surname: String, expected: String) {
-
-        val actual = sanitizeSurname(surname)
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @CsvSource(
-        value = [
             "Llewelyn-Bowen,LLEWELYN BOWEN",
-            "Day-Lewis,DAY LEWIS",
-            "Zeta-Jones,ZETA JONES",
-            "Taylor-Joy,TAYLOR JOY",
-        ]
-    )
-    @ParameterizedTest
-    fun `should replace hyphen with space for surname in sanitized form`(surname: String, expected: String) {
-
-        val actual = sanitizeSurname(surname)
-
-        assertThat(actual).isEqualTo(expected)
-    }
-
-    @CsvSource(
-        value = [
             "Harper Adams,HARPER ADAMS",
             "Harper  Adams,HARPER ADAMS",
-            "Harper   Adams,HARPER ADAMS",
         ]
     )
     @ParameterizedTest
-    fun `should reduce to single space for surname in sanitized form`(surname: String, expected: String) {
+    fun `should sanitize surname`(surname: String, expected: String) {
+        // Given
 
+        // When
         val actual = sanitizeSurname(surname)
 
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @CsvSource(
+        value = [
+            "V123ABCXYZ,V123ABCXYZ",
+            "v123abcxyz,V123ABCXYZ",
+            "v  123  ab  c xy z  ,V123ABCXYZ"
+        ]
+    )
+    @ParameterizedTest
+    fun `should sanitize application reference number`(applicationReference: String, expected: String) {
+        // Given
+
+        // When
+        val actual = sanitizeApplicationReference(applicationReference)
+
+        // Then
         assertThat(actual).isEqualTo(expected)
     }
 }


### PR DESCRIPTION
This PR introduces `AnonymousElectorDocumentSummarySpecificationBuilder` as part of being able to support searching for AEDs by application reference 

At the moment it's not wired into the service etc, so as not to risk the release next week and today's COB code cut off etc

The integration test is a temporary test, and will be removed/refactored when we wire the specification builder into the service etc next week