### PR TITLE
EROPSPT-723: Disable Netty native transport

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -278,7 +278,16 @@ tasks.withType<KtLintCheckTask> {
 
 tasks.withType<BootBuildImage> {
     builder.set("paketobuildpacks/builder-jammy-base")
-    environment.set(mapOf("BP_HEALTH_CHECKER_ENABLED" to "true"))
+    environment.set(
+        mapOf(
+            "BP_HEALTH_CHECKER_ENABLED" to "true",
+            // Netty's native epoll transport interferes with unrelated Apache MINA SSHD NIO2 SFTP sessions,
+            // causing intermittent "Broken pipe"/session reset failures when polling the print provider's SFTP server.
+            // Forcing pure-Java NIO for netty (reactor-netty + AWS SDK netty-nio-client) resolves this;
+            // the performance cost is negligible given this service's low connection volume.
+            "JAVA_TOOL_OPTIONS" to "-Dio.netty.transport.noNative=true",
+        )
+    )
     buildpacks.set(
         listOf(
             "urn:cnb:builder:paketo-buildpacks/java",


### PR DESCRIPTION
## Describe your changes

Disable Netty's native transport and force use of Java NIO - Netty dependency upgrade to `v4.1.135-Final` noted as the point at which the `ProcessPrintResponsesBatchJob` failed to run

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [ ] I double checked that ACs on the ticket are met by this code update
- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- [ ] I have updated the relevant yml versions
- [ ] I have added tests to new code and updated existing tests where needed
- [ ] I have added any corresponding changes to the UI portal
- [ ] I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
