### PR TITLE
EIP1-13829 Reorder codeowners file and temporarily disable rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,9 @@
-# Restrict this file being modified exception for admins
-/.github/CODEOWNERS @communitiesuk/ier-ds-admin-softwire
+# Order matters in this file with last matching row taking effect
 
-# All other files owned by the standard elections development team
-* @communitiesuk/elections-digital-development-team
+# Note: All rules are currently commented out to avoid unnecessary noise
+
+# All files owned by the standard elections development team
+#* @communitiesuk/elections-digital-development-team
+
+# However, this CODEOWNERS file should be restricted to only admins
+#/.github/CODEOWNERS @communitiesuk/ier-ds-admin-softwire


### PR DESCRIPTION
## Describe your changes

Reorder rules as last one takes precedence and want the codeowners file specific rule to override the default.
Also disable the rules entirely for the time being as the codeowner notifications for every PR while experimenting and the regularly updated dependency PRs will cause a lot of noise.

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-13829

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- ❌ I double checked that ACs on the ticket are met by this code update - *temporary reversion so does not meet ACs*
- ❌ I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- ❌ I have updated the relevant yml versions
- ❌ I have added tests to new code and updated existing tests where needed
- ❌ I have added any corresponding changes to the UI portal
- ❌ I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
