### PR TITLE
EIP1-5612 / EIP1-5857 - openAPI updated to support searchBy applicationReference

### DIFF
--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.18.0'
+  version: '1.19.0'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -1028,6 +1028,7 @@ components:
       type: string
       enum:
         - surname
+        - applicationReference
 
     SourceType:
       title: SourceType

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AedSearchQueryStringParametersMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/aed/AedSearchQueryStringParametersMapperTest.kt
@@ -18,6 +18,7 @@ class AedSearchQueryStringParametersMapperTest {
         value = [
             ", ,,", // null [searchBy, searchValue]
             "SURNAME, Thomas, SURNAME",
+            "APPLICATION_REFERENCE, V123ABC456, APPLICATION_REFERENCE",
         ]
     )
     fun `should map AedSearchQueryStringParameters to AnonymousSearchCriteriaDto given searchBy and searchName values`(

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/AedSearchByParametersAreValidConstraintValidatorTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/AedSearchByParametersAreValidConstraintValidatorTest.kt
@@ -2,8 +2,9 @@ package uk.gov.dluhc.printapi.rest.aed
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.dluhc.printapi.models.AedSearchBy
-import uk.gov.dluhc.printapi.models.AedSearchBy.SURNAME
 import javax.validation.ConstraintViolation
 import javax.validation.Validation
 
@@ -25,10 +26,11 @@ class AedSearchByParametersAreValidConstraintValidatorTest {
         assertThat(violations).isEmpty()
     }
 
-    @Test
-    fun `should validate with 1 violations given query string parameters have searchBy but no searchValue`() {
+    @ParameterizedTest
+    @EnumSource(AedSearchBy::class)
+    fun `should validate with 1 violations given query string parameters have searchBy but no searchValue`(searchBy: AedSearchBy) {
         // Then
-        val searchCriteria = buildAedSearchQueryStringParameters(searchValue = null, searchBy = SURNAME)
+        val searchCriteria = buildAedSearchQueryStringParameters(searchValue = null, searchBy = searchBy)
 
         // When
         val violations: Set<ConstraintViolation<AedSearchQueryStringParameters>> =
@@ -55,10 +57,11 @@ class AedSearchByParametersAreValidConstraintValidatorTest {
             .isEqualTo("searchBy and searchValue must be specified together")
     }
 
-    @Test
-    fun `should validate with 0 violations given query string parameters have both searchBy and searchValue`() {
+    @ParameterizedTest
+    @EnumSource(AedSearchBy::class)
+    fun `should validate with 0 violations given query string parameters have both searchBy and searchValue`(searchBy: AedSearchBy) {
         // Then
-        val searchCriteria = buildAedSearchQueryStringParameters(searchValue = "SMITH", searchBy = SURNAME)
+        val searchCriteria = buildAedSearchQueryStringParameters(searchValue = "some value", searchBy = searchBy)
 
         // When
         val violations: Set<ConstraintViolation<AedSearchQueryStringParameters>> =

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/aed/SearchAedSummariesIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.models.AedSearchBy
+import uk.gov.dluhc.printapi.models.AedSearchBy.APPLICATION_REFERENCE
 import uk.gov.dluhc.printapi.models.AedSearchBy.SURNAME
 import uk.gov.dluhc.printapi.models.AedSearchSummaryResponse
 import uk.gov.dluhc.printapi.testsupport.bearerToken
@@ -199,7 +200,7 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
     }
 
     @Test
-    fun `should return empty list given no matching records found when searchBy surname`() {
+    fun `should return summaries matching surname given searchBy surname specified`() {
         // Given
         val eroResponse = buildElectoralRegistrationOfficeResponse(
             id = ERO_ID,
@@ -208,17 +209,29 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
         wireMockService.stubCognitoJwtIssuerResponse()
         wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
 
-        val application1Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, surname = "Smi-th")
+        val currentDate = LocalDate.now()
+        val currentDateTimeInstant = Instant.now()
+        val application1Aed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            issueDate = currentDate.minusDays(2),
+            requestDateTime = currentDateTimeInstant.minusSeconds(10),
+            surname = "Smith",
+        )
+
         val application2Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, surname = "BlackSmith")
-        val application3Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, surname = "Sm1th")
-        val application4Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, surname = "S mith")
-        val otherGssCodeApplicationAed = buildAnonymousElectorDocument(gssCode = ANOTHER_GSS_CODE)
+        val application3Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate.plusDays(1))
+        val application4Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate, surname = "S'mith")
+        val otherApplicationAed = buildAnonymousElectorDocument(gssCode = ANOTHER_GSS_CODE)
 
         anonymousElectorDocumentRepository.saveAll(
             listOf(
-                application1Aed, application2Aed, application3Aed, application4Aed, otherGssCodeApplicationAed
+                application1Aed, application2Aed, application3Aed, application4Aed, otherApplicationAed
             )
         )
+
+        val expectedSummaryRecord1 = buildAedSearchSummaryApiFromAedEntity(application4Aed)
+        val expectedSummaryRecord2 = buildAedSearchSummaryApiFromAedEntity(application1Aed)
+        val expectedResults = listOf(expectedSummaryRecord1, expectedSummaryRecord2)
 
         // When
         val response = webTestClient.get()
