### PR TITLE
EROPSPT-715: Modify print request process flow to be resilient to database failures

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
@@ -59,6 +59,7 @@ class ProcessPrintBatchService(
         updateCertificates(batchId, certificates)
         val savedCertificates = certificateRepository.saveAllAndFlush(certificates)
 
+        // File is uploaded after `saveAllAndFlush` to reduce the chance of uploading a file when the transaction doesn't complete.
         sftpService.sendFile(sftpInputStream, sftpFilename)
 
         metricsClient.recordPrintRequestsSent(savedCertificates.size)

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
@@ -8,11 +8,7 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.ASSIGNED_
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findDistinctByPrintRequestStatusAndBatchId
 import uk.gov.dluhc.printapi.exception.InsufficientPrintRequestsInBatchException
-import uk.gov.dluhc.printapi.service.FilenameFactory
-import uk.gov.dluhc.printapi.service.PrintFileDetailsFactory
-import uk.gov.dluhc.printapi.service.SftpInputStreamProvider
-import uk.gov.dluhc.printapi.service.SftpService
-import uk.gov.dluhc.printapi.service.countPrintRequestsAssignedToBatch
+import uk.gov.dluhc.printapi.service.*
 
 /**
  * Processes a print batch request by streaming a zip file containing manifest and photo images
@@ -29,32 +25,40 @@ class ProcessPrintBatchService(
 ) {
 
     /**
-     * Step 1: Listener receives request
-     * Step 2: DynamoDB is queried for the batch being processed
-     * Step 3: Create Zip & SFTP streams
+     * Step 1: Database is queried for the certificates in the batch being processed
+     * Step 2: Prepare file contents and SFTP stream
      *
      * For Zip stream:
      * Step A: Add CSV file containing applications to print to stream
      * Step B: Add images from S3 to zip stream
      *
-     * For SFTP stream:
+     * Step 3: Update certificate entities and saveAllAndFlush, forcing SQL execution
+     *         immediately so that any optimistic locking conflicts (or other DB errors)
+     *         are surfaced before any file reaches the print provider's SFTP server.
+     *
+     * Step 4: Send file to SFTP (only reached if the DB write succeeded):
      * Step A: Connect to SFTP destination directory and create temp file
      * Step B: Stream contents to SFTP
      * Step C: Rename the file stored on SFTP server
      *
-     * Step 4: Update Dynamo batch records with new status
+     * Step 5: Record metrics
      */
     @Transactional
     fun processBatch(batchId: String, printRequestCount: Int?): List<Certificate> {
         val certificates = certificateRepository.findDistinctByPrintRequestStatusAndBatchId(ASSIGNED_TO_BATCH, batchId)
         verifyPrintRequestCount(certificates, batchId, printRequestCount)
+
         val fileContents = printFileDetailsFactory.createFileDetailsFromCertificates(batchId, certificates)
         val sftpInputStream = sftpZipInputStreamProvider.createSftpInputStream(fileContents)
         val sftpFilename = filenameFactory.createZipFilename(batchId, certificates)
-        sftpService.sendFile(sftpInputStream, sftpFilename)
+
         updateCertificates(batchId, certificates)
-        val savedCertificates = certificateRepository.saveAll(certificates)
+        val savedCertificates = certificateRepository.saveAllAndFlush(certificates)
+
+        sftpService.sendFile(sftpInputStream, sftpFilename)
+
         metricsClient.recordPrintRequestsSent(savedCertificates.size)
+
         return savedCertificates
     }
 

--- a/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchService.kt
@@ -8,7 +8,11 @@ import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status.ASSIGNED_
 import uk.gov.dluhc.printapi.database.repository.CertificateRepository
 import uk.gov.dluhc.printapi.database.repository.CertificateRepositoryExtensions.findDistinctByPrintRequestStatusAndBatchId
 import uk.gov.dluhc.printapi.exception.InsufficientPrintRequestsInBatchException
-import uk.gov.dluhc.printapi.service.*
+import uk.gov.dluhc.printapi.service.FilenameFactory
+import uk.gov.dluhc.printapi.service.PrintFileDetailsFactory
+import uk.gov.dluhc.printapi.service.SftpInputStreamProvider
+import uk.gov.dluhc.printapi.service.SftpService
+import uk.gov.dluhc.printapi.service.countPrintRequestsAssignedToBatch
 
 /**
  * Processes a print batch request by streaming a zip file containing manifest and photo images

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchServiceTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.printapi.messaging.service
 
+import jakarta.persistence.OptimisticLockException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.Test
@@ -7,9 +8,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.any
-import org.mockito.kotlin.given
-import org.mockito.kotlin.verify
+import org.mockito.kotlin.*
 import uk.gov.dluhc.printapi.client.MetricsClient
 import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status
@@ -67,7 +66,7 @@ internal class ProcessPrintBatchServiceTest {
         val zipFilename = aValidZipFilename()
         val sftpPath = aValidSftpPath()
         given(certificateRepository.findByPrintRequestsBatchId(any())).willReturn(certificates)
-        given(certificateRepository.saveAll(any<List<Certificate>>())).willReturn(certificates)
+        given(certificateRepository.saveAllAndFlush(any<List<Certificate>>())).willReturn(certificates)
         given(printFileDetailsFactory.createFileDetailsFromCertificates(any(), any())).willReturn(fileDetails)
         given(sftpZipInputStreamProvider.createSftpInputStream(any())).willReturn(sftpInputStream)
         given(filenameFactory.createZipFilename(any(), any())).willReturn(zipFilename)
@@ -82,7 +81,44 @@ internal class ProcessPrintBatchServiceTest {
         verify(sftpZipInputStreamProvider).createSftpInputStream(fileDetails)
         verify(filenameFactory).createZipFilename(batchId, certificates)
         verify(sftpService).sendFile(sftpInputStream, zipFilename)
+        verify(certificateRepository).saveAllAndFlush(certificates)
         verify(metricsClient).recordPrintRequestsSent(1)
+
+        val inOrder = inOrder(certificateRepository, sftpService)
+        inOrder.verify(certificateRepository).saveAllAndFlush(certificates)
+        inOrder.verify(sftpService).sendFile(sftpInputStream, zipFilename)
+    }
+
+    @Test
+    fun `should not send file to SFTP when saveAllAndFlush throws`() {
+        // Given
+        val batchId = aValidBatchId()
+        val printRequests = listOf(
+            buildPrintRequest(
+                batchId = batchId,
+                printRequestStatuses = listOf(buildPrintRequestStatus(status = Status.ASSIGNED_TO_BATCH))
+            )
+        )
+        val certificates = listOf(buildCertificate(printRequests = printRequests))
+        val printRequestCount = 1
+        val fileDetails = aFileDetails()
+        val sftpInputStream = aValidInputStream()
+        val zipFilename = aValidZipFilename()
+        given(certificateRepository.findByPrintRequestsBatchId(any())).willReturn(certificates)
+        given(printFileDetailsFactory.createFileDetailsFromCertificates(any(), any())).willReturn(fileDetails)
+        given(sftpZipInputStreamProvider.createSftpInputStream(any())).willReturn(sftpInputStream)
+        given(filenameFactory.createZipFilename(any(), any())).willReturn(zipFilename)
+        given(certificateRepository.saveAllAndFlush(any<List<Certificate>>()))
+            .willThrow(OptimisticLockException("locked"))
+
+        // When
+        val error = catchThrowable { processPrintBatchService.processBatch(batchId, printRequestCount) }
+
+        // Then
+        assertThat(error).isInstanceOf(OptimisticLockException::class.java)
+        verify(certificateRepository).saveAllAndFlush(certificates)
+        verify(sftpService, never()).sendFile(any(), any())
+        verify(metricsClient, never()).recordPrintRequestsSent(any())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/printapi/messaging/service/ProcessPrintBatchServiceTest.kt
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import uk.gov.dluhc.printapi.client.MetricsClient
 import uk.gov.dluhc.printapi.database.entity.Certificate
 import uk.gov.dluhc.printapi.database.entity.PrintRequestStatus.Status


### PR DESCRIPTION
## Describe your changes

Current flow:
1. Upload SFTP file
2. Update database entities
3. `saveAll`

Modified flow:
1. Update database entities
2. `saveAndFlush` - this is to surface any locking failures early, so it can be retried without repeating the SFTP upload
3. Upload SFTP file

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EROPSPT-715

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [x] I double checked that ACs on the ticket are met by this code update
- :x: I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- :x: I have updated the relevant yml versions
- [x] I have added tests to new code and updated existing tests where needed
- :x: I have added any corresponding changes to the UI portal
- :x: I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
