### PR TITLE
EROPSPT-89: add deliveryAddressType to printRequestSummary to send to…

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/database/mapper/CertificateSummaryDtoMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/database/mapper/CertificateSummaryDtoMapper.kt
@@ -5,11 +5,14 @@ import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.PrintRequest
 import uk.gov.dluhc.printapi.dto.CertificateSummaryDto
 import uk.gov.dluhc.printapi.dto.PrintRequestSummaryDto
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapperImpl
 
 @Component
 class CertificateSummaryDtoMapper {
 
     val statusMapper: PrintRequestStatusDtoMapper = PrintRequestStatusDtoMapper()
+    val deliveryAddressTypeMapper: DeliveryAddressTypeMapper = DeliveryAddressTypeMapperImpl()
 
     fun certificateToCertificatePrintRequestSummaryDto(certificate: Certificate): CertificateSummaryDto {
         return CertificateSummaryDto(
@@ -29,7 +32,8 @@ class CertificateSummaryDtoMapper {
             userId = printRequest.userId!!,
             status = statusMapper.toPrintRequestStatusDto(currentStatus.status!!),
             dateTime = currentStatus.eventDateTime!!,
-            message = currentStatus.message
+            message = currentStatus.message,
+            deliveryAddressType = deliveryAddressTypeMapper.mapEntityToDto(printRequest.delivery!!.deliveryAddressType)
         )
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/printapi/dto/PrintRequestSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/dto/PrintRequestSummaryDto.kt
@@ -6,5 +6,6 @@ data class PrintRequestSummaryDto(
     val status: PrintRequestStatusDto,
     val dateTime: Instant,
     val userId: String,
-    val message: String?
+    val message: String?,
+    val deliveryAddressType: DeliveryAddressType
 )

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateSummaryResponseMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/CertificateSummaryResponseMapper.kt
@@ -5,7 +5,7 @@ import org.mapstruct.Mapping
 import uk.gov.dluhc.printapi.dto.CertificateSummaryDto
 import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
 
-@Mapper(uses = [PrintRequestStatusMapper::class, InstantMapper::class])
+@Mapper(uses = [PrintRequestStatusMapper::class, InstantMapper::class, DeliveryAddressTypeMapper::class])
 interface CertificateSummaryResponseMapper {
     @Mapping(source = "printRequests", target = "printRequestSummaries")
     fun toCertificateSummaryResponse(dto: CertificateSummaryDto): CertificateSummaryResponse

--- a/src/main/kotlin/uk/gov/dluhc/printapi/mapper/DeliveryAddressTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/mapper/DeliveryAddressTypeMapper.kt
@@ -14,6 +14,9 @@ interface DeliveryAddressTypeMapper {
     @ValueMapping(target = "ERO_COLLECTION", source = "ERO_MINUS_COLLECTION")
     fun mapSqsToEntity(sqsType: DeliveryAddressTypeSqs): DeliveryAddressTypeEntity
 
+    @ValueMapping(target = "ERO_MINUS_COLLECTION", source = "ERO_COLLECTION")
+    fun mapEntityToApi(entityType: DeliveryAddressTypeEntity): ApiDeliveryAddressType
+
     @ValueMapping(target = "ERO_COLLECTION", source = "ERO_MINUS_COLLECTION")
     fun mapApiToDto(apiType: ApiDeliveryAddressType): DtoDeliveryAddressType
 

--- a/src/main/resources/openapi/PrintAPIs.yaml
+++ b/src/main/resources/openapi/PrintAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Print APIs
-  version: '1.18.0'
+  version: '1.18.1'
   description: Print APIs
   contact:
     name: Krister Bone
@@ -1011,6 +1011,8 @@ components:
         message:
           type: string
           description: Message received for the print request status update
+        deliveryAddressType:
+          $ref: '#/components/schemas/DeliveryAddressType'
       required:
         - status
     PrintRequestStatus:
@@ -1117,7 +1119,7 @@ components:
 
     DeliveryAddressType:
       title: DeliveryAddressType
-      description: The delivery address type for the Anonymous Elector Document
+      description: The delivery address type for the Anonymous Elector Document and Voter Authority Certificate
       type: string
       enum:
         - registered

--- a/src/test/kotlin/uk/gov/dluhc/printapi/database/mapper/CertificateSummaryDtoMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/database/mapper/CertificateSummaryDtoMapperTest.kt
@@ -13,12 +13,17 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.VALIDATED
 import uk.gov.dluhc.printapi.dto.CertificateSummaryDto
 import uk.gov.dluhc.printapi.dto.PrintRequestStatusDto
 import uk.gov.dluhc.printapi.dto.PrintRequestSummaryDto
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapperImpl
 import uk.gov.dluhc.printapi.testsupport.testdata.aDifferentValidCertificateStatus
+import uk.gov.dluhc.printapi.testsupport.testdata.aDifferentValidDeliveryAddressType
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateStatus
+import uk.gov.dluhc.printapi.testsupport.testdata.aValidDeliveryAddressType
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidRequestDateTime
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidUserId
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidVacNumber
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildCertificate
+import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildDelivery
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequest
 import uk.gov.dluhc.printapi.testsupport.testdata.entity.buildPrintRequestStatus
 import java.time.Instant
@@ -28,6 +33,7 @@ import java.time.temporal.ChronoUnit.MINUTES
 internal class CertificateSummaryDtoMapperTest {
 
     private val mapper = CertificateSummaryDtoMapper()
+    private val deliveryAddressTypeMapper: DeliveryAddressTypeMapper = DeliveryAddressTypeMapperImpl()
 
     @Test
     fun `should map from Certificate to CertificatePrintRequestSummary given single print request with one status`() {
@@ -36,6 +42,7 @@ internal class CertificateSummaryDtoMapperTest {
         val expectedStatus = aValidCertificateStatus()
         val expectedDateTime = aValidRequestDateTime()
         val expectedUserId = aValidUserId()
+        val deliveryAddressType = aValidDeliveryAddressType()
         val certificate = buildCertificate(
             vacNumber = vacNumber,
             printRequests = listOf(
@@ -43,7 +50,8 @@ internal class CertificateSummaryDtoMapperTest {
                     userId = expectedUserId,
                     printRequestStatuses = listOf(
                         buildPrintRequestStatus(status = expectedStatus, eventDateTime = expectedDateTime, message = null)
-                    )
+                    ),
+                    delivery = buildDelivery(deliveryAddressType = deliveryAddressType)
                 )
             )
         )
@@ -54,7 +62,8 @@ internal class CertificateSummaryDtoMapperTest {
                     status = PrintRequestStatusDto.valueOf(expectedStatus.name),
                     dateTime = expectedDateTime,
                     userId = expectedUserId,
-                    message = null
+                    message = null,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToDto(deliveryAddressType)
                 )
             )
         )
@@ -73,6 +82,7 @@ internal class CertificateSummaryDtoMapperTest {
         val expectedStatus = DISPATCHED
         val expectedDateTime = now().minusSeconds(2)
         val expectedMessage = "Success"
+        val deliveryAddressType = aValidDeliveryAddressType()
         val expectedUserId = aValidUserId()
         val certificate = buildCertificate(
             vacNumber = vacNumber,
@@ -87,7 +97,8 @@ internal class CertificateSummaryDtoMapperTest {
                         printRequestStatus(VALIDATED_BY_PRINT_PROVIDER, now().minusSeconds(6), null),
                         printRequestStatus(IN_PRODUCTION, now().minusSeconds(5), null),
                         printRequestStatus(expectedStatus, expectedDateTime, expectedMessage),
-                    )
+                    ),
+                    delivery = buildDelivery(deliveryAddressType = deliveryAddressType)
                 )
             )
         )
@@ -98,7 +109,8 @@ internal class CertificateSummaryDtoMapperTest {
                     status = PrintRequestStatusDto.valueOf(expectedStatus.name),
                     dateTime = expectedDateTime,
                     userId = expectedUserId,
-                    message = expectedMessage
+                    message = expectedMessage,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToDto(deliveryAddressType)
                 )
             )
         )
@@ -122,6 +134,8 @@ internal class CertificateSummaryDtoMapperTest {
         val expectedDateTime2 = now()
         val expectedUserId2 = aValidUserId()
         val expectedMessage2 = "Successfully dispatched by Royal Mail"
+        val deliveryAddressType1 = aValidDeliveryAddressType()
+        val deliveryAddressType2 = aDifferentValidDeliveryAddressType()
         val certificate = buildCertificate(
             vacNumber = vacNumber,
             printRequests = listOf(
@@ -129,13 +143,15 @@ internal class CertificateSummaryDtoMapperTest {
                     userId = expectedUserId1,
                     printRequestStatuses = listOf(
                         printRequestStatus(expectedStatus1, expectedDateTime1, expectedMessage1)
-                    )
+                    ),
+                    delivery = buildDelivery(deliveryAddressType = deliveryAddressType1)
                 ),
                 buildPrintRequest(
                     userId = expectedUserId2,
                     printRequestStatuses = listOf(
                         printRequestStatus(expectedStatus2, expectedDateTime2, expectedMessage2)
-                    )
+                    ),
+                    delivery = buildDelivery(deliveryAddressType = deliveryAddressType2)
                 )
             )
         )
