### PR TITLE
EROPSPT-123: Change link in emails to use id instead of reference

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/EmailService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/EmailService.kt
@@ -39,7 +39,7 @@ class EmailService(
                 "sourceReference" to sourceReference,
                 "applicationReference" to applicationReference,
                 "localAuthorityEmailAddresses" to localAuthorityEmailAddresses,
-                "applicationUrl" to "${emailContentConfiguration.vacBaseUrl}/${request.applicationReference}"
+                "applicationUrl" to "${emailContentConfiguration.vacBaseUrl}/${request.sourceReference}"
             )
         }
 

--- a/src/main/resources/email-templates/non-prod/certificate-returned.html
+++ b/src/main/resources/email-templates/non-prod/certificate-returned.html
@@ -2,7 +2,7 @@
   <body>
     <h1>NOTE: This is a test email</h1>
     <br>
-    <p>The print provider has notified us that a postal certificate has been returned.</p>
+    <p>The print provider has notified us that a postal certificate has been returned for the application ${applicationReference}.</p>
     <p>You can access the application here:</p>
     <p><a href="${applicationUrl}">${applicationUrl}</a></p>
     <br>

--- a/src/main/resources/email-templates/prod/certificate-returned.html
+++ b/src/main/resources/email-templates/prod/certificate-returned.html
@@ -1,6 +1,6 @@
 <html>
   <body>
-    <p>The print provider has notified us that a postal certificate has been returned.</p>
+    <p>The print provider has notified us that a postal certificate has been returned for the application ${applicationReference}.</p>
     <p>You can access the application here:</p>
     <p><a href="${applicationUrl}">${applicationUrl}</a></p>
     <br>

--- a/src/test/kotlin/uk/gov/dluhc/printapi/service/EmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/service/EmailServiceTest.kt
@@ -47,7 +47,7 @@ internal class EmailServiceTest {
             val expectedToRecipients = setOf("electoral.services@camden.gov.uk")
             val expectedCcRecipients = emptySet<String>()
             val expectedSubject = "Electoral Registration Office Portal - certificate returned - application $applicationReference"
-            val expectedEmailBody = "((.|\\s)*)$applicationReference((.|\\s)*)"
+            val expectedEmailBodyContainingLink = "(.|\\s)*href=\".*/voter-authority-certificate/$sourceReference\"(.|\\s)*"
 
             given(emailContentConfiguration.vacBaseUrl).willReturn("https://ero.dev.erop.ierds.uk/voter-authority-certificate")
             val emailContentProperties = buildEmailContentProperties(
@@ -74,7 +74,8 @@ internal class EmailServiceTest {
                     eq(expectedSubject),
                     capture()
                 )
-                assertThat(firstValue).matches(expectedEmailBody)
+                assertThat(firstValue).contains(applicationReference)
+                assertThat(firstValue).matches(expectedEmailBodyContainingLink)
             }
             verify(emailContentConfiguration).vacBaseUrl
             verify(emailContentConfiguration).certificateReturned
@@ -93,7 +94,7 @@ internal class EmailServiceTest {
             val expectedToRecipients = setOf("electoral.services@camden.gov.uk")
             val expectedCcRecipients = setOf("joe.bloggs@camden.gov.uk")
             val expectedSubject = "Electoral Registration Office Portal - certificate returned - application $applicationReference"
-            val expectedEmailBody = "((.|\\s)*)$applicationReference((.|\\s)*)"
+            val expectedEmailBodyContainingLink = "(.|\\s)*href=\".*/voter-authority-certificate/$sourceReference\"(.|\\s)*"
 
             given(emailContentConfiguration.vacBaseUrl).willReturn("https://ero.dev.erop.ierds.uk/voter-authority-certificate")
             val emailContentProperties = buildEmailContentProperties(
@@ -120,7 +121,8 @@ internal class EmailServiceTest {
                     eq(expectedSubject),
                     capture()
                 )
-                assertThat(firstValue).matches(expectedEmailBody)
+                assertThat(firstValue).contains(applicationReference)
+                assertThat(firstValue).matches(expectedEmailBodyContainingLink)
             }
             verify(emailContentConfiguration).vacBaseUrl
             verify(emailContentConfiguration).certificateReturned
@@ -152,7 +154,7 @@ internal class EmailServiceTest {
             val expectedToRecipients = setOf("electoral.services@camden.gov.uk")
             val expectedCcRecipients = emptySet<String>()
             val expectedSubject = "Electoral Registration Office Portal - printing failed - application $applicationReference"
-            val expectedEmailBody = "((.|\\s)*)$applicationReference((.|\\s)*)"
+            val expectedEmailBodyContainingLink = "(.|\\s)*href=\".*/voter-authority-certificate/$sourceReference\"(.|\\s)*"
 
             given(emailContentConfiguration.vacBaseUrl).willReturn("https://ero.dev.erop.ierds.uk/voter-authority-certificate")
             val emailContentProperties = buildEmailContentProperties(
@@ -179,7 +181,8 @@ internal class EmailServiceTest {
                     eq(expectedSubject),
                     capture()
                 )
-                assertThat(firstValue).matches(expectedEmailBody)
+                assertThat(firstValue).contains(applicationReference)
+                assertThat(firstValue).matches(expectedEmailBodyContainingLink)
             }
             verify(emailContentConfiguration).vacBaseUrl
             verify(emailContentConfiguration).certificateFailedToPrint
@@ -198,7 +201,7 @@ internal class EmailServiceTest {
             val expectedToRecipients = setOf("electoral.services@camden.gov.uk")
             val expectedCcRecipients = setOf("joe.bloggs@camden.gov.uk")
             val expectedSubject = "Electoral Registration Office Portal - printing failed - application $applicationReference"
-            val expectedEmailBody = "((.|\\s)*)$applicationReference((.|\\s)*)"
+            val expectedEmailBodyContainingLink = "(.|\\s)*href=\".*/voter-authority-certificate/$sourceReference\"(.|\\s)*"
 
             given(emailContentConfiguration.vacBaseUrl).willReturn("https://ero.dev.erop.ierds.uk/voter-authority-certificate")
             val emailContentProperties = buildEmailContentProperties(
@@ -225,7 +228,8 @@ internal class EmailServiceTest {
                     eq(expectedSubject),
                     capture()
                 )
-                assertThat(firstValue).matches(expectedEmailBody)
+                assertThat(firstValue).contains(applicationReference)
+                assertThat(firstValue).matches(expectedEmailBodyContainingLink)
             }
             verify(emailContentConfiguration).vacBaseUrl
             verify(emailContentConfiguration).certificateFailedToPrint


### PR DESCRIPTION
This will change the links in emails for both certificate-returned and certificate-failed-to-print emails - I assume both are supposed to have the application id rather than the application reference? The ticket only mentions the certificate returned case but the links are the same in both cases.

It also adds the application reference into the body of the certificate-returned email. The application reference was already in the email subject, and in the body of the certificate-failed-to-print email.