@@ -231,18 +244,15 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
 
         // Then
         val actual = response.responseBody.blockFirst()
-        assertThat(actual).isNotNull
-        with(actual!!) {
-            assertThat(page).isZero()
-            assertThat(pageSize).isEqualTo(100)
-            assertThat(totalPages).isZero()
-            assertThat(totalResults).isZero()
-            assertThat(results).isNotNull.isEmpty()
-        }
+        assertThat(actual!!.results).isNotEmpty
+            .hasSize(2)
+            .usingRecursiveComparison()
+            .ignoringFieldsMatchingRegexes(".*dateTimeCreated")
+            .isEqualTo(expectedResults)
     }
 
     @Test
-    fun `should return summaries matching surname given searchBy surname specified`() {
+    fun `should return summaries matching application reference given searchBy applicationReference specified`() {
         // Given
         val eroResponse = buildElectoralRegistrationOfficeResponse(
             id = ERO_ID,
@@ -251,31 +261,26 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
         wireMockService.stubCognitoJwtIssuerResponse()
         wireMockService.stubEroManagementGetEroByEroId(eroResponse, ERO_ID)
 
-        val currentDate = LocalDate.now()
-        val matchingApplication1Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate.minusDays(2), surname = "Smith")
-        // Although surname matches for below AED 2, however this record won't be returned due to pageSize = 2
-        val matchingApplication2Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate.minusDays(5), surname = "Smith")
-        val matchingApplication3Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate, surname = "S'mith")
+        val applicationReference1 = aValidApplicationReference()
+        val application1Aed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            applicationReference = applicationReference1
+        )
 
-        val unmatchedApplication1Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, surname = "BlackSmith")
-        val unmatchedApplication2Aed = buildAnonymousElectorDocument(gssCode = GSS_CODE, issueDate = currentDate.plusDays(1))
-        val otherGssCodeApplicationAed = buildAnonymousElectorDocument(gssCode = ANOTHER_GSS_CODE)
+        val applicationReference2 = aValidApplicationReference()
+        val application2Aed = buildAnonymousElectorDocument(
+            gssCode = GSS_CODE,
+            applicationReference = applicationReference2
+        )
 
         anonymousElectorDocumentRepository.saveAll(
             listOf(
-                matchingApplication1Aed, matchingApplication2Aed, matchingApplication3Aed,
-                unmatchedApplication1Aed, unmatchedApplication2Aed, otherGssCodeApplicationAed
+                application1Aed, application2Aed
             )
         )
 
-        val expectedSummaryRecord1 = buildAedSearchSummaryApiFromAedEntity(matchingApplication3Aed)
-        val expectedSummaryRecord2 = buildAedSearchSummaryApiFromAedEntity(matchingApplication1Aed)
-        val expectedResultsInExactOrder = listOf(expectedSummaryRecord1, expectedSummaryRecord2)
-        val expectedTotalPages = 2
-        val expectedTotalResults = 3
-
-        val pageSize = 2
-        val searchBySurnameValue = "Smith"
+        val expectedSummaryRecord1 = buildAedSearchSummaryApiFromAedEntity(application1Aed)
+        val expectedResults = listOf(expectedSummaryRecord1)
 
         // When
         val response = webTestClient.get()
@@ -283,10 +288,8 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
                 buildUri(
                     uriTemplate = SEARCH_SUMMARY_URI_TEMPLATE,
                     eroId = ERO_ID,
-                    page = 1,
-                    pageSize = pageSize,
-                    searchBy = SURNAME,
-                    searchValue = searchBySurnameValue
+                    searchBy = APPLICATION_REFERENCE,
+                    searchValue = applicationReference1
                 )
             )
             .bearerToken(getVCAnonymousAdminBearerToken(eroId = ERO_ID))
@@ -297,18 +300,11 @@ internal class SearchAedSummariesIntegrationTest : IntegrationTest() {
 
         // Then
         val actual = response.responseBody.blockFirst()
-        assertThat(actual).isNotNull
-        with(actual!!) {
-            assertThat(page).isEqualTo(1)
-            assertThat(pageSize).isEqualTo(pageSize)
-            assertThat(totalPages).isEqualTo(expectedTotalPages)
-            assertThat(totalResults).isEqualTo(expectedTotalResults)
-            assertThat(results).isNotEmpty
-                .hasSize(2)
-                .usingRecursiveComparison()
-                .ignoringFieldsMatchingRegexes(".*dateTimeCreated")
-                .isEqualTo(expectedResultsInExactOrder)
-        }
+        assertThat(actual!!.results).isNotEmpty
+            .hasSize(1)
+            .usingRecursiveComparison()
+            .ignoringFieldsMatchingRegexes(".*dateTimeCreated")
+            .isEqualTo(expectedResults)
     }
 
     private fun buildUri(


### PR DESCRIPTION
### Note
This PR builds upon (and targets) my [previous PR](https://github.com/cabinetoffice/eip-ero-print-api/pull/275) which added the wired in the specificationBuilder into the AED search service.
When that PR is merged to eip-main, this one can be re-targetted to eip-main

---

This PR updates the openAPI spec to support searching for AEDs by application reference; and a couple of tests to prove.