@@ -146,13 +162,15 @@ internal class CertificateSummaryDtoMapperTest {
                     status = PrintRequestStatusDto.valueOf(expectedStatus2.name),
                     dateTime = expectedDateTime2,
                     userId = expectedUserId2,
-                    message = expectedMessage2
+                    message = expectedMessage2,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToDto(deliveryAddressType2)
                 ),
                 PrintRequestSummaryDto(
                     status = PrintRequestStatusDto.valueOf(expectedStatus1.name),
                     dateTime = expectedDateTime1,
                     userId = expectedUserId1,
-                    message = expectedMessage1
+                    message = expectedMessage1,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToDto(deliveryAddressType1)
                 ),
             )
         )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateSummaryResponseMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/mapper/CertificateSummaryResponseMapperTest.kt
@@ -29,6 +29,9 @@ class CertificateSummaryResponseMapperTest {
     @Mock
     private lateinit var instantMapper: InstantMapper
 
+    @Mock
+    private lateinit var deliveryAddressTypeMapper: DeliveryAddressTypeMapper
+
     @Test
     fun `should map certificate summary dto to certificate summary response`() {
         // Given

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest.kt
@@ -7,6 +7,8 @@ import org.springframework.http.MediaType
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
 import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapperImpl
 import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
 import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.models.PrintRequestStatus
@@ -35,6 +37,8 @@ internal class DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest : I
         private const val ERO_ID = "some-city-council"
         private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
     }
+
+    private val deliveryAddressTypeMapper: DeliveryAddressTypeMapper = DeliveryAddressTypeMapperImpl()
 
     @Test
     fun `should return forbidden given user with valid bearer token belonging to a different ero`() {
@@ -122,13 +126,15 @@ internal class DeprecatedGetCertificateSummaryByApplicationIdIntegrationTest : I
                     status = PrintRequestStatus.PRINT_MINUS_PROCESSING,
                     userId = request1.userId!!,
                     dateTime = status2.eventDateTime!!.atOffset(ZoneOffset.UTC),
-                    message = status2.message
+                    message = status2.message,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToApi(request1.delivery!!.deliveryAddressType)
                 ),
                 PrintRequestSummary(
                     status = PrintRequestStatus.PRINT_MINUS_FAILED,
                     userId = request2.userId!!,
                     dateTime = status4.eventDateTime!!.atOffset(ZoneOffset.UTC),
-                    message = status4.message
+                    message = status4.message,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToApi(request2.delivery!!.deliveryAddressType)
                 ),
             )
         )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/rest/GetCertificateSummaryByApplicationIdIntegrationTest.kt
@@ -7,6 +7,8 @@ import org.springframework.http.MediaType
 import uk.gov.dluhc.printapi.config.IntegrationTest
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
 import uk.gov.dluhc.printapi.database.entity.SourceType
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapper
+import uk.gov.dluhc.printapi.mapper.DeliveryAddressTypeMapperImpl
 import uk.gov.dluhc.printapi.models.CertificateSummaryResponse
 import uk.gov.dluhc.printapi.models.ErrorResponse
 import uk.gov.dluhc.printapi.models.PrintRequestStatus
@@ -28,6 +30,8 @@ internal class GetCertificateSummaryByApplicationIdIntegrationTest : Integration
         private const val URI_TEMPLATE = "/eros/{ERO_ID}/certificates?applicationId={APPLICATION_ID}"
         private const val APPLICATION_ID = "7762ccac7c056046b75d4aa3"
     }
+
+    private val deliveryAddressTypeMapper: DeliveryAddressTypeMapper = DeliveryAddressTypeMapperImpl()
 
     @Test
     fun `should return bad request given request without applicationId query string parameter`() {
@@ -123,13 +127,15 @@ internal class GetCertificateSummaryByApplicationIdIntegrationTest : Integration
                     status = PrintRequestStatus.PRINT_MINUS_PROCESSING,
                     userId = request1.userId!!,
                     dateTime = status2.eventDateTime!!.atOffset(ZoneOffset.UTC),
-                    message = status2.message
+                    message = status2.message,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToApi(request1.delivery!!.deliveryAddressType)
                 ),
                 PrintRequestSummary(
                     status = PrintRequestStatus.PRINT_MINUS_FAILED,
                     userId = request2.userId!!,
                     dateTime = status4.eventDateTime!!.atOffset(ZoneOffset.UTC),
-                    message = status4.message
+                    message = status4.message,
+                    deliveryAddressType = deliveryAddressTypeMapper.mapEntityToApi(request2.delivery!!.deliveryAddressType)
                 ),
             )
         )

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/TestFixedDataFactory.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/TestFixedDataFactory.kt
@@ -28,6 +28,8 @@ fun aValidDeliveryClass(): DeliveryClass = DeliveryClass.STANDARD
 
 fun aValidDeliveryAddressType(): DeliveryAddressType = DeliveryAddressType.REGISTERED
 
+fun aDifferentValidDeliveryAddressType(): DeliveryAddressType = DeliveryAddressType.ERO_COLLECTION
+
 fun aValidAddressFormat(): AddressFormat = AddressFormat.UK
 
 fun aValidTemporaryCertificateTemplateFilename(): String = "temporary-certificate-template-en.pdf"

--- a/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/CertificateSummaryDtoBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/testsupport/testdata/dto/CertificateSummaryDtoBuilder.kt
@@ -1,6 +1,7 @@
 package uk.gov.dluhc.printapi.testsupport.testdata.dto
 
 import uk.gov.dluhc.printapi.dto.CertificateSummaryDto
+import uk.gov.dluhc.printapi.dto.DeliveryAddressType
 import uk.gov.dluhc.printapi.dto.PrintRequestStatusDto
 import uk.gov.dluhc.printapi.dto.PrintRequestSummaryDto
 import uk.gov.dluhc.printapi.testsupport.testdata.aValidCertificateStatus
@@ -21,10 +22,12 @@ fun buildPrintRequestSummaryDto(
     userId: String = aValidUserId(),
     status: PrintRequestStatusDto = PrintRequestStatusDto.valueOf(aValidCertificateStatus().name),
     eventDateTime: Instant = aValidPrintRequestStatusEventDateTime(),
-    message: String? = null
+    message: String? = null,
+    deliveryAddressType: DeliveryAddressType = DeliveryAddressType.REGISTERED
 ) = PrintRequestSummaryDto(
     userId = userId,
     status = status,
     dateTime = eventDateTime,
-    message = message
+    message = message,
+    deliveryAddressType = deliveryAddressType
 )


### PR DESCRIPTION
… EROP

This now sends deliveryAddressType as part of the printSummaryRequest, so that the most recent method of delivery (registered address/ero collection) can be displayed on the EROP certificate tab.

## Ticket

https://technologyprogramme.atlassian.net/browse/EROPSPT-89

> The text above the Reprint Certificate button says the following:
> 
> > The default is the applicant’s previous delivery method. You can change the default by selecting an another method.
> 
> Currently this is not working as described, and the default is, in fact, the applicant’s first delivery method. This means that when a certificate is reprinted, the ERO has no way in the portal to see what delivery method was selected for the reprint. When the delivery method for the reprint is different from that for the initial print, the portal in fact leads the ERO to believe that the attempt to change the delivery method has not worked, by displaying the delivery method for the initial print rather than the reprint.